### PR TITLE
Acceptance tests should use CF CLI v7

### DIFF
--- a/src/acceptance/README.md
+++ b/src/acceptance/README.md
@@ -62,6 +62,7 @@ The full set of config parameters is explained below:
 * `apps_domain` (required): A shared domain that tests can use to create subdomains that will route to applications also craeted in the tests.
 
 * `service_offering_enabled` (optional): Set to true if auto-scaler is offered as a cloudfoundry service. The value should be the consistent with the one in app-autoscaler deployment. Default is true.
+* `enable_service_access` (optional): Set to false if autoscaler is offered as a cloudfoundry service which is globally enabled. Default is true.
 * `skip_ssl_validation` (optional): Set to true if using an invalid (e.g. self-signed) cert for traffic routed to your CF instance; this is generally always true for BOSH-Lite deployments of CF.
 * `use_existing_user` (optional): The admin user configured above will normally be used to create a temporary user (with lesser permissions) to perform actions (such as push applications) during tests, and then delete said user after the tests have run; set this to `true` if you want to use an existing user, configured via the following properties.
 * `keep_user_at_suite_end` (optional): If using an existing user (see above), set this to `true` unless you are okay having your existing user being deleted at the end. You can also set this to `true` when not using an existing user if you want to leave the temporary user around for debugging purposes after the test teardown.

--- a/src/acceptance/api/api_suite_test.go
+++ b/src/acceptance/api/api_suite_test.go
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 	appName = generator.PrefixedRandomName("autoscaler", "nodeapp")
 	initialInstanceCount := 1
 	countStr := strconv.Itoa(initialInstanceCount)
-	createApp := cf.Cf("push", appName, "--no-start","--no-route", "-i", countStr, "-b", cfg.NodejsBuildpackName, "-m", "128M", "-p", config.NODE_APP).Wait(cfg.CfPushTimeoutDuration())
+	createApp := cf.Cf("push", appName, "--no-start", "--no-route", "-i", countStr, "-b", cfg.NodejsBuildpackName, "-m", "128M", "-p", config.NODE_APP).Wait(cfg.CfPushTimeoutDuration())
 	Expect(createApp).To(Exit(0), "failed creating app")
 
 	mapRouteToApp := cf.Cf("map-route", appName, cfg.AppsDomain, "--hostname", appName).Wait(cfg.DefaultTimeoutDuration())

--- a/src/acceptance/api/api_suite_test.go
+++ b/src/acceptance/api/api_suite_test.go
@@ -88,8 +88,7 @@ var _ = BeforeSuite(func() {
 	WaitForNInstancesRunning(appGUID, initialInstanceCount, cfg.DefaultTimeoutDuration())
 
 	if cfg.IsServiceOfferingEnabled() {
-		serviceExists := cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
-		Expect(serviceExists).To(Exit(0), fmt.Sprintf("Service offering, %s, does not exist", cfg.ServiceName))
+		CheckServiceExists(cfg)
 
 		instanceName = generator.PrefixedRandomName("autoscaler", "service")
 		createService := cf.Cf("create-service", cfg.ServiceName, cfg.ServicePlan, instanceName).Wait(cfg.DefaultTimeoutDuration())

--- a/src/acceptance/api/api_suite_test.go
+++ b/src/acceptance/api/api_suite_test.go
@@ -66,7 +66,7 @@ var _ = BeforeSuite(func() {
 	setup.Setup()
 
 	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
-		if cfg.IsServiceOfferingEnabled() {
+		if cfg.IsServiceOfferingEnabled() && cfg.ShouldEnableServiceAccess() {
 			EnableServiceAccess(cfg, setup.GetOrganizationName())
 		}
 	})
@@ -138,7 +138,7 @@ var _ = AfterSuite(func() {
 
 	Expect(cf.Cf("delete", appName, "-f", "-r").Wait(cfg.DefaultTimeoutDuration())).To(Exit(0))
 	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
-		if cfg.IsServiceOfferingEnabled() {
+		if cfg.IsServiceOfferingEnabled() && cfg.ShouldEnableServiceAccess() {
 			DisableServiceAccess(cfg, setup.GetOrganizationName())
 		}
 	})

--- a/src/acceptance/api/api_suite_test.go
+++ b/src/acceptance/api/api_suite_test.go
@@ -88,7 +88,7 @@ var _ = BeforeSuite(func() {
 	WaitForNInstancesRunning(appGUID, initialInstanceCount, cfg.DefaultTimeoutDuration())
 
 	if cfg.IsServiceOfferingEnabled() {
-		serviceExists := cf.Cf("marketplace", "-s", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
+		serviceExists := cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
 		Expect(serviceExists).To(Exit(0), fmt.Sprintf("Service offering, %s, does not exist", cfg.ServiceName))
 
 		instanceName = generator.PrefixedRandomName("autoscaler", "service")

--- a/src/acceptance/app/app_suite_test.go
+++ b/src/acceptance/app/app_suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 	setup.Setup()
 
 	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
-		if cfg.IsServiceOfferingEnabled() {
+		if cfg.IsServiceOfferingEnabled() && cfg.ShouldEnableServiceAccess() {
 			EnableServiceAccess(cfg, setup.GetOrganizationName())
 		}
 	})
@@ -99,7 +99,7 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
-		if cfg.IsServiceOfferingEnabled() {
+		if cfg.IsServiceOfferingEnabled() && cfg.ShouldEnableServiceAccess() {
 			DisableServiceAccess(cfg, setup.GetOrganizationName())
 		}
 	})

--- a/src/acceptance/app/app_suite_test.go
+++ b/src/acceptance/app/app_suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 		}
 	})
 	if cfg.IsServiceOfferingEnabled() {
-		serviceExists := cf.Cf("marketplace", "-s", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
+		serviceExists := cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
 		Expect(serviceExists).To(Exit(0), fmt.Sprintf("Service offering, %s, does not exist", cfg.ServiceName))
 	}
 

--- a/src/acceptance/app/app_suite_test.go
+++ b/src/acceptance/app/app_suite_test.go
@@ -72,8 +72,7 @@ var _ = BeforeSuite(func() {
 		}
 	})
 	if cfg.IsServiceOfferingEnabled() {
-		serviceExists := cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
-		Expect(serviceExists).To(Exit(0), fmt.Sprintf("Service offering, %s, does not exist", cfg.ServiceName))
+		CheckServiceExists(cfg)
 	}
 
 	interval = cfg.AggregateInterval

--- a/src/acceptance/broker/broker_suite_test.go
+++ b/src/acceptance/broker/broker_suite_test.go
@@ -1,18 +1,15 @@
 package broker
 
 import (
-	"fmt"
 	"testing"
 
 	"acceptance/config"
 	. "acceptance/helpers"
 
-	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var (
@@ -47,8 +44,7 @@ var _ = BeforeSuite(func() {
 		}
 	})
 
-	serviceExists := cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
-	Expect(serviceExists).To(Exit(0), fmt.Sprintf("Service offering, %s, does not exist", cfg.ServiceName))
+	CheckServiceExists(cfg)
 })
 
 var _ = AfterSuite(func() {

--- a/src/acceptance/broker/broker_suite_test.go
+++ b/src/acceptance/broker/broker_suite_test.go
@@ -45,7 +45,7 @@ var _ = BeforeSuite(func() {
 		EnableServiceAccess(cfg, setup.GetOrganizationName())
 	})
 
-	serviceExists := cf.Cf("marketplace", "-s", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
+	serviceExists := cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
 	Expect(serviceExists).To(Exit(0), fmt.Sprintf("Service offering, %s, does not exist", cfg.ServiceName))
 })
 

--- a/src/acceptance/broker/broker_suite_test.go
+++ b/src/acceptance/broker/broker_suite_test.go
@@ -42,7 +42,9 @@ var _ = BeforeSuite(func() {
 	setup.Setup()
 
 	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
-		EnableServiceAccess(cfg, setup.GetOrganizationName())
+		if cfg.ShouldEnableServiceAccess() {
+			EnableServiceAccess(cfg, setup.GetOrganizationName())
+		}
 	})
 
 	serviceExists := cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
@@ -51,7 +53,9 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
-		DisableServiceAccess(cfg, setup.GetOrganizationName())
+		if cfg.ShouldEnableServiceAccess() {
+			DisableServiceAccess(cfg, setup.GetOrganizationName())
+		}
 	})
 	setup.Teardown()
 })

--- a/src/acceptance/config/config.go
+++ b/src/acceptance/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 
 	ASApiEndpoint          string `json:"autoscaler_api"`
 	ServiceOfferingEnabled bool   `json:"service_offering_enabled"`
+	EnableServiceAccess    bool   `json:"enable_service_access"`
 }
 
 var defaults = Config{
@@ -76,6 +77,7 @@ var defaults = Config{
 	CfJavaTimeout:          10,  // minutes
 	NodeMemoryLimit:        128, // MB
 	ServiceOfferingEnabled: true,
+	EnableServiceAccess:    true,
 }
 
 func LoadConfig(t *testing.T) *Config {
@@ -271,6 +273,10 @@ func (c *Config) GetApiEndpoint() string {
 
 func (c *Config) IsServiceOfferingEnabled() bool {
 	return c.ServiceOfferingEnabled
+}
+
+func (c *Config) ShouldEnableServiceAccess() bool {
+	return c.EnableServiceAccess
 }
 
 func (c *Config) GetAdminClient() string {

--- a/src/acceptance/helpers/helpers.go
+++ b/src/acceptance/helpers/helpers.go
@@ -116,6 +116,20 @@ func DisableServiceAccess(cfg *config.Config, orgName string) {
 	Expect(enableServiceAccess).To(Exit(0), fmt.Sprintf("Failed to disable service %s for org %s", cfg.ServiceName, orgName))
 }
 
+func CheckServiceExists(cfg *config.Config) {
+	version := cf.Cf("version").Wait(cfg.DefaultTimeoutDuration())
+	Expect(version).To(Exit(0), "Could not determine cf version")
+
+	var serviceExists *Session
+	if strings.Contains(string(version.Out.Contents()), "version 7") {
+		serviceExists = cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
+	} else {
+		serviceExists = cf.Cf("marketplace", "-s", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
+	}
+
+	Expect(serviceExists).To(Exit(0), fmt.Sprintf("Service offering, %s, does not exist", cfg.ServiceName))
+}
+
 func GenerateDynamicScaleOutPolicy(cfg *config.Config, instanceMin, instanceMax int, metricName string, threshold int64) string {
 	scalingOutRule := ScalingRule{
 		MetricType:            metricName,


### PR DESCRIPTION
When running the autoscaler acceptance tests, using a GA version of the CF CLI version 7, the tests fail because there is no longer a `-s` flag when running `cf marketplace`

In v7 the flags `-b` for broker and `-e` for offering exist instead.

Acceptance tests should check that service offering exists with appropriate name using CF CLI v7

---

When running the autoscaler acceptance tests where the autoscaler is deployed and globally available, `cf disable-service-access -o org-id` will fail. A new flag `enable_service_access` which defaults to true controls whether `enable-service-access` and `disable-service-access` are called.

---

#### Checklist

- [x] CLA
- [x]  Run against a CF Deployment with Autoscaler