### PR TITLE
let the test nodejs app use default node engines

### DIFF
--- a/src/acceptance/assets/app/nodeApp/package.json
+++ b/src/acceptance/assets/app/nodeApp/package.json
@@ -8,8 +8,5 @@
 	"dependencies": {
 		"express": "^4.17.1",
 		"request": "^2.88.0"
-	},
-	"engines": {
-		"node": "8.x"
 	}
 }


### PR DESCRIPTION
node 8.x.x will be deprecated soon. 
`**WARNING** node 8.x.x will no longer be available in new buildpacks released after 2019-12-01.`