### PR TITLE
Added an example operations file to change the default vm type

### DIFF
--- a/example/operation/alternative-vm-type.yml
+++ b/example/operation/alternative-vm-type.yml
@@ -1,0 +1,20 @@
+
+- type: replace
+  path: /instance_groups/name=asactors/vm_type
+  value: ((alternative_vm_type))
+
+- type: replace
+  path: /instance_groups/name=asmetrics/vm_type
+  value: ((alternative_vm_type))
+
+- type: replace
+  path: /instance_groups/name=asnozzle/vm_type
+  value: ((alternative_vm_type))
+
+- type: replace
+  path: /instance_groups/name=asapi/vm_type
+  value: ((alternative_vm_type))
+
+- type: replace
+  path: /instance_groups/name=postgres_autoscaler/vm_type
+  value: ((alternative_vm_type))


### PR DESCRIPTION
This will be used when testing the pipeline via the `bosh/main-bosh-docker` image, as the default cloud config only contains the  a `default` vm type