### PR TITLE
Update to Golang 1.13

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,11 +1,7 @@
-golang/go1.11.darwin-amd64.tar.gz:
-  size: 124131633
-  object_id: 15c884ef-42b7-49c4-4a08-e40449af257a
-  sha: afcfe6d8d18771e2cb431b4a812c66a6f6d46597
-golang/go1.11.linux-amd64.tar.gz:
-  size: 127163815
-  object_id: bfe16a31-b00b-4cc5-73d1-19f285a4c3da
-  sha: 8ffb718cab4371df3495d8f6c0b15c7e6dc28fea
+golang/go1.13.linux-amd64.tar.gz:
+  size: 120050424
+  sha: sha256:68a2297eb099d1a76097905a2ce334e3155004ec08cdea85f24527be3c48e856
+  object_id: bcb0a27b-78fc-4545-4786-8498dd07be62
 maven/apache-maven-3.5.4-bin.tar.gz:
   size: 8842660
   object_id: b5e0cf3e-032e-4fdf-64f8-f0519281a3a1

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -5,20 +5,20 @@ golang/go1.13.linux-amd64.tar.gz:
 maven/apache-maven-3.5.4-bin.tar.gz:
   size: 8842660
   object_id: b5e0cf3e-032e-4fdf-64f8-f0519281a3a1
-  sha: 22cac91b3557586bb1eba326f2f7727543ff15e3
+  sha: sha256:ce50b1c91364cb77efe3776f756a6d92b76d9038b0a0782f7d53acf1e997a14d
 nodejs/node-v8.11.4-darwin-x64.tar.gz:
   size: 16042407
   object_id: cc5c6ea9-9f1c-4c9d-7fe7-b1c0fd50e72c
-  sha: ae434fecf15ad21686cf9bc4ea88a6bb2d6b5906
+  sha: sha256:aa1de83b388581d0d9ec3276f4526ee67e17e0f1bc0deb5133f960ce5dc9f1ef
 nodejs/node-v8.11.4-linux-x64.tar.xz:
   size: 11351232
   object_id: 74319675-b9d5-4e07-58f1-b632aa7ba7c1
-  sha: 3b1552d91cf853fdca32d163a991f17cc1ffb288
+  sha: sha256:85ea7cbb5bf624e130585bfe3946e99c85ce5cb84c2aee474038bdbe912f908c
 openjdk/openjdk-10.0.1_linux-x64_bin.tar.gz:
   size: 204885801
   object_id: b4e6fb76-a537-4a4d-53d9-e3a84fe613b6
-  sha: 1377697996cad66def4f6627d13a031a26af9b7c
+  sha: sha256:0b14aaecd5323457bd15dc7798d08181ad04bad4156e55387ed714190912a9ce
 openjdk/openjdk-10.0.1_osx-x64_bin.tar.gz:
   size: 200863681
   object_id: a026032a-86ac-4362-4630-2e660b957c55
-  sha: 85f722da8da7a151d8500a19d535e7fbf979ba71
+  sha: sha256:650e06c203a9d2752d686dc62206580afdc909af924b7ea8573b1c671e182ab0

--- a/packages/changeloglockcleaner/packaging
+++ b/packages/changeloglockcleaner/packaging
@@ -3,6 +3,8 @@ set -e -x
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 export GOPATH=${BOSH_COMPILE_TARGET}
+export GOCACHE=/tmp/gocache
+
 mkdir ${GOPATH}/src && mv changeloglockcleaner ${GOPATH}/src/ && mv github.com ${GOPATH}/src/
 go install changeloglockcleaner
 cp -a ${BOSH_COMPILE_TARGET}/bin/changeloglockcleaner ${BOSH_INSTALL_TARGET}

--- a/packages/eventgenerator/packaging
+++ b/packages/eventgenerator/packaging
@@ -3,6 +3,7 @@ set -e -x
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 export GOPATH=${BOSH_COMPILE_TARGET}/app-autoscaler
+export GOCACHE=/tmp/gocache
 
 go install autoscaler/eventgenerator/cmd/eventgenerator
 cp -a ${BOSH_COMPILE_TARGET}/app-autoscaler/bin/eventgenerator ${BOSH_INSTALL_TARGET}

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -1,4 +1,4 @@
 set -e -x
 
-tar xzf golang/go1.11.linux-amd64.tar.gz
+tar xzf golang/go1.13.linux-amd64.tar.gz
 cp -R go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -2,4 +2,4 @@
 name: golang
 
 files:
-    - golang/go1.11.linux-amd64.tar.gz
+    - golang/go1.13.linux-amd64.tar.gz

--- a/packages/metricscollector/packaging
+++ b/packages/metricscollector/packaging
@@ -3,6 +3,7 @@ set -e -x
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 export GOPATH=${BOSH_COMPILE_TARGET}/app-autoscaler
+export GOCACHE=/tmp/gocache
 
 go install autoscaler/metricscollector/cmd/metricscollector
 cp -a ${BOSH_COMPILE_TARGET}/app-autoscaler/bin/metricscollector ${BOSH_INSTALL_TARGET}

--- a/packages/metricsforwarder/packaging
+++ b/packages/metricsforwarder/packaging
@@ -3,6 +3,7 @@ set -e -x
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 export GOPATH=${BOSH_COMPILE_TARGET}/app-autoscaler
+export GOCACHE=/tmp/gocache
 
 go install autoscaler/metricsforwarder/cmd/metricsforwarder
 cp -a ${BOSH_COMPILE_TARGET}/app-autoscaler/bin/metricsforwarder ${BOSH_INSTALL_TARGET}

--- a/packages/metricsgateway/packaging
+++ b/packages/metricsgateway/packaging
@@ -3,6 +3,7 @@ set -e -x
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 export GOPATH=${BOSH_COMPILE_TARGET}/app-autoscaler
+export GOCACHE=/tmp/gocache
 
 go install autoscaler/metricsgateway/cmd/metricsgateway
 cp -a ${BOSH_COMPILE_TARGET}/app-autoscaler/bin/metricsgateway ${BOSH_INSTALL_TARGET}

--- a/packages/metricsserver/packaging
+++ b/packages/metricsserver/packaging
@@ -3,6 +3,7 @@ set -e -x
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 export GOPATH=${BOSH_COMPILE_TARGET}/app-autoscaler
+export GOCACHE=/tmp/gocache
 
 go install autoscaler/metricsserver/cmd/metricsserver
 cp -a ${BOSH_COMPILE_TARGET}/app-autoscaler/bin/metricsserver ${BOSH_INSTALL_TARGET}

--- a/packages/operator/packaging
+++ b/packages/operator/packaging
@@ -3,6 +3,7 @@ set -e -x
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 export GOPATH=${BOSH_COMPILE_TARGET}/app-autoscaler
+export GOCACHE=/tmp/gocache
 
 go install autoscaler/operator/cmd/operator
 cp -a ${BOSH_COMPILE_TARGET}/app-autoscaler/bin/operator ${BOSH_INSTALL_TARGET}

--- a/packages/scalingengine/packaging
+++ b/packages/scalingengine/packaging
@@ -3,6 +3,7 @@ set -e -x
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=$GOROOT/bin:$PATH
 export GOPATH=${BOSH_COMPILE_TARGET}/app-autoscaler
+export GOCACHE=/tmp/gocache
 
 go install autoscaler/scalingengine/cmd/scalingengine
 cp -a ${BOSH_COMPILE_TARGET}/app-autoscaler/bin/scalingengine ${BOSH_INSTALL_TARGET}


### PR DESCRIPTION
Golang 1.11 is an archived release, and there are a few CVEs open.