### PR TITLE
Add features: use_dns_addresses: true

### DIFF
--- a/templates/app-autoscaler-deployment.yml
+++ b/templates/app-autoscaler-deployment.yml
@@ -26,6 +26,8 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.0
   version: 1.1.0
   sha1: 82e83a5e8ebd6e07f6ca0765e94eb69e03324a19
+features:
+  use_dns_addresses: true
 addons:
 - name: bosh-dns-aliases
   include:


### PR DESCRIPTION
As it is needed for mTLS to work via the wildcard SANs, and it might not be enabled director-wide. Closes #210 

https://bosh.io/docs/dns/#links