### PR TITLE
Fix references to CA certificates in Credhub

### DIFF
--- a/example/operation/external-db.yml
+++ b/example/operation/external-db.yml
@@ -75,3 +75,8 @@
 - type: replace
   path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/lock_db
   value: *external_database
+
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/policy_db
+  value: *external_database
+

--- a/templates/app-autoscaler-deployment-fewer.yml
+++ b/templates/app-autoscaler-deployment-fewer.yml
@@ -138,7 +138,7 @@ instance_groups:
             port: &scalingEngineHealthPort 6204
           defaultCoolDownSecs: 300
           lockSize: 32
-          ca_cert: ((scalingengine_ca.ca))
+          ca_cert: ((scalingengine_server.ca))
           server_cert: ((scalingengine_server.certificate))
           server_key: ((scalingengine_server.private_key))
           require_consul: true
@@ -154,11 +154,11 @@ instance_groups:
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
           notification_reschedule_maxcount: 3
-          ca_cert: ((scheduler_ca.ca))
+          ca_cert: ((scheduler_server.ca))
           server_cert: ((scheduler_server.certificate))
           server_key: ((scheduler_server.private_key))
           scaling_engine:
-            ca_cert: ((scalingengine_ca.ca))
+            ca_cert: ((scalingengine_client.ca))
             client_cert: ((scalingengine_client.certificate))
             client_key: ((scalingengine_client.private_key))
           require_consul: false
@@ -182,14 +182,14 @@ instance_groups:
           app_sync_interval: 24h
           scaling_engine:
             port: *scalingEnginePort
-            ca_cert: ((scalingengine_ca.ca))
+            ca_cert: ((scalingengine_client.ca))
             client_cert: ((scalingengine_client.certificate))
-            client_key: ((scalingengine_client.private_key))                
+            client_key: ((scalingengine_client.private_key))
           scheduler:
             port: *schedulerPort
-            ca_cert: ((scheduler_ca.ca))
+            ca_cert: ((scheduler_client.ca))
             client_cert: ((scheduler_client.certificate))
-            client_key: ((scheduler_client.private_key))        
+            client_key: ((scheduler_client.private_key))
           db_lock: 
             ttl: 15s
             retry_interval: 5s
@@ -235,34 +235,34 @@ instance_groups:
           http_client_timeout: 60000
           service_offering_enabled: true
           db_config: &db_config
-            idle_timeout: 60000
+            idle_timeout: 1000
             max_connections: 10
             min_connections: 0
           port: 6100
           publicPort: &apiServerPublicPort 6106
           health:
             port: 6200
-          ca_cert: ((apiserver_ca.ca))
+          ca_cert: ((apiserver_server.ca))
           server_cert: ((apiserver_server.certificate))
           server_key:  ((apiserver_server.private_key))
           scheduler:
-            ca_cert: ((scheduler_ca.ca))
+            ca_cert: ((scheduler_client.ca))
             client_cert: ((scheduler_client.certificate))
             client_key: ((scheduler_client.private_key))
           scaling_engine:
-            ca_cert: ((scalingengine_ca.ca))
+            ca_cert: ((scalingengine_client.ca))
             client_cert: ((scalingengine_client.certificate))
             client_key: ((scalingengine_client.private_key))
           metrics_collector:
-            ca_cert: ((metricscollector_ca.ca))
+            ca_cert: ((metricscollector_client.ca))
             client_cert: ((metricscollector_client.certificate))
             client_key: ((metricscollector_client.private_key))
           eventgenerator:
-            ca_cert: ((eventgenerator_ca.ca))
+            ca_cert: ((eventgenerator_client.ca))
             client_cert: ((eventgenerator_client.certificate))
-            client_key: ((eventgenerator_client.private_key))               
+            client_key: ((eventgenerator_client.private_key))
           service_broker:
-            ca_cert: ((servicebroker_ca.ca))
+            ca_cert: ((servicebroker_client.ca))
             client_cert: ((servicebroker_client.certificate))
             client_key: ((servicebroker_client.private_key))
           require_consul: true
@@ -279,10 +279,10 @@ instance_groups:
           port: 6107
           health:
             port: 6201
-          ca_cert: ((servicebroker_ca.ca))
+          ca_cert: ((servicebroker_server.ca))
           server_cert: ((servicebroker_server.certificate))
           server_key: ((servicebroker_server.private_key))
-          public_ca_cert: ((servicebroker_public_ca.ca))
+          public_ca_cert: ((servicebroker_public_server.ca))
           public_server_cert: ((servicebroker_public_server.certificate))
           public_server_key: ((servicebroker_public_server.private_key))
           username: autoscaler_service_broker_user
@@ -300,7 +300,7 @@ instance_groups:
                 name: autoscaler-free-plan
                 description: This is the free service plan for the Auto-Scaling service.
           api_server:
-            ca_cert: ((apiserver_ca.ca))
+            ca_cert: ((apiserver_client.ca))
             client_cert: ((apiserver_client.certificate))
             client_key: ((apiserver_client.private_key))
           require_consul: false
@@ -381,7 +381,7 @@ instance_groups:
             refresh_interval: 60s
             collect_interval: 30s
             save_interval: 5s
-          ca_cert: ((metricscollector_ca.ca))
+          ca_cert: ((metricscollector_server.ca))
           server_cert: ((metricscollector_server.certificate))
           server_key: ((metricscollector_server.private_key))
           require_consul: true
@@ -401,7 +401,7 @@ instance_groups:
             port: &eventGeneratorPort 6105
           health:
             port: &eventGeneratorHealthPort 6205
-          ca_cert: ((eventgenerator_ca.ca))
+          ca_cert: ((eventgenerator_server.ca))
           server_cert: ((eventgenerator_server.certificate))
           server_key: ((eventgenerator_server.private_key))
           aggregator:
@@ -424,13 +424,13 @@ instance_groups:
           scaling_engine:
             host: scalingengine.service.cf.internal
             port: *scalingEnginePort
-            ca_cert: ((scalingengine_ca.ca))
+            ca_cert: ((scalingengine_client.ca))
             client_cert: ((scalingengine_client.certificate))
             client_key: ((scalingengine_client.private_key))
           metricscollector:
             host: metricscollector.service.cf.internal
             port: *metricsCollectorPort
-            ca_cert: ((metricscollector_ca.ca))
+            ca_cert: ((metricscollector_client.ca))
             client_cert: ((metricscollector_client.certificate))
             client_key: ((metricscollector_client.private_key))
           require_consul: false

--- a/templates/app-autoscaler-deployment.yml
+++ b/templates/app-autoscaler-deployment.yml
@@ -107,34 +107,34 @@ instance_groups:
           http_client_timeout: 60000
           service_offering_enabled: true
           db_config: &db_config
-            idle_timeout: 60000
+            idle_timeout: 1000
             max_connections: 10
             min_connections: 0
           port: 6100
           publicPort: &apiServerPublicPort 6106
           health:
             port: 6200
-          ca_cert: ((apiserver_ca.ca))
+          ca_cert: ((apiserver_server.ca))
           server_cert: ((apiserver_server.certificate))
           server_key:  ((apiserver_server.private_key))
           scheduler:
-            ca_cert: ((scheduler_ca.ca))
+            ca_cert: ((scheduler_client.ca))
             client_cert: ((scheduler_client.certificate))
             client_key: ((scheduler_client.private_key))
           scaling_engine:
-            ca_cert: ((scalingengine_ca.ca))
+            ca_cert: ((scalingengine_client.ca))
             client_cert: ((scalingengine_client.certificate))
             client_key: ((scalingengine_client.private_key))
           metrics_collector:
-            ca_cert: ((metricscollector_ca.ca))
+            ca_cert: ((metricscollector_client.ca))
             client_cert: ((metricscollector_client.certificate))
             client_key: ((metricscollector_client.private_key))
           eventgenerator:
-            ca_cert: ((eventgenerator_ca.ca))
+            ca_cert: ((eventgenerator_client.ca))
             client_cert: ((eventgenerator_client.certificate))
-            client_key: ((eventgenerator_client.private_key))            
+            client_key: ((eventgenerator_client.private_key))
           service_broker:
-            ca_cert: ((servicebroker_ca.ca))
+            ca_cert: ((servicebroker_client.ca))
             client_cert: ((servicebroker_client.certificate))
             client_key: ((servicebroker_client.private_key))
         policy_db: *database
@@ -196,11 +196,11 @@ instance_groups:
           job_reschedule_interval_millisecond: 10000
           job_reschedule_maxcount: 6
           notification_reschedule_maxcount: 3
-          ca_cert: ((scheduler_ca.ca))
+          ca_cert: ((scheduler_server.ca))
           server_cert: ((scheduler_server.certificate))
           server_key: ((scheduler_server.private_key))
           scaling_engine:
-            ca_cert: ((scalingengine_ca.ca))
+            ca_cert: ((scalingengine_client.ca))
             client_cert: ((scalingengine_client.certificate))
             client_key: ((scalingengine_client.private_key))
         scheduler_db: *database
@@ -252,7 +252,7 @@ instance_groups:
             port: &scalingEngineHealthPort 6204
           defaultCoolDownSecs: 300
           lockSize: 32
-          ca_cert: ((scalingengine_ca.ca))
+          ca_cert: ((scalingengine_server.ca))
           server_cert: ((scalingengine_server.certificate))
           server_key: ((scalingengine_server.private_key))
       
@@ -288,10 +288,10 @@ instance_groups:
           port: 6107
           health:
             port: 6201
-          ca_cert: ((servicebroker_ca.ca))
+          ca_cert: ((servicebroker_server.ca))
           server_cert: ((servicebroker_server.certificate))
           server_key: ((servicebroker_server.private_key))
-          public_ca_cert: ((servicebroker_public_ca.ca))
+          public_ca_cert: ((servicebroker_public_server.ca))
           public_server_cert: ((servicebroker_public_server.certificate))
           public_server_key: ((servicebroker_public_server.private_key))
           username: autoscaler_service_broker_user
@@ -309,7 +309,7 @@ instance_groups:
                 name: autoscaler-free-plan
                 description: This is the free service plan for the Auto-Scaling service.
           api_server:
-            ca_cert: ((apiserver_ca.ca))
+            ca_cert: ((apiserver_client.ca))
             client_cert: ((apiserver_client.certificate))
             client_key: ((apiserver_client.private_key))
         binding_db: *database
@@ -374,7 +374,7 @@ instance_groups:
             refresh_interval: 60s
             collect_interval: 30s
             save_interval: 5s
-          ca_cert: ((metricscollector_ca.ca))
+          ca_cert: ((metricscollector_server.ca))
           server_cert: ((metricscollector_server.certificate))
           server_key: ((metricscollector_server.private_key))
 
@@ -419,7 +419,7 @@ instance_groups:
             port: &eventGeneratorPort 6105
           health:
             port: &eventGeneratorHealthPort 6205
-          ca_cert: ((eventgenerator_ca.ca))
+          ca_cert: ((eventgenerator_server.ca))
           server_cert: ((eventgenerator_server.certificate))
           server_key: ((eventgenerator_server.private_key))
           aggregator:
@@ -442,13 +442,13 @@ instance_groups:
           scaling_engine:
             host: scalingengine.service.cf.internal
             port: *scalingEnginePort
-            ca_cert: ((scalingengine_ca.ca))
+            ca_cert: ((scalingengine_client.ca))
             client_cert: ((scalingengine_client.certificate))
             client_key: ((scalingengine_client.private_key))
           metricscollector:
             host: metricscollector.service.cf.internal
             port: *metricsCollectorPort
-            ca_cert: ((metricscollector_ca.ca))
+            ca_cert: ((metricscollector_client.ca))
             client_cert: ((metricscollector_client.certificate))
             client_key: ((metricscollector_client.private_key))
 
@@ -493,12 +493,12 @@ instance_groups:
           app_sync_interval: 24h
           scaling_engine:
             port: *scalingEnginePort
-            ca_cert: ((scalingengine_ca.ca))
+            ca_cert: ((scalingengine_client.ca))
             client_cert: ((scalingengine_client.certificate))
-            client_key: ((scalingengine_client.private_key))                
+            client_key: ((scalingengine_client.private_key))
           scheduler:
             port: *schedulerPort
-            ca_cert: ((scheduler_ca.ca))
+            ca_cert: ((scheduler_client.ca))
             client_cert: ((scheduler_client.certificate))
             client_key: ((scheduler_client.private_key))
           db_lock: 


### PR DESCRIPTION
When deploying with bosh using the templates provided, CA certificates are not filled when job templates are rendered, causing some jobs fail to start. It seems the problem is because the references to interpolate those variables in Credhub are wrong.

For example:

Currently in `templates/app-autoscaler-deployment-fewer.yml` (https://github.com/cloudfoundry/app-autoscaler-release/blob/master/templates/app-autoscaler-deployment-fewer.yml#L253):
 ```
ca_cert: ((scalingengine_ca.ca))
```

Credhub shows:

```
credhub get  -n '/test-bosh-env/cf-app-autoscaler/scalingengine_ca'             id: 197bf469-dc4a-4231-8848-e22203e0629f
name: /test-bosh-env/cf-app-autoscaler/scalingengine_ca
type: certificate
value:
  ca: null
  certificate: |
    -----BEGIN CERTIFICATE-----
    MIIDTTCCAjWgAwIBAgIUWvhHmP1V3avvuux3LkUptJHoMO8wDQYJKoZIhvcNAQEL
    ...
    Bh+MWpP5Moz/y70snPGL3KjOs34XSueOul9Qw2KbNGpp
    -----END CERTIFICATE-----
  private_key: |
    -----BEGIN RSA PRIVATE KEY-----
    MIIEpAIBAAKCAQEAsbp8WyTGHTQR9t6/gUguSEIwOAVqO3kr8BiFCLgq+b2t22hi
    ...
    VvuD+MXMFox4PTCYi4z3v+ZqJPAiE4BApISYKwGCnwzda40NhLUH5Q==
    -----END RSA PRIVATE KEY-----
version_created_at: "2019-05-07T12:56:51Z"
```

Which I think is correct because is a CA certificate (https://github.com/cloudfoundry/app-autoscaler-release/blob/master/templates/app-autoscaler-deployment-fewer.yml#L446)

```
- name: scalingengine_ca
  type: certificate
  options:
    is_ca: true
    common_name: scalingengineCA
```


Because Credhub variables type cert already have a field to reference its CA, it is just about use such field, which in the current example is:

 ```
ca_cert: ((scalingengine_client.ca))
```
 