### PR TITLE
Enable nats tls by default

### DIFF
--- a/REQUIRED_OPS_FILES
+++ b/REQUIRED_OPS_FILES
@@ -1,1 +1,2 @@
 example/operation/instance-identity-cert-from-cf.yml
+example/operation/enable-nats-tls.yml


### PR DESCRIPTION
Required with cf-deployment v17.x