### PR TITLE
Add replace rule for instance operator and policy_db when external DB

### DIFF
--- a/example/operation/external-db.yml
+++ b/example/operation/external-db.yml
@@ -75,3 +75,8 @@
 - type: replace
   path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/lock_db
   value: *external_database
+
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/policy_db
+  value: *external_database
+


### PR DESCRIPTION
The policy_db in the operator instance also needs to get the external DB settings.