### PR TITLE
Id error handling fixes and creating traceable test id's

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ data store. These are run up locally with docker images so ensure that docker is
 your system before running up the tests.
 
 ### Setup
+**Note:** all of the setup is encapsulated in the makefile targets. So you can run the test targets (test|integration) directly
+and it will setup and start the tests.
 
 To set up the development, firstly clone this project
 
@@ -248,6 +250,7 @@ Generate [scheduler test certs](https://github.com/cloudfoundry/app-autoscaler/b
 
 
 #### Initialize the Database
+**Note:** The makefile will init the database if it has not already been run before running the tests. 
 
 * **Postgres**
 ```shell
@@ -263,35 +266,77 @@ make init-db db_type=mysql
 #### Generate TLS Certificates
 create the certificates
 
-**Note**: on macos it will install `certstrap` automatically but on other OS's it needs to be pre-installed
+**Note**: 
+ - on macos it will install `certstrap` automatically but on other OS's it needs to be pre-installed
+ - The makefile will create the certificates if it has not already been run before running the tests.
 ```shell
 make test-certs
 ```
 
-
 ### Unit tests
+The default database is postgres
 
 * **Postgres**:
 ```shell
 make test
 ```
 
+To use a specific postgres version
+```shell
+make clean #Only if you're changing versions to refresh the running docker image.
+make test POSTGRES_TAG=x.y
+```
+where: 
+ - x is the major version
+ - y is the minor version ( this can be left out to get the most recent patch)
+
+
 * **MySQL**:
 ```shell
 make test db_type=mysql
 ```
 
-### Integration tests
+To use a specific MySQL version
+```shell
+make clean #Only if you're changing versions to refresh the running docker image.
+make test db_type=mysql MYSQL_TAG=x.y
+```
+where:
+- x is the major version
+- y is the minor version ( this can be left out to get the most recent patch)
 
-**Postgres**
+
+### Integration tests
+The default database is postgres
+
+* **Postgres**:
 ```shell
 make integration
 ```
 
-**MySQL**:
+To use a specific postgres version
 ```shell
-make test db_type=mysql
+make clean #Only if you're changing versions to refresh the running docker image.
+make integration POSTGRES_TAG=x.y
 ```
+where:
+- x is the major version
+- y is the minor version ( this can be left out to get the most recent patch)
+
+
+* **MySQL**:
+```shell
+make integration db_type=mysql
+```
+
+To use a specific MySQL version
+```shell
+make clean #Only if you're changing versions to refresh the running docker image.
+make integration db_type=mysql MYSQL_TAG=x.y
+```
+where:
+- x is the major version
+- y is the minor version ( this can be left out to get the most recent patch)
 
 ### Build App-AutoScaler
 ```shell

--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -9,7 +9,7 @@ export GO111MODULE=on
 #TODO: https://github.com/cloudfoundry/app-autoscaler-release/issues/564 allow the tests to be run in parallel
 #GINKGO_OPTS=-r --race --require-suite -p --randomize-all --cover
 
-GINKGO_OPTS=-r --race --require-suite --randomize-all --cover
+GINKGO_OPTS=-r --race --require-suite --randomize-all --cover ${OPTS}
 
 build-%:
 	@echo "# building $*"
@@ -64,7 +64,7 @@ testsuite: ginkgo_check
 .PHONY: integration
 integration: ginkgo_check
 	@echo "# Running integration tests"
-	@APP_AUTOSCALER_TEST_RUN=true ginkgo ${GINKGO_OPTS}  integration
+	APP_AUTOSCALER_TEST_RUN=true ginkgo ${GINKGO_OPTS} integration
 
 generate:
 	@echo "# Generating counterfeits"
@@ -102,4 +102,3 @@ clean:
 	@echo "# cleaning autoscaler"
 	@go clean -cache -testcache
 	@rm -rf build
-

--- a/src/autoscaler/api/brokerserver/broker_server_suite_test.go
+++ b/src/autoscaler/api/brokerserver/broker_server_suite_test.go
@@ -149,7 +149,11 @@ var _ = BeforeSuite(func() {
 	catalogBytes, err = ioutil.ReadFile("../exampleconfig/catalog-example.json")
 	Expect(err).NotTo(HaveOccurred())
 
-	urlPath, _ := routes.SchedulerRoutes().Get(routes.UpdateScheduleRouteName).URLPath("appId", testAppId)
+	urlPath, err := routes.SchedulerRoutes().Get(routes.UpdateScheduleRouteName).URLPath("appId", testAppId)
+	if err != nil {
+		Fail(err.Error())
+	}
+
 	schedulerServer.RouteToHandler("PUT", urlPath.String(), ghttp.RespondWith(http.StatusOK, nil))
 	schedulerServer.RouteToHandler("DELETE", urlPath.String(), ghttp.RespondWith(http.StatusOK, nil))
 })

--- a/src/autoscaler/api/schedulerutil/schedulerutil.go
+++ b/src/autoscaler/api/schedulerutil/schedulerutil.go
@@ -77,7 +77,10 @@ func (su *SchedulerUtil) CreateOrUpdateSchedule(appId string, policyJSONStr stri
 
 func (su *SchedulerUtil) DeleteSchedule(appId string) error {
 	var url string
-	path, _ := routes.SchedulerRoutes().Get(routes.DeleteScheduleRouteName).URLPath("appId", appId)
+	path, err := routes.SchedulerRoutes().Get(routes.DeleteScheduleRouteName).URLPath("appId", appId)
+	if err != nil {
+		return fmt.Errorf("deleteScheduleRouteName could not make url: %w", err)
+	}
 
 	url = su.schedulerUrl + path.RequestURI()
 

--- a/src/autoscaler/eventgenerator/generator/evaluator.go
+++ b/src/autoscaler/eventgenerator/generator/evaluator.go
@@ -193,6 +193,10 @@ func (e *Evaluator) sendTriggerAlarm(trigger *models.Trigger) error {
 	}
 
 	path, _ := routes.ScalingEngineRoutes().Get(routes.ScaleRouteName).URLPath("appid", trigger.AppId)
+	if err != nil {
+		return fmt.Errorf("failed to create url ScaleRouteName, %s: %w", trigger.AppId, err)
+	}
+
 	resp, err := e.httpClient.Post(e.scalingEngineUrl+path.Path, "application/json", bytes.NewReader(jsonBytes))
 	if err != nil {
 		e.logger.Error("failed-send-trigger-alarm-request", err, lager.Data{"trigger": trigger})

--- a/src/autoscaler/integration/integration_golangapi_eventgenerator_test.go
+++ b/src/autoscaler/integration/integration_golangapi_eventgenerator_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Integration_GolangApi_EventGenerator", func() {
 			true,
 			tmpDir)
 		startGolangApiServer()
-		appId = getRandomId()
+		appId = getRandomIdRef("appId")
 		pathVariables = []string{appId, metricType}
 
 	})
@@ -169,7 +169,7 @@ var _ = Describe("Integration_GolangApi_EventGenerator", func() {
 				metric.Timestamp = 444444
 				insertAppMetric(metric)
 				//add some  other appId
-				metric.AppId = getRandomId()
+				metric.AppId = getRandomIdRef("metric.appId")
 				metric.MetricType = models.MetricNameMemoryUsed
 				metric.Unit = models.UnitMegaBytes
 				metric.Timestamp = 444444

--- a/src/autoscaler/integration/integration_golangapi_metricsserver_test.go
+++ b/src/autoscaler/integration/integration_golangapi_metricsserver_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Integration_GolangApi_MetricsServer", func() {
 			true,
 			tmpDir)
 		startGolangApiServer()
-		appId = getRandomId()
+		appId = getRandomIdRef("appId")
 		pathVariables = []string{appId, metricType}
 
 	})
@@ -187,7 +187,7 @@ var _ = Describe("Integration_GolangApi_MetricsServer", func() {
 				metric.InstanceIndex = 1
 				insertAppInstanceMetric(metric)
 				//add some  other appId
-				metric.AppId = getRandomId()
+				metric.AppId = getRandomIdRef("metric.appId")
 				metric.Name = models.MetricNameMemoryUsed
 				metric.Unit = models.UnitMegaBytes
 				metric.Timestamp = 444444

--- a/src/autoscaler/integration/integration_golangapi_scalingengine_test.go
+++ b/src/autoscaler/integration/integration_golangapi_scalingengine_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Integration_GolangApi_ScalingEngine", func() {
 			true,
 			tmpDir)
 		startGolangApiServer()
-		appId = getRandomId()
+		appId = getRandomIdRef("appId")
 		pathVariables = []string{appId}
 
 	})
@@ -166,7 +166,7 @@ var _ = Describe("Integration_GolangApi_ScalingEngine", func() {
 				insertScalingHistory(&history5)
 
 				//add some other app id
-				history6 := createScalingHistory(getRandomId(), 444444)
+				history6 := createScalingHistory(getRandomIdRef("history6"), 444444)
 				insertScalingHistory(&history6)
 			})
 			It("should get the scaling histories ", func() {

--- a/src/autoscaler/integration/integration_golangapi_scheduler_test.go
+++ b/src/autoscaler/integration/integration_golangapi_scheduler_test.go
@@ -37,15 +37,15 @@ var _ = Describe("Integration_GolangApi_Scheduler", func() {
 		schedulerConfPath = components.PrepareSchedulerConfig(dbUrl, fmt.Sprintf("https://127.0.0.1:%d", components.Ports[ScalingEngine]), tmpDir, defaultHttpClientTimeout)
 		startScheduler()
 
-		serviceInstanceId = getRandomId()
-		orgId = getRandomId()
-		spaceId = getRandomId()
-		bindingId = getRandomId()
-		binding2Id = getRandomId()
-		binding3Id = getRandomId()
-		appId = getRandomId()
-		app2Id = getRandomId()
-		app3Id = getRandomId()
+		serviceInstanceId = getRandomIdRef("serviceInstanceId")
+		orgId = getRandomIdRef("orgId")
+		spaceId = getRandomIdRef("spaceId")
+		bindingId = getRandomIdRef("bindingId")
+		binding2Id = getRandomIdRef("binding2Id")
+		binding3Id = getRandomIdRef("binding3Id")
+		appId = getRandomIdRef("appId")
+		app2Id = getRandomIdRef("app2Id")
+		app3Id = getRandomIdRef("app3Id")
 		brokerAuth = base64.StdEncoding.EncodeToString([]byte("broker_username:broker_password"))
 	})
 
@@ -434,7 +434,7 @@ var _ = Describe("Integration_GolangApi_Scheduler", func() {
 							BeforeEach(func() {
 								newDefaultPolicy = []byte("{\t\n}\r\n")
 							})
-							It("is reflected in the apps' policies and schedules", func() {
+							It("is reflected in the apps policies and schedules", func() {
 								checkApiServerStatus(appId, http.StatusNotFound, components.Ports[GolangAPIServer], httpClientForPublicApi)
 								checkSchedulerStatus(appId, http.StatusNotFound)
 								checkApiServerContent(app2Id, secondPolicy, http.StatusOK, components.Ports[GolangAPIServer], httpClientForPublicApi)

--- a/src/autoscaler/integration/integration_golangapi_scheduler_test.go
+++ b/src/autoscaler/integration/integration_golangapi_scheduler_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Integration_GolangApi_Scheduler", func() {
 		schedulerConfPath = components.PrepareSchedulerConfig(dbUrl, fmt.Sprintf("https://127.0.0.1:%d", components.Ports[ScalingEngine]), tmpDir, defaultHttpClientTimeout)
 		startScheduler()
 
-		serviceInstanceId = getRandomIdRef("serviceInstanceId")
+		serviceInstanceId = getRandomIdRef("serviceInstId")
 		orgId = getRandomIdRef("orgId")
 		spaceId = getRandomIdRef("spaceId")
 		bindingId = getRandomIdRef("bindingId")

--- a/src/autoscaler/integration/integration_metricsgateway_metricserver_eventgenerator_scalingengine_test.go
+++ b/src/autoscaler/integration/integration_metricsgateway_metricserver_eventgenerator_scalingengine_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Integration_Metricsgateway_Metricserver_Eventgenerator_Scaling
 		fakeRLPEmitInterval = 500 * time.Millisecond
 	)
 	BeforeEach(func() {
-		testAppId = getRandomId()
+		testAppId = getRandomIdRef("testAppId")
 		startFakeCCNOAAUAA(initInstanceCount)
 	})
 

--- a/src/autoscaler/integration/integration_operator_others_test.go
+++ b/src/autoscaler/integration/integration_operator_others_test.go
@@ -20,11 +20,10 @@ var _ = Describe("Integration_Operator_Others", func() {
 	)
 
 	BeforeEach(func() {
-		startFakeCCNOAAUAA(initInstanceCount)
 		initializeHttpClient("api.crt", "api.key", "autoscaler-ca.crt", apiSchedulerHttpRequestTimeout)
 
-		testAppId = getRandomId()
-		testGuid = getRandomId()
+		testAppId = getRandomIdRef("testAppId")
+		testGuid = getRandomIdRef("testGuid")
 		startFakeCCNOAAUAA(initInstanceCount)
 
 		golangApiServerConfPath = components.PrepareGolangApiServerConfig(

--- a/src/autoscaler/integration/integration_scheduler_scalingengine_test.go
+++ b/src/autoscaler/integration/integration_scheduler_scalingengine_test.go
@@ -20,8 +20,8 @@ var _ = Describe("Integration_Scheduler_ScalingEngine", func() {
 	BeforeEach(func() {
 		initializeHttpClient("scheduler.crt", "scheduler.key", "autoscaler-ca.crt", schedulerScalingEngineHttpRequestTimeout)
 
-		testAppId = getRandomId()
-		testGuid = getRandomId()
+		testAppId = getRandomIdRef("testAppId")
+		testGuid = getRandomIdRef("testGuid")
 		startFakeCCNOAAUAA(initInstanceCount)
 
 		scalingEngineConfPath = components.PrepareScalingEngineConfig(dbUrl, components.Ports[ScalingEngine], fakeCCNOAAUAA.URL(), defaultHttpClientTimeout, tmpDir)

--- a/src/autoscaler/integration/integration_suite_test.go
+++ b/src/autoscaler/integration/integration_suite_test.go
@@ -252,9 +252,33 @@ func stopMetricsServer() {
 	ginkgomon_v2.Kill(processMap[MetricsServerHTTP], 5*time.Second)
 }
 
-func getRandomId() string {
+func getRandomIdRef(ref string) string {
+	report := CurrentSpecReport()
+	// 0123456789012345678901234567890123456789
+	// operator_others:189,11,instance:a5f63cbf7c204c417941d91d21cb3bd0
+	// |15|3|2|10|x| +4 == 40
+
+	id := fmt.Sprintf("%s:%d,%s,%d:%s", testFileFragment(report.FileName()), report.LineNumber(), ref, GinkgoParallelProcess(), randomBits())
+	if len(id) > 40 {
+		id = id[:40]
+	}
+	return id
+}
+
+func randomBits() string {
 	v4, _ := uuid.NewV4()
-	return v4.String()
+	randomBits := v4.String()
+	return strings.ReplaceAll(randomBits, "-", "")
+}
+
+func testFileFragment(filename string) string {
+	base := filepath.Base(filename)
+	base = strings.TrimSuffix(base, "_test.go")
+	base = strings.TrimPrefix(base, "integration_")
+	if len(base) > 15 {
+		return base[(len(base) - 15):]
+	}
+	return base
 }
 
 func initializeHttpClient(certFileName string, keyFileName string, caCertFileName string, httpRequestTimeout time.Duration) {

--- a/src/autoscaler/integration/integration_suite_test.go
+++ b/src/autoscaler/integration/integration_suite_test.go
@@ -255,9 +255,13 @@ func stopMetricsServer() {
 func getRandomIdRef(ref string) string {
 	report := CurrentSpecReport()
 	// 0123456789012345678901234567890123456789
-	// operator_others:189,11,instance:a5f63cbf7c204c417941d91d21cb3bd0
-	// |15|3|2|10|x| +4 == 40
-
+	// operator_others:189,11,instance:a5f63cbf 7c204c417941d91d21cb3bd0
+	// |filename|:|linenumber|,|ref|process|:|random|
+	// |15|1|3-4|1|14|2|1|3-4| == 40 (max id length)
+	if len(ref) > 13 {
+		GinkgoT().Logf("WARNING: %s:%d using a ref that is being truncated '%s' should be <= 13 chars", report.FileName(), report.LineNumber(), ref)
+		ref = ref[:13]
+	}
 	id := fmt.Sprintf("%s:%d,%s,%d:%s", testFileFragment(report.FileName()), report.LineNumber(), ref, GinkgoParallelProcess(), randomBits())
 	if len(id) > 40 {
 		id = id[:40]

--- a/src/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManager.java
+++ b/src/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManager.java
@@ -179,7 +179,7 @@ public class ScheduleManager {
           if (compensatorySchedule != null) {
             // create a compensatory schedule to bring the first fire back
             if (specificDateSchedules == null) {
-              specificDateSchedules = new ArrayList<SpecificDateScheduleEntity>();
+              specificDateSchedules = new ArrayList<>();
             }
             specificDateSchedules.add(compensatorySchedule);
             logger.debug(


### PR DESCRIPTION
1. Fixed some internal error handling for 
-- POST `/v1/apps/{appid}/scale` on scaling engine
-- DELETE `/v1/apps/{appId}/schedules`
These continue to return 500 if the appId is too long but no longer panic internally.
1. Improved the tracebility of some of the internal test ids to help track down some intermittant test failures
