### PR TITLE
Ignore extra fields in policies

### DIFF
--- a/src/acceptance/api/api_test.go
+++ b/src/acceptance/api/api_test.go
@@ -97,6 +97,14 @@ var _ = Describe("AutoScaler Public API", func() {
 			Expect(string(newPolicy)).Should(MatchJSON(policy))
 		})
 
+		It("should succeed to create a valid policy but remove any extra fields", func() {
+			policyWithExtraFields, validPolicy := GenerateDynamicScaleOutPolicyWithExtraFields(1, 2, "memoryused", 30)
+			newPolicy, status := createPolicy(policyWithExtraFields)
+			Expect(status).To(Or(Equal(200), Equal(201)))
+			Expect(string(newPolicy)).ShouldNot(MatchJSON(policyWithExtraFields))
+			Expect(string(newPolicy)).Should(MatchJSON(validPolicy))
+		})
+
 		It("should fail to create an invalid policy", func() {
 			response, status := createPolicy(GenerateDynamicScaleOutPolicy(0, 2, "memoryused", 30))
 			Expect(status).To(Equal(400))
@@ -130,6 +138,14 @@ var _ = Describe("AutoScaler Public API", func() {
 			newPolicy, status := createPolicy(GenerateDynamicScaleOutPolicy(1, 2, "memoryused", memThreshold))
 			Expect(status).To(Equal(200))
 			Expect(string(newPolicy)).Should(MatchJSON(policy))
+		})
+
+		It("should succeed to update a valid policy but remove any extra fields", func() {
+			policyWithExtraFields, validPolicy := GenerateDynamicScaleOutPolicyWithExtraFields(1, 2, "memoryused", memThreshold)
+			newPolicy, status := createPolicy(policyWithExtraFields)
+			Expect(status).To(Or(Equal(200), Equal(201)))
+			Expect(string(newPolicy)).ShouldNot(MatchJSON(policyWithExtraFields))
+			Expect(string(newPolicy)).Should(MatchJSON(validPolicy))
 		})
 
 		It("should fail to update an invalid policy", func() {

--- a/src/autoscaler/api/brokerserver/broker_handler.go
+++ b/src/autoscaler/api/brokerserver/broker_handler.go
@@ -122,13 +122,13 @@ func (h *BrokerHandler) CreateServiceInstance(w http.ResponseWriter, r *http.Req
 	}
 	policyGuidStr := ""
 	if policyStr != "" {
-		errResults, valid, validatedPolicyStr := h.policyValidator.ValidatePolicy(policyStr)
+		errResults, valid, validatedPolicy := h.policyValidator.ValidatePolicy(policyStr)
 		if !valid {
 			h.logger.Error("failed to validate policy", err, lager.Data{"instanceId": instanceId, "policy": policyStr})
 			handlers.WriteJSONResponse(w, http.StatusBadRequest, errResults)
 			return
 		}
-		policyStr = validatedPolicyStr
+		policyStr = validatedPolicy
 
 		if h.planDefinitionExceeded(policyStr, body.PlanID, instanceId, w) {
 			return
@@ -323,13 +323,13 @@ func (h *BrokerHandler) UpdateServiceInstance(w http.ResponseWriter, r *http.Req
 	h.logger.Info("update-service-instance", lager.Data{"instanceId": instanceId, "serviceId": body.ServiceID, "planId": body.PlanID, "updatedDefaultPolicy": updatedDefaultPolicy})
 
 	if updatedDefaultPolicy != "" && updatedDefaultPolicyGuid == "" {
-		errResults, valid, validatedPolicyStr := h.policyValidator.ValidatePolicy(updatedDefaultPolicy)
+		errResults, valid, validatedPolicy := h.policyValidator.ValidatePolicy(updatedDefaultPolicy)
 		if !valid {
 			h.logger.Error("failed to validate policy", err, lager.Data{"instanceId": instanceId, "policy": updatedDefaultPolicy})
 			handlers.WriteJSONResponse(w, http.StatusBadRequest, errResults)
 			return
 		}
-		updatedDefaultPolicy = validatedPolicyStr
+		updatedDefaultPolicy = validatedPolicy
 
 		servicePlan, err := h.cfClient.GetServicePlan(instanceId)
 		if err != nil {

--- a/src/autoscaler/api/brokerserver/broker_handler.go
+++ b/src/autoscaler/api/brokerserver/broker_handler.go
@@ -122,12 +122,13 @@ func (h *BrokerHandler) CreateServiceInstance(w http.ResponseWriter, r *http.Req
 	}
 	policyGuidStr := ""
 	if policyStr != "" {
-		errResults, valid := h.policyValidator.ValidatePolicy(policyStr)
+		errResults, valid, validatedPolicyStr := h.policyValidator.ValidatePolicy(policyStr)
 		if !valid {
 			h.logger.Error("failed to validate policy", err, lager.Data{"instanceId": instanceId, "policy": policyStr})
 			handlers.WriteJSONResponse(w, http.StatusBadRequest, errResults)
 			return
 		}
+		policyStr = validatedPolicyStr
 
 		if h.planDefinitionExceeded(policyStr, body.PlanID, instanceId, w) {
 			return
@@ -322,12 +323,13 @@ func (h *BrokerHandler) UpdateServiceInstance(w http.ResponseWriter, r *http.Req
 	h.logger.Info("update-service-instance", lager.Data{"instanceId": instanceId, "serviceId": body.ServiceID, "planId": body.PlanID, "updatedDefaultPolicy": updatedDefaultPolicy})
 
 	if updatedDefaultPolicy != "" && updatedDefaultPolicyGuid == "" {
-		errResults, valid := h.policyValidator.ValidatePolicy(updatedDefaultPolicy)
+		errResults, valid, validatedPolicyStr := h.policyValidator.ValidatePolicy(updatedDefaultPolicy)
 		if !valid {
 			h.logger.Error("failed to validate policy", err, lager.Data{"instanceId": instanceId, "policy": updatedDefaultPolicy})
 			handlers.WriteJSONResponse(w, http.StatusBadRequest, errResults)
 			return
 		}
+		updatedDefaultPolicy = validatedPolicyStr
 
 		servicePlan, err := h.cfClient.GetServicePlan(instanceId)
 		if err != nil {
@@ -525,12 +527,13 @@ func (h *BrokerHandler) BindServiceInstance(w http.ResponseWriter, r *http.Reque
 
 	policyStr := string(body.Policy)
 	if policyStr != "" {
-		errResults, valid := h.policyValidator.ValidatePolicy(policyStr)
+		errResults, valid, validatedPolicyStr := h.policyValidator.ValidatePolicy(policyStr)
 		if !valid {
 			h.logger.Error("failed to validate policy", err, lager.Data{"appId": body.AppID, "policy": policyStr})
 			handlers.WriteJSONResponse(w, http.StatusBadRequest, errResults)
 			return
 		}
+		policyStr = validatedPolicyStr
 
 		if h.planDefinitionExceeded(policyStr, body.PlanID, instanceId, w) {
 			return

--- a/src/autoscaler/api/policyvalidator/policy_validator_test.go
+++ b/src/autoscaler/api/policyvalidator/policy_validator_test.go
@@ -12,12 +12,13 @@ import (
 
 var _ = Describe("PolicyValidator", func() {
 	var (
-		policyValidator   *PolicyValidator
-		errResult         *[]PolicyValidationErrors
-		valid             bool
-		policyString      string
-		lowerCPUThreshold int
-		upperCPUThreshold int
+		policyValidator       *PolicyValidator
+		errResult             *[]PolicyValidationErrors
+		valid                 bool
+		policyString          string
+		validatedPolicyString string
+		lowerCPUThreshold     int
+		upperCPUThreshold     int
 	)
 	BeforeEach(func() {
 		lowerCPUThreshold = 0
@@ -25,7 +26,7 @@ var _ = Describe("PolicyValidator", func() {
 		policyValidator = NewPolicyValidator("./policy_json.schema.json", lowerCPUThreshold, upperCPUThreshold)
 	})
 	JustBeforeEach(func() {
-		errResult, valid = policyValidator.ValidatePolicy(policyString)
+		errResult, valid, validatedPolicyString = policyValidator.ValidatePolicy(policyString)
 	})
 	Context("Policy Schema &  Validation", func() {
 		Context("when invalid json", func() {
@@ -182,6 +183,46 @@ var _ = Describe("PolicyValidator", func() {
 			})
 			It("should succeed", func() {
 				Expect(valid).To(BeTrue())
+				Expect(validatedPolicyString).To(MatchJSON(policyString))
+			})
+		})
+
+		Context("when additional fields are present", func() {
+			BeforeEach(func() {
+				policyString = `{
+					"instance_max_count":4,
+					"instance_min_count":1,
+					"scaling_rules":[
+					{
+						"metric_type":"memoryutil",
+						"stats_window_secs": 600,
+						"breach_duration_secs":600,
+						"threshold":90,
+						"operator":">=",
+						"cool_down_secs":300,
+						"adjustment":"+1"
+					}],
+					"is_admin": true,
+					"is_sso": true,
+					"role": "admin"
+				}`
+			})
+			It("the validation succeed and remove them", func() {
+				Expect(valid).To(BeTrue())
+				validPolicyString := `{
+					"instance_max_count":4,
+					"instance_min_count":1,
+					"scaling_rules":[
+					{
+						"metric_type":"memoryutil",
+						"breach_duration_secs":600,
+						"threshold":90,
+						"operator":">=",
+						"cool_down_secs":300,
+						"adjustment":"+1"
+					}]
+				}`
+				Expect(validatedPolicyString).To(MatchJSON(validPolicyString))
 			})
 		})
 
@@ -364,6 +405,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -466,6 +508,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -514,6 +557,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -702,6 +746,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -730,6 +775,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -750,6 +796,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -851,6 +898,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -1020,6 +1068,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -1087,6 +1136,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 				Context("when only end_date is present", func() {
@@ -1117,6 +1167,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 				Context("when only start_date is present and is same as current date", func() {
@@ -1149,6 +1200,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 				Context("when only end_date is present and is same as current date", func() {
@@ -1181,6 +1233,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 				Context("when start_date is after end_date", func() {
@@ -1351,6 +1404,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 				Context("when instance_min_count is greater than instance_max_count", func() {
@@ -1582,6 +1636,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 				Context("when overlapping time range in overlapping days_of_week in non-overlapping date range", func() {
@@ -1627,6 +1682,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 				Context("when overlapping time range in overlapping days_of_week in overlapping date range", func() {
@@ -1865,6 +1921,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 
@@ -1909,6 +1966,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 
@@ -1985,6 +2043,7 @@ var _ = Describe("PolicyValidator", func() {
 				})
 				It("should succeed", func() {
 					Expect(valid).To(BeTrue())
+					Expect(validatedPolicyString).To(MatchJSON(policyString))
 				})
 			})
 
@@ -2184,6 +2243,7 @@ var _ = Describe("PolicyValidator", func() {
 					})
 					It("should succeed", func() {
 						Expect(valid).To(BeTrue())
+						Expect(validatedPolicyString).To(MatchJSON(policyString))
 					})
 				})
 
@@ -2482,6 +2542,7 @@ var _ = Describe("PolicyValidator", func() {
 		})
 		It("It should succeed", func() {
 			Expect(valid).To(BeTrue())
+			Expect(validatedPolicyString).To(MatchJSON(policyString))
 		})
 	})
 })

--- a/src/autoscaler/api/publicapiserver/public_api_handler.go
+++ b/src/autoscaler/api/publicapiserver/public_api_handler.go
@@ -136,12 +136,13 @@ func (h *PublicApiHandler) AttachScalingPolicy(w http.ResponseWriter, r *http.Re
 
 	policyStr := string(policyBytes)
 
-	errResults, valid := h.policyValidator.ValidatePolicy(policyStr)
+	errResults, valid, validatedPolicyStr := h.policyValidator.ValidatePolicy(policyStr)
 	if !valid {
 		h.logger.Error("Failed to validate policy", nil, lager.Data{"errResults": errResults})
 		handlers.WriteJSONResponse(w, http.StatusBadRequest, errResults)
 		return
 	}
+	policyStr = validatedPolicyStr
 
 	policyGuid, err := uuid.NewV4()
 	if err != nil {

--- a/src/autoscaler/api/publicapiserver/public_api_handler_test.go
+++ b/src/autoscaler/api/publicapiserver/public_api_handler_test.go
@@ -54,6 +54,31 @@ var _ = Describe("PublicApiHandler", func() {
 				}]
 			}
 		}`
+		VALID_POLICY_STR_WITH_EXTRA_FIELDS = `{
+			"instance_min_count": 1,
+			"instance_max_count": 5,
+			"scaling_rules": [{
+				"metric_type": "memoryused",
+				"breach_duration_secs": 300,
+				"stats_window_secs": 666,
+				"threshold": 30,
+				"operator": ">",
+				"cool_down_secs": 300,
+				"adjustment": "-1"
+			}],
+			"schedules": {
+				"timezone": "Asia/Kolkata",
+				"recurring_schedule": [{
+					"start_time": "10:00",
+					"end_time": "18:00",
+					"days_of_week": [1, 2, 3],
+					"instance_min_count": 1,
+					"instance_max_count": 10,
+					"initial_min_instance_count": 5
+				}]
+			},
+			"is_admin": true
+		}`
 	)
 	var (
 		policydb      *fakes.FakePolicyDB
@@ -223,6 +248,18 @@ var _ = Describe("PublicApiHandler", func() {
 			})
 			It("should succeed", func() {
 				Expect(resp.Code).To(Equal(http.StatusOK))
+			})
+		})
+
+		Context("When providing extra fields", func() {
+			BeforeEach(func() {
+				pathVariables["appId"] = TEST_APP_ID
+				req, _ = http.NewRequest(http.MethodPut, "", bytes.NewBufferString(VALID_POLICY_STR_WITH_EXTRA_FIELDS))
+				schedulerStatus = 200
+			})
+			It("should succeed and ignore the extra fields", func() {
+				Expect(resp.Code).To(Equal(http.StatusOK))
+				Expect(resp.Body).To(MatchJSON(VALID_POLICY_STR))
 			})
 		})
 


### PR DESCRIPTION
Extra fields in a policy should be silently ignored for backwards
compatibility, but never persisted or returned.

Closes #550 