### PR TITLE
replace -d option in cf push to fix acceptence test

### DIFF
--- a/src/acceptance/api/api_suite_test.go
+++ b/src/acceptance/api/api_suite_test.go
@@ -74,8 +74,11 @@ var _ = BeforeSuite(func() {
 	appName = generator.PrefixedRandomName("autoscaler", "nodeapp")
 	initialInstanceCount := 1
 	countStr := strconv.Itoa(initialInstanceCount)
-	createApp := cf.Cf("push", appName, "--no-start", "-i", countStr, "-b", cfg.NodejsBuildpackName, "-m", "128M", "-p", config.NODE_APP, "-d", cfg.AppsDomain).Wait(cfg.CfPushTimeoutDuration())
+	createApp := cf.Cf("push", appName, "--no-start","--no-route", "-i", countStr, "-b", cfg.NodejsBuildpackName, "-m", "128M", "-p", config.NODE_APP).Wait(cfg.CfPushTimeoutDuration())
 	Expect(createApp).To(Exit(0), "failed creating app")
+
+	mapRouteToApp := cf.Cf("map-route", appName, cfg.AppsDomain, "--hostname", appName).Wait(cfg.DefaultTimeoutDuration())
+	Expect(mapRouteToApp).To(Exit(0), "failed to map route to app")
 
 	guid := cf.Cf("app", appName, "--guid").Wait(cfg.DefaultTimeoutDuration())
 	Expect(guid).To(Exit(0))


### PR DESCRIPTION
> Deprecation warning: Use of the '-d' command-line flag option is deprecated in favor of the 'routes' property in the manifest. Please see https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#routes for usage information. The '-d' command-line flag option will be removed in the future.

'-d' option is removed in the new cf cli.