### PR TITLE
Fix java linter

### DIFF
--- a/style-guide/inspect-java-format-0.1.sh
+++ b/style-guide/inspect-java-format-0.1.sh
@@ -57,9 +57,9 @@ CHECKSTYLE_OUTPUT=$(java \
   -jar "$DOWNLOAD_PATH"/"$CHECKSTYLE_JAR_NAME" \
   -p "${CHECKSTYLE_CONFIG_PATH}"/checkstyle.properties \
   -c "${CHECKSTYLE_CONFIG_PATH}"/"${CHECKSTYLE_CONFIG_FILE_NAME}" \
-  -o "${result_log}" $changed_java_files  )
-FILES_NEEDS_CORRECTION=$(echo "$CHECKSTYLE_OUTPUT" | sed  '0d;1d;$d' "$result_log")
+  -o "${result_log}" $changed_java_files)
 
+FILES_NEEDS_CORRECTION=$(cat "${result_log}" | grep -v "Starting audit..." | grep -v "Audit done")
 
 if  [[ -n "$FILES_NEEDS_CORRECTION" ]]; then
   echo "$FILES_NEEDS_CORRECTION"


### PR DESCRIPTION
```
❯ git commit -m "migration to mockito 4"
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /Users/C5326931/.cache/pre-commit/patch1640168034-64116.
java-formatter...........................................................Failed
- hook id: java-formatter
- exit code: 1

Running Checkstyle using /Users/C5326931/SAPDevelop/app-autoscaler-release/.cache/checkstyle-8.44-all.jar...
sed: -e expression #1, char 2: invalid usage of line address 0
rm: cannot remove '/Users/C5326931/SAPDevelop/app-autoscaler-release/style-guide/result.txt': No such file or directory

Running Checkstyle using /Users/C5326931/SAPDevelop/app-autoscaler-release/.cache/checkstyle-8.44-all.jar...
sed: -e expression #1, char 2: invalid usage of line address 0

golangci-lint........................................(no files to check)Skipped
[INFO] Restored changes from /Users/C5326931/.cache/pre-commit/patch1640168034-64116.
```