### PR TITLE
Schedule Dependabot update more often

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,35 +5,46 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-
+      interval: "daily"
+      time: "08:00"
+      timezone: "Europe/Berlin"
 
   # The root pom
   - package-ecosystem: "maven"
     directory: "/src/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "08:00"
+      timezone: "Europe/Berlin"
 
   # Gomod updates
   - package-ecosystem: "gomod"
     directory: "/src/acceptance/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "08:00"
+      timezone: "Europe/Berlin"
 
   # Gomod updates
   - package-ecosystem: "gomod"
     directory: "/src/autoscaler/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "08:00"
+      timezone: "Europe/Berlin"
 
   # Gomod updates
   - package-ecosystem: "gomod"
     directory: "/src/changelog/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "08:00"
+      timezone: "Europe/Berlin"
 
   # Gomod updates
   - package-ecosystem: "gomod"
     directory: "/src/changeloglockcleaner/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "08:00"
+      timezone: "Europe/Berlin"


### PR DESCRIPTION
`daily` means weekdays, see the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval)
