### PR TITLE
change default idle_timeout for node.js component

### DIFF
--- a/jobs/apiserver/spec
+++ b/jobs/apiserver/spec
@@ -164,7 +164,7 @@ properties:
     description: "Minimum number of connections that should be held in the apiserver db pool"
   autoscaler.api_server.db_config.idle_timeout:
     default: "60000"
-    description: "The idle timeout for connections (seconds)"
+    description: "The idle timeout for connections (milliseconds)"
   autoscaler.policy_db.address:
     description: "IP address on which the policydb server will listen"
     default: "autoscalerpostgres.service.cf.internal"

--- a/jobs/apiserver/spec
+++ b/jobs/apiserver/spec
@@ -148,10 +148,10 @@ properties:
     default: "Autoscaler"
   autoscaler.api_server.info.build:
     description: "Autoscaler application build number"
-    default: "1.1.0"
+    default: "1.2.1"
   autoscaler.api_server.info.support_url:
     description: "Autoscaler application support page URL"
-    default: "https://github.com/cloudfoundry-incubator/app-autoscaler"
+    default: "https://github.com/cloudfoundry/app-autoscaler"
   autoscaler.api_server.info.description:
     description: "Autoscaler application short description"
     default: "Automatically increase or decrease the number of application instances based on a policy you define."

--- a/jobs/apiserver/spec
+++ b/jobs/apiserver/spec
@@ -148,7 +148,7 @@ properties:
     default: "Autoscaler"
   autoscaler.api_server.info.build:
     description: "Autoscaler application build number"
-    default: "1.2.1"
+    default: "1.2.2"
   autoscaler.api_server.info.support_url:
     description: "Autoscaler application support page URL"
     default: "https://github.com/cloudfoundry/app-autoscaler"
@@ -157,13 +157,13 @@ properties:
     default: "Automatically increase or decrease the number of application instances based on a policy you define."
 
   autoscaler.api_server.db_config.max_connections:
-    default: "10"  
+    default: 10  
     description: "Maximum number of connections that may be held in the apiserver db pool"
   autoscaler.api_server.db_config.min_connections:
-    default: "0"   
+    default: 0   
     description: "Minimum number of connections that should be held in the apiserver db pool"
   autoscaler.api_server.db_config.idle_timeout:
-    default: "60000"
+    default: 60000
     description: "The idle timeout for connections (milliseconds)"
   autoscaler.policy_db.address:
     description: "IP address on which the policydb server will listen"

--- a/jobs/apiserver/spec
+++ b/jobs/apiserver/spec
@@ -163,7 +163,7 @@ properties:
     default: "0"   
     description: "Minimum number of connections that should be held in the apiserver db pool"
   autoscaler.api_server.db_config.idle_timeout:
-    default: "1000"
+    default: "60000"
     description: "The idle timeout for connections (seconds)"
   autoscaler.policy_db.address:
     description: "IP address on which the policydb server will listen"

--- a/jobs/servicebroker/spec
+++ b/jobs/servicebroker/spec
@@ -81,7 +81,7 @@ properties:
     default: 0
     description: "Minimum number of connections that should be held in the servicebroker db pool"
   autoscaler.service_broker.db_config.idle_timeout:
-    default: 1000
+    default: 60000
     description: "The idle timeout for connections (seconds)"
   autoscaler.service_broker.http_request_timeout:
     default: 60000

--- a/jobs/servicebroker/spec
+++ b/jobs/servicebroker/spec
@@ -82,7 +82,7 @@ properties:
     description: "Minimum number of connections that should be held in the servicebroker db pool"
   autoscaler.service_broker.db_config.idle_timeout:
     default: 60000
-    description: "The idle timeout for connections (seconds)"
+    description: "The idle timeout for connections (milliseconds)"
   autoscaler.service_broker.http_request_timeout:
     default: 60000
     description: "The timeout for http request (milliseconds)"

--- a/templates/app-autoscaler-deployment-fewer.yml
+++ b/templates/app-autoscaler-deployment-fewer.yml
@@ -235,7 +235,7 @@ instance_groups:
           http_client_timeout: 60000
           service_offering_enabled: true
           db_config: &db_config
-            idle_timeout: 1000
+            idle_timeout: 60000
             max_connections: 10
             min_connections: 0
           port: 6100

--- a/templates/app-autoscaler-deployment.yml
+++ b/templates/app-autoscaler-deployment.yml
@@ -107,7 +107,7 @@ instance_groups:
           http_client_timeout: 60000
           service_offering_enabled: true
           db_config: &db_config
-            idle_timeout: 1000
+            idle_timeout: 60000
             max_connections: 10
             min_connections: 0
           port: 6100


### PR DESCRIPTION
The previous default 1000ms is too short 