### PR TITLE
Upgrade liquibase 4.6.2

### DIFF
--- a/jobs/eventgenerator/spec
+++ b/jobs/eventgenerator/spec
@@ -2,6 +2,7 @@
 name: eventgenerator
 templates:
   pre-start.erb: bin/pre-start
+  liquibase.properties: bin/liquibase.properties
   eventgenerator_ctl: bin/eventgenerator_ctl
   eventgenerator.yml.erb: config/eventgenerator.yml
   eventgenerator_ca.crt.erb: config/certs/eventgenerator/ca.crt

--- a/jobs/eventgenerator/templates/liquibase.properties
+++ b/jobs/eventgenerator/templates/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.hub.mode=off

--- a/jobs/golangapiserver/spec
+++ b/jobs/golangapiserver/spec
@@ -3,6 +3,7 @@ templates:
   apiserver_ctl.erb: bin/apiserver_ctl
   apiserver.yml.erb: config/apiserver.yml
   pre-start.erb: bin/pre-start
+  liquibase.properties: bin/liquibase.properties
   info.json.erb: config/info.json
   catalog.json.erb: config/catalog.json
   apiserver_ca.crt.erb: config/certs/apiserver/ca.crt

--- a/jobs/golangapiserver/templates/liquibase.properties
+++ b/jobs/golangapiserver/templates/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.hub.mode=off

--- a/jobs/metricsserver/spec
+++ b/jobs/metricsserver/spec
@@ -2,6 +2,7 @@
 name: metricsserver
 templates:
   pre-start.erb: bin/pre-start
+  liquibase.properties: bin/liquibase.properties
   metricsserver_ctl: bin/metricsserver_ctl
   metricsserver.yml.erb: config/metricsserver.yml
   metricsserver_ca.crt.erb: config/certs/metricsserver/ca.crt

--- a/jobs/metricsserver/templates/liquibase.properties
+++ b/jobs/metricsserver/templates/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.hub.mode=off

--- a/jobs/operator/spec
+++ b/jobs/operator/spec
@@ -4,6 +4,7 @@ templates:
   operator_ctl: bin/operator_ctl
   operator.yml.erb: config/operator.yml
   pre-start.erb: bin/pre-start
+  liquibase.properties: bin/liquibase.properties
   scalingengine_ca.crt.erb: config/certs/scalingengine/ca.crt
   scalingengine_client.crt.erb: config/certs/scalingengine/client.crt
   scalingengine_client.key.erb: config/certs/scalingengine/client.key

--- a/jobs/operator/templates/liquibase.properties
+++ b/jobs/operator/templates/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.hub.mode=off

--- a/jobs/scalingengine/spec
+++ b/jobs/scalingengine/spec
@@ -2,6 +2,7 @@
 name: scalingengine
 templates:
   pre-start.erb: bin/pre-start
+  liquibase.properties: bin/liquibase.properties
   scalingengine_ctl: bin/scalingengine_ctl
   scalingengine.yml.erb: config/scalingengine.yml
   scalingengine_ca.crt.erb: config/certs/scalingengine/ca.crt

--- a/jobs/scalingengine/templates/liquibase.properties
+++ b/jobs/scalingengine/templates/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.hub.mode=off

--- a/jobs/scheduler/spec
+++ b/jobs/scheduler/spec
@@ -3,6 +3,7 @@ name: scheduler
 templates:
   scheduler.erb: bin/scheduler
   pre-start.erb: bin/pre-start
+  liquibase.properties: bin/liquibase.properties
   application.properties.erb: config/application.properties
   install_crt_keystore.erb: bin/install_crt_keystore
   install_crt_truststore.erb: bin/install_crt_truststore

--- a/jobs/scheduler/templates/liquibase.properties
+++ b/jobs/scheduler/templates/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.hub.mode=off

--- a/liquibase-4-test.sh
+++ b/liquibase-4-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+git restore src/db/pom.xml
+rm -f liquibase.properties
+
+make clean
+# set liquibase to 3.6.3
+sed -i 's/3.10.3/3.6.3/' src/db/pom.xml
+make init-db | grep -v '##'
+# set liquibase to 4.x.x
+
+sed -i 's/3.6.3/4.6.2/' src/db/pom.xml
+pushd src/db
+  mvn clean package -DskipTests
+popd
+
+rm target/init-db-postgres
+
+echo "liquibase.hub.mode=off" > liquibase.properties
+
+make init-db | grep -v '##'
+
+psql postgres://postgres:postgres@localhost/autoscaler\?sslmode=disable -c "select id,author,liquibase,filename,exectype from databasechangelog;"
+make clean
+make init-db | grep -v '##'
+psql postgres://postgres:postgres@localhost/autoscaler\?sslmode=disable -c "select id,author,liquibase,filename,exectype from databasechangelog;"

--- a/liquibase.properties
+++ b/liquibase.properties
@@ -1,0 +1,1 @@
+liquibase.hub.mode=off

--- a/src/db/pom.xml
+++ b/src/db/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-			<version>3.10.3</version>
+			<version>4.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.yaml</groupId>


### PR DESCRIPTION
**Liquibase 3.6.3 and 4.6.2 Output**

The upgrade from 3.6.3 to 4.6.3 works. It has correctly determined the filepaths.

```
 id |    author    | liquibase |                              filename                              | exectype
----+--------------+-----------+--------------------------------------------------------------------+----------
 1  | pradyutsarma | 3.6.3     | /var/vcap/packages/golangapiserver/api.db.changelog.yml            | EXECUTED
 2  | fujitsu      | 3.6.3     | /var/vcap/packages/golangapiserver/api.db.changelog.yml            | EXECUTED
 3  | paltanmoy    | 3.6.3     | /var/vcap/packages/golangapiserver/api.db.changelog.yml            | EXECUTED
 1  | ying         | 3.6.3     | /var/vcap/packages/golangapiserver/servicebroker.db.changelog.json | EXECUTED
 2  | qy           | 3.6.3     | /var/vcap/packages/golangapiserver/servicebroker.db.changelog.json | EXECUTED
 3  | qy           | 3.6.3     | /var/vcap/packages/golangapiserver/servicebroker.db.changelog.json | EXECUTED
 4  | silvestre    | 3.6.3     | /var/vcap/packages/golangapiserver/servicebroker.db.changelog.yaml | EXECUTED
 1  | Fujitsu      | 3.6.3     | /var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 2  | Fujitsu      | 3.6.3     | /var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 3  | Fujitsu      | 3.6.3     | /var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 4  | Fujitsu      | 3.6.3     | /var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 5  | qibobo       | 3.6.3     | /var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 6  | fujitsu      | 3.6.3     | /var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 7  | aqan213      | 3.6.3     | /var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 8  | aqan213      | 3.6.3     | /var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 1  | Fujitsu      | 3.6.3     | /var/vcap/packages/scheduler/db/quartz.changelog-master.yaml       | EXECUTED
 2  | aqan         | 3.6.3     | /var/vcap/packages/scheduler/db/quartz.changelog-master.yaml       | EXECUTED
 1  | byang        | 3.6.3     | /var/vcap/packages/metricsserver/metricscollector.db.changelog.yml | EXECUTED
 2  | paltanmoy    | 3.6.3     | /var/vcap/packages/metricsserver/metricscollector.db.changelog.yml | EXECUTED
 3  | byang        | 3.6.3     | /var/vcap/packages/metricsserver/metricscollector.db.changelog.yml | EXECUTED
 1  | qiyang       | 3.6.3     | /var/vcap/packages/eventgenerator/dataaggregator.db.changelog.yml  | EXECUTED
 2  | paltanmoy    | 3.6.3     | /var/vcap/packages/eventgenerator/dataaggregator.db.changelog.yml  | EXECUTED
 4  | byang        | 3.6.3     | /var/vcap/packages/eventgenerator/dataaggregator.db.changelog.yml  | EXECUTED
 1  | byang        | 3.6.3     | /var/vcap/packages/scalingengine/scalingengine.db.changelog.yml    | EXECUTED
 3  | byang        | 3.6.3     | /var/vcap/packages/scalingengine/scalingengine.db.changelog.yml    | EXECUTED
 4  | cdlliuy      | 3.6.3     | /var/vcap/packages/scalingengine/scalingengine.db.changelog.yml    | EXECUTED
 7  | aadeshmisra  | 3.6.3     | /var/vcap/packages/scalingengine/scalingengine.db.changelog.yml    | EXECUTED
 1  | cdlliuy      | 3.6.3     | /var/vcap/packages/operator/operator.db.changelog.yml              | MARK_RAN
 2  | cdlliuy      | 3.6.3     | /var/vcap/packages/operator/operator.db.changelog.yml              | EXECUTED
(29 rows)
```





**Liquibase 4.6.2 output**

On a fresh installation, the initial "/" in the filepath is dropped which is fine for upgrade but may cause issues in downgrade

```
 id |    author    | liquibase |                             filename                              | exectype
----+--------------+-----------+-------------------------------------------------------------------+----------
 1  | pradyutsarma | 4.6.2     | var/vcap/packages/golangapiserver/api.db.changelog.yml            | EXECUTED
 2  | fujitsu      | 4.6.2     | var/vcap/packages/golangapiserver/api.db.changelog.yml            | EXECUTED
 3  | paltanmoy    | 4.6.2     | var/vcap/packages/golangapiserver/api.db.changelog.yml            | EXECUTED
 1  | ying         | 4.6.2     | var/vcap/packages/golangapiserver/servicebroker.db.changelog.json | EXECUTED
 2  | qy           | 4.6.2     | var/vcap/packages/golangapiserver/servicebroker.db.changelog.json | EXECUTED
 3  | qy           | 4.6.2     | var/vcap/packages/golangapiserver/servicebroker.db.changelog.json | EXECUTED
 4  | silvestre    | 4.6.2     | var/vcap/packages/golangapiserver/servicebroker.db.changelog.yaml | EXECUTED
 1  | Fujitsu      | 4.6.2     | var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 2  | Fujitsu      | 4.6.2     | var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 3  | Fujitsu      | 4.6.2     | var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 4  | Fujitsu      | 4.6.2     | var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 5  | qibobo       | 4.6.2     | var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 6  | fujitsu      | 4.6.2     | var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 7  | aqan213      | 4.6.2     | var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 8  | aqan213      | 4.6.2     | var/vcap/packages/scheduler/db/scheduler.changelog-master.yaml    | EXECUTED
 1  | Fujitsu      | 4.6.2     | var/vcap/packages/scheduler/db/quartz.changelog-master.yaml       | EXECUTED
 2  | aqan         | 4.6.2     | var/vcap/packages/scheduler/db/quartz.changelog-master.yaml       | EXECUTED
 1  | byang        | 4.6.2     | var/vcap/packages/metricsserver/metricscollector.db.changelog.yml | EXECUTED
 2  | paltanmoy    | 4.6.2     | var/vcap/packages/metricsserver/metricscollector.db.changelog.yml | EXECUTED
 3  | byang        | 4.6.2     | var/vcap/packages/metricsserver/metricscollector.db.changelog.yml | EXECUTED
 1  | qiyang       | 4.6.2     | var/vcap/packages/eventgenerator/dataaggregator.db.changelog.yml  | EXECUTED
 2  | paltanmoy    | 4.6.2     | var/vcap/packages/eventgenerator/dataaggregator.db.changelog.yml  | EXECUTED
 4  | byang        | 4.6.2     | var/vcap/packages/eventgenerator/dataaggregator.db.changelog.yml  | EXECUTED
 1  | byang        | 4.6.2     | var/vcap/packages/scalingengine/scalingengine.db.changelog.yml    | EXECUTED
 3  | byang        | 4.6.2     | var/vcap/packages/scalingengine/scalingengine.db.changelog.yml    | EXECUTED
 4  | cdlliuy      | 4.6.2     | var/vcap/packages/scalingengine/scalingengine.db.changelog.yml    | EXECUTED
 7  | aadeshmisra  | 4.6.2     | var/vcap/packages/scalingengine/scalingengine.db.changelog.yml    | EXECUTED
 1  | cdlliuy      | 4.6.2     | var/vcap/packages/operator/operator.db.changelog.yml              | MARK_RAN
 2  | cdlliuy      | 4.6.2     | var/vcap/packages/operator/operator.db.changelog.yml              | EXECUTED
(29 rows)
```