### PR TITLE
nodejs 8.x is now out of support. fixture needs tiny bump to ensure it can push

### DIFF
--- a/src/acceptance/assets/app/nodeApp/package.json
+++ b/src/acceptance/assets/app/nodeApp/package.json
@@ -10,6 +10,6 @@
 		"request": "^2.88.0"
 	},
 	"engines": {
-		"node": "8.x"
+		"node": "10.x"
 	}
 }


### PR DESCRIPTION
nodejs buildpack removed support for nodejs 8.x unfortunately one of the fixtures in the v3.0.0 release is hard coded to use this version.

The result is any deployment using modern nodejs_buildpack ends up with failing acceptance tests for app-autoscaler.

I've pushed this over here and it works nicely

Ta