### PR TITLE
Removing unnecessary ca Cert file for metricsforwarder mtls

### DIFF
--- a/jobs/metricsforwarder/spec
+++ b/jobs/metricsforwarder/spec
@@ -10,10 +10,7 @@ templates:
   metron_client.key.erb: config/certs/metron_client/client.key
 
   policy_db_ca.crt.erb: config/certs/policy_db/ca.crt
-
   storedprocedure_db_ca.crt.erb: config/certs/storedprocedure_db/ca.crt
-
-  instance_identity_ca.crt.erb: config/certs/instance_identity_ca.crt
 
   hooks/pre-start.sh.erb: bin/hooks/pre-start.sh
   hooks/pre-stop.sh.erb: bin/hooks/pre-stop.sh
@@ -45,10 +42,6 @@ properties:
     description: "PEM-encoded tls client key to connect to loggregator ingress client"
   autoscaler.metricsforwarder.loggregator.tls.ca_cert:
     description: "PEM-encoded ca certificate of loggregator ingress client"
-
-  autoscaler.metricsforwarder.metricshandler.tls.ca_cert:
-    description: "PEM-encoded ca certificate for mTLS verification of applications"
-    default: ""
 
   autoscaler.metricsforwarder.cred_helper.plugin:
     description: "Either default|stored_procedure or the location (not directory) of a plugin executable which retrieves and manages credentials"

--- a/jobs/metricsforwarder/templates/instance_identity_ca.crt.erb
+++ b/jobs/metricsforwarder/templates/instance_identity_ca.crt.erb
@@ -1,3 +1,0 @@
-<% if_p("autoscaler.metricsforwarder.metricshandler.tls.ca_cert") do |value|%>
-<%= value %>
-<% end %>

--- a/jobs/metricsforwarder/templates/metricsforwarder.yml.erb
+++ b/jobs/metricsforwarder/templates/metricsforwarder.yml.erb
@@ -70,12 +70,6 @@ rate_limit:
   valid_duration: <%= p("autoscaler.metricsforwarder.rate_limit.valid_duration") %>
   max_amount: <%= p("autoscaler.metricsforwarder.rate_limit.max_amount") %>
 
-<% if p("autoscaler.metricsforwarder.metricshandler.tls.ca_cert") != '' %>
-metrics_forwarder:
-  tls:
-    ca_file: /var/vcap/jobs/metricsforwarder/config/certs/instance_identity_ca.crt
-<% end %>
-
 cred_helper_plugin: <%= p("autoscaler.metricsforwarder.cred_helper.plugin") %>
 <% if p('autoscaler.metricsforwarder.cred_helper.stored_procedure_config') != {} %>
 <%= {"stored_procedure_config" => p("autoscaler.metricsforwarder.cred_helper.stored_procedure_config")}.to_yaml.lines[1..-1].join %>

--- a/spec/jobs/metricsforwarder/metricsforwarder_spec.rb
+++ b/spec/jobs/metricsforwarder/metricsforwarder_spec.rb
@@ -70,38 +70,7 @@ describe 'metricsforwarder' do
            )
 		end
 
-    it 'has no instance identity configured by default' do
-      rendered_template = YAML.safe_load(template.render(properties))
-      expect(rendered_template).
-        to_not include( 'metrics_forwarder' )
-    end
-
-    it 'has instance identity configured' do
-      properties['autoscaler'].merge!(
-        'metricsforwarder' => {
-          'metricshandler' => {
-            'tls' => {
-              'ca_cert' => '--- THIS IS A CERTIFICATE ---',
-            }
-          }
-        }
-      )
-
-      rendered_template = YAML.safe_load(template.render(properties))
-      expect(rendered_template).
-        to include(
-             {
-               "metrics_forwarder" => {
-                 "tls"=> {
-                   "ca_file" => "/var/vcap/jobs/metricsforwarder/config/certs/instance_identity_ca.crt"
-                 }
-               }
-             }
-           )
-    end
-
     it 'has a cred helper plugin by default' do
-
       rendered_template = YAML.safe_load(template.render(properties))
       expect(rendered_template).to include(
         {
@@ -143,7 +112,6 @@ describe 'metricsforwarder' do
     end
 
     it 'has a cred helper plugin that can be configured by specifying different path' do
-
       properties['autoscaler'].merge!(
         'metricsforwarder' => {
           'cred_helper' => {


### PR DESCRIPTION
This PR just removes all the ca_cert stuff that we thought was needed in mtls but actually was unnecessary and just complicates the process.
This relies on the changes from autoscaler to me merged in first.
https://github.com/cloudfoundry/app-autoscaler/pull/796