### PR TITLE
CVE-2022-22965: Update to Spring Framework 5.3.18

### DIFF
--- a/src/scheduler/pom.xml
+++ b/src/scheduler/pom.xml
@@ -19,6 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <io.prometheus.simpleclient.version>0.15.0</io.prometheus.simpleclient.version>
+        <spring-framework.version>5.3.18</spring-framework.version> <!-- CVE-2022-22965, see https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#status -->
     </properties>
 
     <dependencies>


### PR DESCRIPTION
see https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#status