### PR TITLE
AAS-75: changes to the "health server" properties

### DIFF
--- a/jobs/scheduler/spec
+++ b/jobs/scheduler/spec
@@ -104,7 +104,7 @@ properties:
     description: "sslmode to connect to postgres server"
 
   autoscaler.scheduler.health.port:
-    description: "the listening port of health endpoint"
+    description: "The scheduler server port to collect prometheus metrics."
     default: 6204
   autoscaler.changeloglock_timeout_seconds:
     default: 180

--- a/jobs/scheduler/templates/application.properties.erb
+++ b/jobs/scheduler/templates/application.properties.erb
@@ -100,7 +100,7 @@ spring.quartz.properties.org.quartz.threadPool.threadCount=10
 
 # scheduler port
 server.port=<%=p('autoscaler.scheduler.port') %>
-scheduler.healthserver.port=<%=p('autoscaler.scheduler.health.port') %>
+scheduler.metrics.port=<%=p('autoscaler.scheduler.health.port') %>
 
 spring.application.name=scheduler
 spring.mvc.servlet.load-on-startup=1


### PR DESCRIPTION
The rational of this change is that the health server is not a health enpoint but a metrics endpoint which can be used to derive health stats or other stats.