### PR TITLE
Multi CPU scaling policies

### DIFF
--- a/jobs/golangapiserver/spec
+++ b/jobs/golangapiserver/spec
@@ -148,6 +148,12 @@ properties:
   autoscaler.apiserver.metrics_forwarder.mtls_host:
     description: "Host where metricsforwarder mtls authentication route is available"
     default: ""
+  autoscaler.apiserver.scaling_rules.cpu.lower_threshold:
+    description: "Allowable lower threshold of the cpu scaling range"
+    default: 1
+  autoscaler.apiserver.scaling_rules.cpu.upper_threshold:
+    description: "Allowable upper threshold of the cpu scaling range"
+    default: 100
   autoscaler.policy_db.address:
     description: "IP address on which the policydb server will listen"
     default: "autoscalerpostgres.service.cf.internal"

--- a/jobs/golangapiserver/templates/apiserver.yml.erb
+++ b/jobs/golangapiserver/templates/apiserver.yml.erb
@@ -144,6 +144,11 @@ metrics_forwarder:
   metrics_forwarder_mtls_url: https://<%= p("autoscaler.apiserver.metrics_forwarder.mtls_host") %>
 <% end %>
 
+scaling_rules:
+  cpu:
+    lower_threshold: <%= p("autoscaler.apiserver.scaling_rules.cpu.lower_threshold") %>
+    upper_threshold: <%= p("autoscaler.apiserver.scaling_rules.cpu.upper_threshold") %>
+
 rate_limit:
   valid_duration: <%= p("autoscaler.apiserver.rate_limit.valid_duration") %>
   max_amount: <%= p("autoscaler.apiserver.rate_limit.max_amount") %>

--- a/src/acceptance/app/dynamic_policy_test.go
+++ b/src/acceptance/app/dynamic_policy_test.go
@@ -247,14 +247,13 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 	Context("when scaling by cpu", func() {
 
 		BeforeEach(func() {
-			policy = helpers.GenerateDynamicScaleOutAndInPolicy(1, 2, "cpu", 5, 10)
+			policy = helpers.GenerateDynamicScaleOutAndInPolicy(1, 2, "cpu", int64(float64(cfg.CPUUpperThreshold)*0.2), int64(float64(cfg.CPUUpperThreshold)*0.4))
 			initialInstanceCount = 1
 		})
 
 		It("when cpu is greater than scaling out threshold", func() {
-
 			By("should scale out to 2 instances")
-			helpers.AppSetCpuUsage(cfg, appName, 50, 5)
+			helpers.AppSetCpuUsage(cfg, appName, int(float64(cfg.CPUUpperThreshold)*0.9), 5)
 			helpers.WaitForNInstancesRunning(appGUID, 2, 5*time.Minute)
 
 			By("should scale in to 1 instance after cpu usage is reduced")

--- a/src/acceptance/assets/app/nodeApp/worker.js
+++ b/src/acceptance/assets/app/nodeApp/worker.js
@@ -1,0 +1,22 @@
+const { workerData } = require("worker_threads");
+var enableCpuTest = false;
+
+async function loadCPU(util, minute) {
+    var busyTime = 100;
+    var idleTime = busyTime * (100 - util) / util;
+    var msg = 'set app cpu utilization to ' + util + '% for ' + minute + ' minutes, busyTime=' + busyTime + ', idleTime=' + idleTime
+    console.log(msg);
+    var startTime = new Date().getTime();
+    var endTime = startTime + minute * 60 * 1000;
+    enableCpuTest = true;
+    while (enableCpuTest && startTime < endTime) {
+        startTime = new Date().getTime();
+        while (enableCpuTest && new Date().getTime() - startTime < busyTime) {
+            ;
+        }
+        await new Promise(done => setTimeout(done, idleTime));
+    }
+}
+
+loadCPU(workerData.util, workerData.minute)
+console.log('finish cpu test on worker');

--- a/src/acceptance/broker/broker_test.go
+++ b/src/acceptance/broker/broker_test.go
@@ -89,7 +89,7 @@ var _ = Describe("AutoScaler Service Broker", func() {
 		Expect(deleteService).To(Exit(0))
 	})
 
-	It("should update service instance from  autoscaler-free-plan to acceptance-standard", func() {
+	It("should update service instance from autoscaler-free-plan to acceptance-standard", func() {
 		plans := getPlans()
 		if plans.length() < 2 {
 			Skip(fmt.Sprintf("2 plans needed, only one plan available plans:%+v", plans))

--- a/src/acceptance/config/config.go
+++ b/src/acceptance/config/config.go
@@ -64,6 +64,8 @@ type Config struct {
 	EnableServiceAccess    bool   `json:"enable_service_access"`
 
 	HealthEndpointsBasicAuthEnabled bool `json:"health_endpoints_basic_auth_enabled"`
+
+	CPUUpperThreshold int64 `json:"cpu_upper_threshold"`
 }
 
 var defaults = Config{
@@ -91,6 +93,7 @@ var defaults = Config{
 	ServiceOfferingEnabled:          true,
 	EnableServiceAccess:             true,
 	HealthEndpointsBasicAuthEnabled: true,
+	CPUUpperThreshold:               100,
 }
 
 func LoadConfig(t *testing.T) *Config {

--- a/src/autoscaler/api/brokerserver/broker_handler.go
+++ b/src/autoscaler/api/brokerserver/broker_handler.go
@@ -56,7 +56,7 @@ func NewBrokerHandler(logger lager.Logger, conf *config.Config, bindingdb db.Bin
 		bindingdb:             bindingdb,
 		policydb:              policydb,
 		catalog:               catalog,
-		policyValidator:       policyvalidator.NewPolicyValidator(conf.PolicySchemaPath),
+		policyValidator:       policyvalidator.NewPolicyValidator(conf.PolicySchemaPath, conf.ScalingRules.CPU.LowerThreshold, conf.ScalingRules.CPU.UpperThreshold),
 		schedulerUtil:         schedulerutil.NewSchedulerUtil(conf, logger),
 		quotaManagementClient: quota.NewClient(conf, logger, cfClient),
 		planChecker:           plancheck.NewPlanChecker(conf.PlanCheck, logger),

--- a/src/autoscaler/api/policyvalidator/policy_validator.go
+++ b/src/autoscaler/api/policyvalidator/policy_validator.go
@@ -16,7 +16,17 @@ const (
 	TimeLayout     = "15:04"
 )
 
+type ScalingRulesConfig struct {
+	CPU CPUConfig
+}
+
+type CPUConfig struct {
+	LowerThreshold int
+	UpperThreshold int
+}
+
 type PolicyValidator struct {
+	scalingRules       ScalingRulesConfig
 	policySchemaPath   string
 	policySchemaLoader gojsonschema.JSONLoader
 }
@@ -59,9 +69,15 @@ func newPolicyValidationError(context *gojsonschema.JsonContext, formatString st
 	return &err
 }
 
-func NewPolicyValidator(policySchemaPath string) *PolicyValidator {
+func NewPolicyValidator(policySchemaPath string, lowerThreshold int, upperThreshold int) *PolicyValidator {
 	policyValidator := &PolicyValidator{
 		policySchemaPath: policySchemaPath,
+		scalingRules: ScalingRulesConfig{
+			CPU: CPUConfig{
+				LowerThreshold: lowerThreshold,
+				UpperThreshold: upperThreshold,
+			},
+		},
 	}
 	policyValidator.policySchemaLoader = gojsonschema.NewReferenceLoader("file://" + policyValidator.policySchemaPath)
 	return policyValidator
@@ -159,8 +175,8 @@ func (pv *PolicyValidator) validateScalingRuleThreshold(policy *models.ScalingPo
 				result.AddError(err, errDetails)
 			}
 		case "cpu":
-			if scalingRule.Threshold <= 0 || scalingRule.Threshold > 100 {
-				formatString := "scaling_rules[{{.scalingRuleIndex}}].threshold for metric_type cpu should be greater than 0 and less than equal to 100"
+			if scalingRule.Threshold < int64(pv.scalingRules.CPU.LowerThreshold) || scalingRule.Threshold >= int64(pv.scalingRules.CPU.UpperThreshold) {
+				formatString := fmt.Sprintf("scaling_rules[{{.scalingRuleIndex}}].threshold for metric_type cpu should be greater than %d and less than or equal to %d", pv.scalingRules.CPU.LowerThreshold, pv.scalingRules.CPU.UpperThreshold)
 				err := newPolicyValidationError(currentContext, formatString, errDetails)
 				result.AddError(err, errDetails)
 			}

--- a/src/autoscaler/api/policyvalidator/policy_validator_test.go
+++ b/src/autoscaler/api/policyvalidator/policy_validator_test.go
@@ -12,13 +12,17 @@ import (
 
 var _ = Describe("PolicyValidator", func() {
 	var (
-		policyValidator *PolicyValidator
-		errResult       *[]PolicyValidationErrors
-		valid           bool
-		policyString    string
+		policyValidator   *PolicyValidator
+		errResult         *[]PolicyValidationErrors
+		valid             bool
+		policyString      string
+		lowerCPUThreshold int
+		upperCPUThreshold int
 	)
 	BeforeEach(func() {
-		policyValidator = NewPolicyValidator("./policy_json.schema.json")
+		lowerCPUThreshold = 0
+		upperCPUThreshold = 333
+		policyValidator = NewPolicyValidator("./policy_json.schema.json", lowerCPUThreshold, upperCPUThreshold)
 	})
 	JustBeforeEach(func() {
 		errResult, valid = policyValidator.ValidatePolicy(policyString)
@@ -513,7 +517,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 			})
 
-			Context("when threshold for cpu is less than 0", func() {
+			Context(fmt.Sprintf("when threshold for cpu is less than %d", lowerCPUThreshold), func() {
 				BeforeEach(func() {
 					policyString = `{
 					"instance_max_count":4,
@@ -534,13 +538,13 @@ var _ = Describe("PolicyValidator", func() {
 					Expect(errResult).To(Equal(&[]PolicyValidationErrors{
 						{
 							Context:     "(root).scaling_rules.0",
-							Description: "scaling_rules[0].threshold for metric_type cpu should be greater than 0 and less than equal to 100",
+							Description: fmt.Sprintf("scaling_rules[0].threshold for metric_type cpu should be greater than %d and less than or equal to %d", lowerCPUThreshold, upperCPUThreshold),
 						},
 					}))
 				})
 			})
 
-			Context("when threshold for cpu is greater than 100", func() {
+			Context(fmt.Sprintf("when threshold for cpu is greater than %d", upperCPUThreshold), func() {
 				BeforeEach(func() {
 					policyString = `{
 					"instance_max_count":4,
@@ -561,7 +565,7 @@ var _ = Describe("PolicyValidator", func() {
 					Expect(errResult).To(Equal(&[]PolicyValidationErrors{
 						{
 							Context:     "(root).scaling_rules.0",
-							Description: "scaling_rules[0].threshold for metric_type cpu should be greater than 0 and less than equal to 100",
+							Description: fmt.Sprintf("scaling_rules[0].threshold for metric_type cpu should be greater than %d and less than or equal to %d", lowerCPUThreshold, upperCPUThreshold),
 						},
 					}))
 				})

--- a/src/autoscaler/api/publicapiserver/public_api_handler.go
+++ b/src/autoscaler/api/publicapiserver/public_api_handler.go
@@ -64,7 +64,7 @@ func NewPublicApiHandler(logger lager.Logger, conf *config.Config, policydb db.P
 		scalingEngineClient:    seClient,
 		metricsCollectorClient: mcClient,
 		eventGeneratorClient:   egClient,
-		policyValidator:        policyvalidator.NewPolicyValidator(conf.PolicySchemaPath),
+		policyValidator:        policyvalidator.NewPolicyValidator(conf.PolicySchemaPath, conf.ScalingRules.CPU.LowerThreshold, conf.ScalingRules.CPU.UpperThreshold),
 		schedulerUtil:          schedulerutil.NewSchedulerUtil(conf, logger),
 		credentials:            credentials,
 	}


### PR DESCRIPTION
This change allows CPU threshold to be set in a more flexible way.
So far the threshold was hardcoded to 100% but now it's possible to provide values in the deployment manifest.
This is very useful if diego VMs have more than one CPU core and you want your app to scale when CPU usage is reported as more than 100%

In the nodejs app, multiple workers are now spun up to utilise multiple CPU
threads when trying to achieve a load of more than 100% CPU.
It is now possible to configure the tests to check that an app is able to scale up if CPU usage exceeds
an upper CPU threshold of over 100%.

We left the default at 100 so there is no change for and users who do not use this setting. 