### PR TITLE
upgrade nodejs vesion of test application

### DIFF
--- a/src/acceptance/assets/app/nodeApp/package.json
+++ b/src/acceptance/assets/app/nodeApp/package.json
@@ -10,6 +10,6 @@
 		"sleep": "^5.1.1"
 	},
 	"engines": {
-		"node": "6.x"
+		"node": "8.x"
 	}
 }


### PR DESCRIPTION
current nodejs version of the test application is 6.x and there is a warning message when staging application:

```
Downloading app package...
Downloaded app package (1.3M)
-----> Nodejs Buildpack version 1.6.45
-----> Installing binaries
       engines.node (package.json): 6.x
       engines.npm (package.json): unspecified (use default)
-----> Installing node 6.17.0
       Download [https://buildpacks.cloudfoundry.org/dependencies/node/node-6.17.0-linux-x64-cflinuxfs3-7d9e1436.tgz]
       **WARNING** node 6.x will no longer be available in new buildpacks released after 2019-04-30.
       See: https://github.com/nodejs/LTS
       Using default npm version: 3.10.10
-----> Installing yarn 1.13.0
       Download [https://buildpacks.cloudfoundry.org/dependencies/yarn/yarn-1.13.0-any-stack-125d40eb.tar.gz]
       Installed yarn 1.13.0
-----> Creating runtime environment
       NODE_ENV=production
       NODE_HOME=/tmp/contents192097769/deps/0/node
       NODE_MODULES_CACHE=true
       NODE_VERBOSE=false
       NPM_CONFIG_LOGLEVEL=error
       NPM_CONFIG_PRODUCTION=true
-----> Building dependencies
       Prebuild detected (node_modules already exists)
       Rebuilding any native modules
```