### PR TITLE
Fix bad request on stop cpu when instance is already removed

### DIFF
--- a/src/acceptance/app/dynamic_policy_test.go
+++ b/src/acceptance/app/dynamic_policy_test.go
@@ -282,10 +282,10 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 			helpers.WaitForNInstancesRunning(appGUID, 2, 5*time.Minute)
 
 			By("should scale in to 1 instance after cpu usage is reduced")
-			for i := 0; i < 2; i++ {
-				helpers.AppEndCpuTest(cfg, appName, i)
-			}
-			helpers.WaitForNInstancesRunning(appGUID, 1, 5*time.Minute)
+			//only hit the one instance that was asked to run hot.
+			helpers.AppEndCpuTest(cfg, appName, 0)
+
+			helpers.WaitForNInstancesRunning(appGUID, 1, 10*time.Minute)
 		})
 	})
 })

--- a/src/acceptance/post_upgrade/post_dynamic_policy_test.go
+++ b/src/acceptance/post_upgrade/post_dynamic_policy_test.go
@@ -42,11 +42,10 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 			helpers.WaitForNInstancesRunning(appGUID, 2, 10*time.Minute)
 
 			By("should scale in to 1 instance after cpu usage is reduced")
-			for i := 0; i < 2; i++ {
-				helpers.AppEndCpuTest(cfg, appName, i)
-			}
-			helpers.WaitForNInstancesRunning(appGUID, 1, 10*time.Minute)
+			//only hit the one instance that was asked to run hot.
+			helpers.AppEndCpuTest(cfg, appName, 0)
 
+			helpers.WaitForNInstancesRunning(appGUID, 1, 10*time.Minute)
 		})
 	})
 })

--- a/src/acceptance/pre_upgrade/pre_dynamic_policy_test.go
+++ b/src/acceptance/pre_upgrade/pre_dynamic_policy_test.go
@@ -40,11 +40,9 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 				helpers.WaitForNInstancesRunning(appGUID, 2, 10*time.Minute)
 
 				By("should scale in to 1 instance after cpu usage is reduced")
-				for i := 0; i < 2; i++ {
-					helpers.AppEndCpuTest(cfg, appName, i)
-				}
+				//only hit the one instance that was asked to run hot.
+				helpers.AppEndCpuTest(cfg, appName, 0)
 				helpers.WaitForNInstancesRunning(appGUID, 1, 10*time.Minute)
-
 			})
 
 		})


### PR DESCRIPTION
There is a possibility that the down scale happens very fast and that the second instance is not available any more.
This causes a bad request and fails the test.
Since only instance 0 was generating the cpu load then only instance 0 needs to be stopped for the scale down to occur.

 e.g.
 https://bosh.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/upgrade-test-main/builds/52.1
