### PR TITLE
Add support for v8 CF CLI.

### DIFF
--- a/src/acceptance/helpers/helpers.go
+++ b/src/acceptance/helpers/helpers.go
@@ -111,15 +111,7 @@ func DisableServiceAccess(cfg *config.Config, orgName string) {
 }
 
 func CheckServiceExists(cfg *config.Config) {
-	version := cf.Cf("version").Wait(cfg.DefaultTimeoutDuration())
-	Expect(version).To(Exit(0), "Could not determine cf version")
-
-	var serviceExists *Session
-	if strings.Contains(string(version.Out.Contents()), "version 7") {
-		serviceExists = cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
-	} else {
-		serviceExists = cf.Cf("marketplace", "-s", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
-	}
+	serviceExists := cf.Cf("marketplace", "-e", cfg.ServiceName).Wait(cfg.DefaultTimeoutDuration())
 
 	Expect(serviceExists).To(Exit(0), fmt.Sprintf("Service offering, %s, does not exist", cfg.ServiceName))
 }


### PR DESCRIPTION
Also drops support for v6 CLI, which is no longer supported with current CF deployments: https://github.com/cloudfoundry/cli/wiki/Versioning-and-Support-Policy