### PR TITLE
Enable rotation credentials for service broker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-its
 
 BUNDLED WITH
-   1.17.2
+  2.1.2

--- a/jobs/golangapiserver/spec
+++ b/jobs/golangapiserver/spec
@@ -49,10 +49,9 @@ properties:
     description: "PEM-encoded server certificate"
   autoscaler.apiserver.broker.server.server_key:
     description: "PEM-encoded server key"
-  autoscaler.apiserver.broker.username:
-    description: "username to authenticate with service broker"
-  autoscaler.apiserver.broker.password:
-    description: "password to authenticate with service broker"
+
+  autoscaler.apiserver.broker_credentials:
+    description: "the list of credentials to authenticate with service broker"
   autoscaler.apiserver.broker.server.catalog:
     description: ""
   autoscaler.apiserver.broker.server.dashboard_redirect_uri:

--- a/jobs/golangapiserver/spec
+++ b/jobs/golangapiserver/spec
@@ -50,14 +50,20 @@ properties:
   autoscaler.apiserver.broker.server.server_key:
     description: "PEM-encoded server key"
 
+  autoscaler.apiserver.broker.username:
+    description: "DEPRECATED - username to authenticate with service broker"
+  autoscaler.apiserver.broker.password:
+    description: "DEPRECATED - password to authenticate with service broker"
+
   autoscaler.apiserver.broker.broker_credentials:
     description: |
-      The list of credentials to authenticate with service broker. This is usefull when credential rotation is required
+      The list of credentials to authenticate with service broker. This is useful when credential rotation is required
       example:
        - broker_username: user1
          broker_password: password1
        - broker_username: user2
          broker_password: password2
+    default: ''
   autoscaler.apiserver.broker.server.catalog:
     description: ""
   autoscaler.apiserver.broker.server.dashboard_redirect_uri:

--- a/jobs/golangapiserver/spec
+++ b/jobs/golangapiserver/spec
@@ -51,7 +51,13 @@ properties:
     description: "PEM-encoded server key"
 
   autoscaler.apiserver.broker.broker_credentials:
-    description: "the list of credentials to authenticate with service broker"
+    description: |
+      The list of credentials to authenticate with service broker. This is usefull when credential rotation is required
+      example:
+       - broker_username: user1
+         broker_password: password1
+       - broker_username: user2
+         broker_password: password2
   autoscaler.apiserver.broker.server.catalog:
     description: ""
   autoscaler.apiserver.broker.server.dashboard_redirect_uri:

--- a/jobs/golangapiserver/spec
+++ b/jobs/golangapiserver/spec
@@ -50,7 +50,7 @@ properties:
   autoscaler.apiserver.broker.server.server_key:
     description: "PEM-encoded server key"
 
-  autoscaler.apiserver.broker_credentials:
+  autoscaler.apiserver.broker.broker_credentials:
     description: "the list of credentials to authenticate with service broker"
   autoscaler.apiserver.broker.server.catalog:
     description: ""

--- a/jobs/golangapiserver/templates/apiserver.yml.erb
+++ b/jobs/golangapiserver/templates/apiserver.yml.erb
@@ -48,7 +48,7 @@ public_api_server:
 broker_server:
   port:  <%= p("autoscaler.apiserver.broker.server.port") %>
 
-broker_credentials: <%= p_arr('autoscaler.apiserver.broker_credentials') %>
+broker_credentials: <%= p_arr('autoscaler.apiserver.broker.broker_credentials') %>
 
 catalog_path: /var/vcap/jobs/golangapiserver/config/catalog.json
 catalog_schema_path: /var/vcap/packages/golangapiserver/catalog.schema.json

--- a/jobs/golangapiserver/templates/apiserver.yml.erb
+++ b/jobs/golangapiserver/templates/apiserver.yml.erb
@@ -48,7 +48,13 @@ public_api_server:
 broker_server:
   port:  <%= p("autoscaler.apiserver.broker.server.port") %>
 
+<% if p("autoscaler.apiserver.broker.broker_credentials") != '' %>
 <%= {'broker_credentials' => p('autoscaler.apiserver.broker.broker_credentials')}.to_yaml.lines[1..-1].join %>
+<% else %>
+broker_credentials:
+- broker_username: <%= p("autoscaler.apiserver.broker.username") %>
+  broker_password: <%= p("autoscaler.apiserver.broker.password") %>
+<% end %>
 
 catalog_path: /var/vcap/jobs/golangapiserver/config/catalog.json
 catalog_schema_path: /var/vcap/packages/golangapiserver/catalog.schema.json

--- a/jobs/golangapiserver/templates/apiserver.yml.erb
+++ b/jobs/golangapiserver/templates/apiserver.yml.erb
@@ -48,7 +48,7 @@ public_api_server:
 broker_server:
   port:  <%= p("autoscaler.apiserver.broker.server.port") %>
 
-broker_credentials: <%= p_arr('autoscaler.apiserver.broker.broker_credentials') %>
+<%= {'broker_credentials' => p('autoscaler.apiserver.broker.broker_credentials')}.to_yaml.lines[1..-1].join %>
 
 catalog_path: /var/vcap/jobs/golangapiserver/config/catalog.json
 catalog_schema_path: /var/vcap/packages/golangapiserver/catalog.schema.json

--- a/jobs/golangapiserver/templates/apiserver.yml.erb
+++ b/jobs/golangapiserver/templates/apiserver.yml.erb
@@ -48,9 +48,7 @@ public_api_server:
 broker_server:
   port:  <%= p("autoscaler.apiserver.broker.server.port") %>
 
-broker_credentials:
-- broker_username: <%= p("autoscaler.apiserver.broker.username") %>
-  broker_password: <%= p("autoscaler.apiserver.broker.password") %>
+broker_credentials: <%= p_arr('autoscaler.apiserver.broker_credentials') %>
 
 catalog_path: /var/vcap/jobs/golangapiserver/config/catalog.json
 catalog_schema_path: /var/vcap/packages/golangapiserver/catalog.schema.json

--- a/spec/jobs/golangapiserver/apiserver_spec.rb
+++ b/spec/jobs/golangapiserver/apiserver_spec.rb
@@ -20,8 +20,6 @@ describe 'golangapiserver' do
           roles:
           - name: foo
             tag: default
-          - name: autoscaler-sbss-user
-            tag: sbssdb
         policy_db:
           address: 10.11.137.101
           databases:
@@ -32,22 +30,12 @@ describe 'golangapiserver' do
           roles:
           - name: foo
             tag: default
-          - name: autoscaler-sbss-user
-            tag: sbssdb
-        sbss_db:
-          address: 10.11.137.101
-          databases:
-          - name: foo
-            tag: default
           db_scheme: postgres
           port: 5432
           roles:
           - name: foo
             password: default
             tag: default
-          - name: autoscaler-sbss-user
-            password: default
-            tag: sbssdb
         cf:
           api: https://api.cf.domain
           auth_endpoint: https://login.cf.domain
@@ -61,7 +49,7 @@ describe 'golangapiserver' do
     ))
   end
 
-  context 'config/apisderer.yml' do
+  context 'config/apiserver.yml' do
     context 'apiserver does not use buildin mode' do
       before(:each) do
         properties['autoscaler']['apiserver'].merge!(

--- a/spec/jobs/golangapiserver/apiserver_spec.rb
+++ b/spec/jobs/golangapiserver/apiserver_spec.rb
@@ -19,6 +19,7 @@ describe 'golangapiserver' do
           port: 5432
           roles:
           - name: foo
+            password: default
             tag: default
         policy_db:
           address: 10.11.137.101

--- a/spec/jobs/golangapiserver/apiserver_spec.rb
+++ b/spec/jobs/golangapiserver/apiserver_spec.rb
@@ -1,0 +1,93 @@
+require 'rspec'
+require 'json'
+require 'bosh/template/test'
+require 'yaml'
+
+describe 'golangapiserver' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
+  let(:job) { release.job('golangapiserver') }
+  let(:template) { job.template('config/apiserver.yml') }
+  let(:properties) do
+    YAML.safe_load(%(
+      autoscaler:
+        binding_db:
+          address: 10.11.137.101
+          databases:
+          - name: foo
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: foo
+            tag: default
+          - name: autoscaler-sbss-user
+            tag: sbssdb
+        policy_db:
+          address: 10.11.137.101
+          databases:
+          - name: foo
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: foo
+            tag: default
+          - name: autoscaler-sbss-user
+            tag: sbssdb
+        sbss_db:
+          address: 10.11.137.101
+          databases:
+          - name: foo
+            tag: default
+          db_scheme: postgres
+          port: 5432
+          roles:
+          - name: foo
+            password: default
+            tag: default
+          - name: autoscaler-sbss-user
+            password: default
+            tag: sbssdb
+        cf:
+          api: https://api.cf.domain
+          auth_endpoint: https://login.cf.domain
+          client_id: client_id
+          secret: uaa_secret
+        apiserver:
+          broker:
+            server:
+              dashboard_redirect_uri: https://application-autoscaler-dashboard.cf.domain
+            plan_check: --
+    ))
+  end
+
+  context 'config/apisderer.yml' do
+    context 'apiserver does not use buildin mode' do
+      before(:each) do
+        properties['autoscaler']['apiserver'].merge!(
+          'use_buildin_mode' => false,
+        )
+      end
+
+      it 'writes service_broker_usernames' do
+        properties['autoscaler']['apiserver']['broker'].merge!(
+          'broker_credentials' => [
+            { 'broker_username' => 'fake_b_user_1',
+              'broker_password' => 'fake_b_password_1' },
+            { 'broker_username' => 'fake_b_user_2',
+              'broker_password' => 'fake_b_password_2' },
+          ],
+        )
+
+        rendered_template = YAML.safe_load(template.render(properties))
+
+        expect(rendered_template['broker_credentials']).to include(
+          { 'broker_username' => 'fake_b_user_1',
+            'broker_password' => 'fake_b_password_1' },
+          { 'broker_username' => 'fake_b_user_2',
+            'broker_password' => 'fake_b_password_2' },
+        )
+      end
+    end
+  end
+end

--- a/spec/jobs/golangapiserver/apiserver_spec.rb
+++ b/spec/jobs/golangapiserver/apiserver_spec.rb
@@ -77,6 +77,43 @@ describe 'golangapiserver' do
             'broker_password' => 'fake_b_password_2' },
         )
       end
+
+      it 'writes deprecated service_broker_usernames' do
+        properties['autoscaler']['apiserver']['broker'].merge!(
+          'username' => 'deprecated_username',
+          'password' => 'deprecated_password'
+        )
+
+        rendered_template = YAML.safe_load(template.render(properties))
+
+        expect(rendered_template['broker_credentials']).to include(
+          { 'broker_username' => 'deprecated_username',
+            'broker_password' => 'deprecated_password' },
+        )
+      end
+
+      it 'favour list of credentials over deprecated values' do
+        properties['autoscaler']['apiserver']['broker'].merge!(
+          'broker_credentials' => [
+            { 'broker_username' => 'fake_b_user_1',
+              'broker_password' => 'fake_b_password_1' },
+            { 'broker_username' => 'fake_b_user_2',
+              'broker_password' => 'fake_b_password_2' },
+          ],
+          'username' => 'deprecated_username',
+          'password' => 'deprecated_password'
+        )
+
+        rendered_template = YAML.safe_load(template.render(properties))
+
+        expect(rendered_template['broker_credentials']).to include(
+          { 'broker_username' => 'fake_b_user_1',
+            'broker_password' => 'fake_b_password_1' },
+          { 'broker_username' => 'fake_b_user_2',
+            'broker_password' => 'fake_b_password_2' },
+        )
+      end
+
     end
   end
 end


### PR DESCRIPTION
Enable the ablitiy to rotate credentials for the service broker  by having multiple logins for past and new user/password combos
