### PR TITLE
change scale out threshold of throughput from 2 to 1

### DIFF
--- a/src/acceptance/app/dynamic_policy_test.go
+++ b/src/acceptance/app/dynamic_policy_test.go
@@ -224,7 +224,7 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 		Context("when throughput is greater than scaling out threshold", func() {
 
 			BeforeEach(func() {
-				policy = GenerateDynamicScaleOutPolicy(cfg, 1, 2, "throughput", 2)
+				policy = GenerateDynamicScaleOutPolicy(cfg, 1, 2, "throughput", 1)
 				initialInstanceCount = 1
 			})
 


### PR DESCRIPTION
The network connection is slow in the container when running acceptance test in concourse pipeline, resulting throughput scale out test failed as the throughput cannot reach 2 rps/s.
```
Summarizing 1 Failure:
• Failure [529.750 seconds]
AutoScaler dynamic policy when scaling by throughput when throughput is greater than scaling out threshold [It] should scale out 
/tmp/build/124e3615/app-autoscaler-git-release/src/acceptance/app/dynamic_policy_test.go:250

  Timed out after 420.000s.
  Expected
      <int>: 1
  to equal
      <int>: 2

  /tmp/build/124e3615/app-autoscaler-git-release/src/acceptance/helpers/helpers.go:259

  Full Stack Trace
  	/tmp/build/124e3615/app-autoscaler-git-release/src/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go:147 +0x439
  github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).Should(0xc420402140, 0x9a7a20, 0xc4204ee080, 0x0, 0x0, 0x0, 0xc420402140)
  	/tmp/build/124e3615/app-autoscaler-git-release/src/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go:48 +0x62
  acceptance/helpers.WaitForNInstancesRunning(0xc4204fc030, 0x24, 0x2, 0x61c9f36800)
  	/tmp/build/124e3615/app-autoscaler-git-release/src/acceptance/helpers/helpers.go:259 +0x203
  acceptance/app.glob..func3.7.3.3()
  	/tmp/build/124e3615/app-autoscaler-git-release/src/acceptance/app/dynamic_policy_test.go:252 +0x62
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc420296960, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
  	/tmp/build/124e3615/app-autoscaler-git-release/src/acceptance/app/app_suite_test.go:51 +0xc0
  testing.tRunner(0xc4204380f0, 0x7f9fd8)
  	/opt/go/src/testing/testing.go:746 +0xd0
  created by testing.(*T).Run
  	/opt/go/src/testing/testing.go:789 +0x2de
```