### PR TITLE
Log4J 2.17.0

### DIFF
--- a/src/scheduler/pom.xml
+++ b/src/scheduler/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <io.prometheus.simpleclient.version>0.12.0</io.prometheus.simpleclient.version>
-        <log4j2.version>2.16.0</log4j2.version>
+        <log4j2.version>2.17.0</log4j2.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Important: Security Vulnerability CVE-2021-45105
The Log4j team has been made aware of a security vulnerability, CVE-2021-45105, that has been addressed in Log4j 2.17.0 for Java 8 and up.

Summary: Apache Log4j2 does not always protect from infinite recursion in lookup evaluation.

Details
Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.

Mitigation
From version 2.17.0 (for Java 8), only lookup strings in configuration are expanded recursively; in any other usage, only the top-level lookup is resolved, and any nested lookups are not resolved.

In prior releases this issue can be mitigated by ensuring your logging configuration does the following:

In PatternLayout in the logging configuration, replace Context Lookups like ${ctx:loginId}or $${ctx:loginId} with Thread Context Map patterns (%X, %mdc, or %MDC).
Otherwise, in the configuration, remove references to Context Lookups like ${ctx:loginId} or $${ctx:loginId} where they originate from sources external to the application such as HTTP headers or user input.
Reference
Please refer to the Security page for details and mitigation measures for older versions of Log4j.