### PR TITLE
Fix templates to allow enabling mTLS for public API endpoints

### DIFF
--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -1,0 +1,28 @@
+name: rubocop
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  rubocop:
+    name: Rubocop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Not needed with a .ruby-version file
+          ruby-version: 2.7
+          # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
+
+      - name: rubocop
+        uses: reviewdog/action-rubocop@v2
+        with:
+          rubocop_version: gemfile
+          rubocop_extensions: standard:gemfile
+          reporter: github-pr-review # Default is github-pr-check # github-pr-review

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+require: standard
+
+inherit_gem:
+  standard: config/base.yml
+
+AllCops:
+  Exclude:
+    - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 group :development, :test do
-  gem 'bosh-template'
-  gem 'rspec'
-  gem 'rspec-its'
+  gem "bosh-template"
+  gem "rspec"
+  gem "rspec-its"
+  gem "standard"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     bosh-template (2.2.1)
       semi_semantic (~> 1.2.0)
     diff-lcs (1.4.4)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
+    regexp_parser (2.3.0)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -20,7 +27,26 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
+    rubocop (1.27.0)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.16.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.17.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.13.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.11.0)
     semi_semantic (1.2.0)
+    standard (1.10.0)
+      rubocop (= 1.27.0)
+      rubocop-performance (= 1.13.3)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
@@ -29,6 +55,7 @@ DEPENDENCIES
   bosh-template
   rspec
   rspec-its
+  standard
 
 BUNDLED WITH
-  2.1.2
+   2.1.4

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,8 @@ lint: golangci-lint $(addprefix lint_,$(go_modules))
 
 golangci-lint:
 	@make -C src/autoscaler golangci-lint
+rubocop:
+	bundle exec rubocop -a
 
 $(addprefix lint_,$(go_modules)): lint_%:
 	@echo " - linting: $(patsubst lint_%,%,$@)"

--- a/jobs/golangapiserver/templates/apiserver.yml.erb
+++ b/jobs/golangapiserver/templates/apiserver.yml.erb
@@ -66,9 +66,22 @@ cf:
 
 public_api_server:
   port:  <%= p("autoscaler.apiserver.public_api.server.port") %>
+  <% if_p("autoscaler.apiserver.public_api.server.ca_cert", "autoscaler.apiserver.public_api.server.server_cert", "autoscaler.apiserver.public_api.server.server_key") do %>
+  tls:
+    ca_file: /var/vcap/jobs/golangapiserver/config/certs/apiserver/ca.crt
+    cert_file: /var/vcap/jobs/golangapiserver/config/certs/apiserver/server.crt
+    key_file: /var/vcap/jobs/golangapiserver/config/certs/apiserver/server.key
+  <% end %>
+
 <% if p("autoscaler.apiserver.use_buildin_mode") == false %>
 broker_server:
   port:  <%= p("autoscaler.apiserver.broker.server.port") %>
+  <% if_p("autoscaler.apiserver.broker.server.ca_cert", "autoscaler.apiserver.broker.server.server_cert", "autoscaler.apiserver.broker.server.server_key") do %>
+  tls:
+    ca_file: /var/vcap/jobs/golangapiserver/config/certs/brokerserver/ca.crt
+    cert_file: /var/vcap/jobs/golangapiserver/config/certs/brokerserver/server.crt
+    key_file: /var/vcap/jobs/golangapiserver/config/certs/brokerserver/server.key
+  <% end %>
 
 <% if p("autoscaler.apiserver.broker.broker_credentials") != '' %>
 <%= {'broker_credentials' => p('autoscaler.apiserver.broker.broker_credentials')}.to_yaml.lines[1..-1].join %>

--- a/spec/jobs/eventgenerator/eventgenerator_spec.rb
+++ b/spec/jobs/eventgenerator/eventgenerator_spec.rb
@@ -1,12 +1,12 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'yaml'
+require "rspec"
+require "json"
+require "bosh/template/test"
+require "yaml"
 
-describe 'eventgenerator' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
-  let(:job) { release.job('eventgenerator') }
-  let(:template) { job.template('config/eventgenerator.yml') }
+describe "eventgenerator" do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), "../../..")) }
+  let(:job) { release.job("eventgenerator") }
+  let(:template) { job.template("config/eventgenerator.yml") }
   let(:properties) do
     YAML.safe_load(%(
       autoscaler:
@@ -37,53 +37,47 @@ describe 'eventgenerator' do
     ))
   end
 
-  context 'config/eventgenerator.yml' do
-
-    it 'does not set username nor password if not configured' do
-      properties['autoscaler'].merge!(
-        'eventgenerator' => {
-          'health' => {
-            'port' => 1234,
-          }
+  context "config/eventgenerator.yml" do
+    it "does not set username nor password if not configured" do
+      properties["autoscaler"]["eventgenerator"] = {
+        "health" => {
+          "port" => 1234
         }
-      )
+      }
       links = [
         Bosh::Template::Test::Link.new(
-          name: 'eventgenerator',
+          name: "eventgenerator",
           properties: {}
         )
       ]
       rendered_template = YAML.safe_load(template.render(properties, consumes: links))
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234 }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234}
+        )
     end
 
-    it 'check eventgenerator username and password' do
-      properties['autoscaler'].merge!(
-        'eventgenerator' => {
-          'health' => {
-            'port' => 1234,
-            'username' => 'test-user',
-            'password' => 'test-user-password'
-          }
+    it "check eventgenerator username and password" do
+      properties["autoscaler"]["eventgenerator"] = {
+        "health" => {
+          "port" => 1234,
+          "username" => "test-user",
+          "password" => "test-user-password"
         }
-      )
+      }
       links = [
         Bosh::Template::Test::Link.new(
-          name: 'eventgenerator',
+          name: "eventgenerator",
           properties: {}
         )
       ]
       rendered_template = YAML.safe_load(template.render(properties, consumes: links))
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234,
-               'username' => 'test-user',
-               'password' => 'test-user-password'
-             }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234,
+           "username" => "test-user",
+           "password" => "test-user-password"}
+        )
     end
   end
 end

--- a/spec/jobs/golangapiserver/apiserver_spec.rb
+++ b/spec/jobs/golangapiserver/apiserver_spec.rb
@@ -1,12 +1,12 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'yaml'
+require "rspec"
+require "json"
+require "bosh/template/test"
+require "yaml"
 
-describe 'golangapiserver' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
-  let(:job) { release.job('golangapiserver') }
-  let(:template) { job.template('config/apiserver.yml') }
+describe "golangapiserver" do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), "../../..")) }
+  let(:job) { release.job("golangapiserver") }
+  let(:template) { job.template("config/apiserver.yml") }
   let(:properties) do
     YAML.safe_load(%(
       autoscaler:
@@ -63,190 +63,172 @@ describe 'golangapiserver' do
     ))
   end
 
-  context 'config/apiserver.yml' do
-    context 'apiserver does not use buildin mode' do
+  context "config/apiserver.yml" do
+    context "apiserver does not use buildin mode" do
       before(:each) do
-        properties['autoscaler']['apiserver'].merge!(
-          'use_buildin_mode' => false,
+        properties["autoscaler"]["apiserver"].merge!(
+          "use_buildin_mode" => false
         )
       end
 
-      it 'writes service_broker_usernames' do
-        properties['autoscaler']['apiserver']['broker'].merge!(
-          'broker_credentials' => [
-            { 'broker_username' => 'fake_b_user_1',
-              'broker_password' => 'fake_b_password_1' },
-            { 'broker_username' => 'fake_b_user_2',
-              'broker_password' => 'fake_b_password_2' },
+      it "writes service_broker_usernames" do
+        properties["autoscaler"]["apiserver"]["broker"]["broker_credentials"] = [
+          {"broker_username" => "fake_b_user_1",
+           "broker_password" => "fake_b_password_1"},
+          {"broker_username" => "fake_b_user_2",
+           "broker_password" => "fake_b_password_2"}
+        ]
+
+        rendered_template = YAML.safe_load(template.render(properties))
+
+        expect(rendered_template["broker_credentials"]).to include(
+          {"broker_username" => "fake_b_user_1",
+           "broker_password" => "fake_b_password_1"},
+          {"broker_username" => "fake_b_user_2",
+           "broker_password" => "fake_b_password_2"}
+        )
+      end
+
+      it "writes deprecated service_broker_usernames" do
+        properties["autoscaler"]["apiserver"]["broker"].merge!(
+          "username" => "deprecated_username",
+          "password" => "deprecated_password"
+        )
+
+        rendered_template = YAML.safe_load(template.render(properties))
+
+        expect(rendered_template["broker_credentials"]).to include(
+          {"broker_username" => "deprecated_username",
+           "broker_password" => "deprecated_password"}
+        )
+      end
+
+      it "favour list of credentials over deprecated values" do
+        properties["autoscaler"]["apiserver"]["broker"].merge!(
+          "broker_credentials" => [
+            {"broker_username" => "fake_b_user_1",
+             "broker_password" => "fake_b_password_1"},
+            {"broker_username" => "fake_b_user_2",
+             "broker_password" => "fake_b_password_2"}
           ],
+          "username" => "deprecated_username",
+          "password" => "deprecated_password"
         )
 
         rendered_template = YAML.safe_load(template.render(properties))
 
-        expect(rendered_template['broker_credentials']).to include(
-          { 'broker_username' => 'fake_b_user_1',
-            'broker_password' => 'fake_b_password_1' },
-          { 'broker_username' => 'fake_b_user_2',
-            'broker_password' => 'fake_b_password_2' },
+        expect(rendered_template["broker_credentials"]).to include(
+          {"broker_username" => "fake_b_user_1",
+           "broker_password" => "fake_b_password_1"},
+          {"broker_username" => "fake_b_user_2",
+           "broker_password" => "fake_b_password_2"}
         )
-      end
-
-      it 'writes deprecated service_broker_usernames' do
-        properties['autoscaler']['apiserver']['broker'].merge!(
-          'username' => 'deprecated_username',
-          'password' => 'deprecated_password'
-        )
-
-        rendered_template = YAML.safe_load(template.render(properties))
-
-        expect(rendered_template['broker_credentials']).to include(
-          { 'broker_username' => 'deprecated_username',
-            'broker_password' => 'deprecated_password' },
-        )
-      end
-
-      it 'favour list of credentials over deprecated values' do
-        properties['autoscaler']['apiserver']['broker'].merge!(
-          'broker_credentials' => [
-            { 'broker_username' => 'fake_b_user_1',
-              'broker_password' => 'fake_b_password_1' },
-            { 'broker_username' => 'fake_b_user_2',
-              'broker_password' => 'fake_b_password_2' },
-          ],
-          'username' => 'deprecated_username',
-          'password' => 'deprecated_password'
-        )
-
-        rendered_template = YAML.safe_load(template.render(properties))
-
-        expect(rendered_template['broker_credentials']).to include(
-          { 'broker_username' => 'fake_b_user_1',
-            'broker_password' => 'fake_b_password_1' },
-          { 'broker_username' => 'fake_b_user_2',
-            'broker_password' => 'fake_b_password_2' },
-        )
-      end
-
-    end
-
-    context 'quota_management' do
-
-      it 'writes config when quota management is enabled' do
-
-        properties['autoscaler']['apiserver']['broker'].merge!(
-          'quota_management' =>
-            { 'enabled' => 'true',
-              'api' => 'https://quota_management.api',
-              'client_id' => 'quota_management.client_id',
-              'secret' => 'quota_management.secret',
-              'oauth_url' => 'https://quota_management.oauth.api',
-              'skip_ssl_validation' => 'true'
-            }
-        )
-
-        rendered_template = YAML.safe_load(template.render(properties))
-
-        expect(rendered_template['quota_management']).to include(
-                                                           {
-                                                             'api' => 'https://quota_management.api',
-                                                             'client_id' => 'quota_management.client_id',
-                                                             'secret' => 'quota_management.secret',
-                                                             'oauth_url' => 'https://quota_management.oauth.api',
-                                                             'skip_ssl_validation' => true
-                                                           }
-                                                         )
-      end
-
-      it 'does not write config when quota management is disabled' do
-        properties['autoscaler']['apiserver']['broker'].merge!(
-          'quota_management' => { 'enabled' => false }
-        )
-
-        rendered_template = YAML.safe_load(template.render(properties))
-
-        expect(rendered_template['quota_management']).to be_nil
       end
     end
 
-    context 'plan_check' do
-
-      it 'by default plan checks are disabled' do
+    context "quota_management" do
+      it "writes config when quota management is enabled" do
+        properties["autoscaler"]["apiserver"]["broker"]["quota_management"] = {"enabled" => "true",
+             "api" => "https://quota_management.api",
+             "client_id" => "quota_management.client_id",
+             "secret" => "quota_management.secret",
+             "oauth_url" => "https://quota_management.oauth.api",
+             "skip_ssl_validation" => "true"}
 
         rendered_template = YAML.safe_load(template.render(properties))
 
-        expect(rendered_template['plan_check']).to be_nil
+        expect(rendered_template["quota_management"]).to include(
+          {
+            "api" => "https://quota_management.api",
+            "client_id" => "quota_management.client_id",
+            "secret" => "quota_management.secret",
+            "oauth_url" => "https://quota_management.oauth.api",
+            "skip_ssl_validation" => true
+          }
+        )
       end
 
-      it 'plan checks can be enabled' do
-        properties['autoscaler']['apiserver']['broker'].merge!(
-          'plan_check' => {
-            'plan_definitions' => {
-              'Some-example-uuid-ONE' => { 'planCheckEnabled' => true, 'schedules_count' => 2, 'scaling_rules_count' => 4 },
-              'Some-example-uuid-TWO' => { 'planCheckEnabled' => true, 'schedules_count' => 10, 'scaling_rules_count' => 10 },
-            } })
+      it "does not write config when quota management is disabled" do
+        properties["autoscaler"]["apiserver"]["broker"]["quota_management"] = {"enabled" => false}
 
         rendered_template = YAML.safe_load(template.render(properties))
 
-        expect(rendered_template['plan_check']).to include(
-                                                     {"plan_definitions"=>{
-                                                       "Some-example-uuid-ONE"=>{"planCheckEnabled"=>true, "scaling_rules_count"=>4, "schedules_count"=>2},
-                                                       "Some-example-uuid-TWO"=>{"planCheckEnabled"=>true, "scaling_rules_count"=>10, "schedules_count"=>10}
-                                                     }})
+        expect(rendered_template["quota_management"]).to be_nil
       end
     end
 
+    context "plan_check" do
+      it "by default plan checks are disabled" do
+        rendered_template = YAML.safe_load(template.render(properties))
 
-    context 'cred_helper_impl' do
+        expect(rendered_template["plan_check"]).to be_nil
+      end
 
-      it 'has a cred helper impl by default' do
+      it "plan checks can be enabled" do
+        properties["autoscaler"]["apiserver"]["broker"]["plan_check"] = {
+          "plan_definitions" => {
+            "Some-example-uuid-ONE" => {"planCheckEnabled" => true, "schedules_count" => 2, "scaling_rules_count" => 4},
+            "Some-example-uuid-TWO" => {"planCheckEnabled" => true, "schedules_count" => 10, "scaling_rules_count" => 10}
+          }
+        }
+
+        rendered_template = YAML.safe_load(template.render(properties))
+
+        expect(rendered_template["plan_check"]).to include(
+          {"plan_definitions" => {
+            "Some-example-uuid-ONE" => {"planCheckEnabled" => true, "scaling_rules_count" => 4, "schedules_count" => 2},
+            "Some-example-uuid-TWO" => {"planCheckEnabled" => true, "scaling_rules_count" => 10, "schedules_count" => 10}
+          }}
+        )
+      end
+    end
+
+    context "cred_helper_impl" do
+      it "has a cred helper impl by default" do
+        rendered_template = YAML.safe_load(template.render(properties))
+        expect(rendered_template).to include(
+          {
+            "cred_helper_impl" => "default"
+          }
+        )
+      end
+
+      it "has a cred helper impl configured for stored procedures" do
+        properties["autoscaler"]["apiserver"]["cred_helper"] = {
+          "impl" => "stored_procedure",
+          "stored_procedure_config" => {
+            "schema_name" => "SCHEMA",
+            "create_binding_credential_procedure_name" => "CREATE_BINDING_CREDENTIAL",
+            "drop_binding_credential_procedure_name" => "DROP_BINDING_CREDENTIAL",
+            "drop_all_binding_credential_procedure_name" => "DROP_ALL_BINDING_CREDENTIALS",
+            "validate_binding_credential_procedure_name" => "VALIDATE_BINDING_CREDENTIALS"
+          }
+        }
 
         rendered_template = YAML.safe_load(template.render(properties))
         expect(rendered_template).to include(
-            {
-              "cred_helper_impl" => "default"
+          {
+            "cred_helper_impl" => "stored_procedure",
+            "stored_procedure_binding_credential_config" => {
+              "schema_name" => "SCHEMA",
+              "create_binding_credential_procedure_name" => "CREATE_BINDING_CREDENTIAL",
+              "drop_binding_credential_procedure_name" => "DROP_BINDING_CREDENTIAL",
+              "drop_all_binding_credential_procedure_name" => "DROP_ALL_BINDING_CREDENTIALS",
+              "validate_binding_credential_procedure_name" => "VALIDATE_BINDING_CREDENTIALS"
             }
+          }
         )
       end
-
-      it 'has a cred helper impl configured for stored procedures' do
-
-        properties['autoscaler']['apiserver'].merge!(
-            'cred_helper' => {
-              'impl' => 'stored_procedure',
-              'stored_procedure_config' => {
-                'schema_name' => 'SCHEMA',
-                'create_binding_credential_procedure_name' => 'CREATE_BINDING_CREDENTIAL',
-                'drop_binding_credential_procedure_name' => 'DROP_BINDING_CREDENTIAL',
-                'drop_all_binding_credential_procedure_name' => 'DROP_ALL_BINDING_CREDENTIALS',
-                'validate_binding_credential_procedure_name' => 'VALIDATE_BINDING_CREDENTIALS'
-              }
-            }
-        )
-
-        rendered_template = YAML.safe_load(template.render(properties))
-        expect(rendered_template).to include(
-            {
-              'cred_helper_impl' => 'stored_procedure',
-              'stored_procedure_binding_credential_config' => {
-                'schema_name' => 'SCHEMA',
-                'create_binding_credential_procedure_name' => 'CREATE_BINDING_CREDENTIAL',
-                'drop_binding_credential_procedure_name' => 'DROP_BINDING_CREDENTIAL',
-                'drop_all_binding_credential_procedure_name' => 'DROP_ALL_BINDING_CREDENTIALS',
-                'validate_binding_credential_procedure_name' => 'VALIDATE_BINDING_CREDENTIALS'
-              }
-            }
-        )
-      end
-     end
+    end
   end
 
-    let(:rendered_template){ YAML.safe_load(template.render(properties)) }
-    context 'storedprocedure_db' do
-      it 'selects db role with storedproceduredb tag by default' do
-        rendered_template["db"]["storedprocedure_db"]["url"].tap do |url|
-          expect(url).to include("stored_procedure_username")
-          expect(url).to include("store_procedure_db")
-        end
+  let(:rendered_template) { YAML.safe_load(template.render(properties)) }
+  context "storedprocedure_db" do
+    it "selects db role with storedproceduredb tag by default" do
+      rendered_template["db"]["storedprocedure_db"]["url"].tap do |url|
+        expect(url).to include("stored_procedure_username")
+        expect(url).to include("store_procedure_db")
       end
     end
+  end
 end

--- a/spec/jobs/metricsforwarder/metricsforwarder_spec.rb
+++ b/spec/jobs/metricsforwarder/metricsforwarder_spec.rb
@@ -1,12 +1,12 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'yaml'
+require "rspec"
+require "json"
+require "bosh/template/test"
+require "yaml"
 
-describe 'metricsforwarder' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
-  let(:job) { release.job('metricsforwarder') }
-  let(:template) { job.template('config/metricsforwarder.yml') }
+describe "metricsforwarder" do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), "../../..")) }
+  let(:job) { release.job("metricsforwarder") }
+  let(:template) { job.template("config/metricsforwarder.yml") }
   let(:properties) do
     YAML.safe_load(%(
       autoscaler:
@@ -31,46 +31,40 @@ describe 'metricsforwarder' do
     ))
   end
 
-  context 'config/metricsforwarder.yml' do
-
-    it 'does not set username nor password if not configured' do
-      properties['autoscaler'].merge!(
-        'metricsforwarder' => {
-          'health' => {
-            'port' => 1234,
-          }
+  context "config/metricsforwarder.yml" do
+    it "does not set username nor password if not configured" do
+      properties["autoscaler"]["metricsforwarder"] = {
+        "health" => {
+          "port" => 1234
         }
-      )
+      }
       rendered_template = YAML.safe_load(template.render(properties))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234 }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234}
+        )
     end
 
-    it 'check metricsforwarder basic auth username and password' do
-      properties['autoscaler'].merge!(
-        'metricsforwarder' => {
-          'health' => {
-            'port' => 1234,
-            'username' => 'test-user',
-            'password' => 'test-user-password'
-          }
+    it "check metricsforwarder basic auth username and password" do
+      properties["autoscaler"]["metricsforwarder"] = {
+        "health" => {
+          "port" => 1234,
+          "username" => "test-user",
+          "password" => "test-user-password"
         }
-      )
+      }
       rendered_template = YAML.safe_load(template.render(properties))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234,
-               'username' => 'test-user',
-               'password' => 'test-user-password'
-             }
-           )
-		end
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234,
+           "username" => "test-user",
+           "password" => "test-user-password"}
+        )
+    end
 
-    it 'has a cred helper impl by default' do
+    it "has a cred helper impl by default" do
       rendered_template = YAML.safe_load(template.render(properties))
       expect(rendered_template).to include(
         {
@@ -79,37 +73,33 @@ describe 'metricsforwarder' do
       )
     end
 
-    it 'has a cred helper impl configured for stored procedures' do
-
-      properties['autoscaler'].merge!(
-        'metricsforwarder' => {
-          'cred_helper' => {
-            'impl' => 'stored_procedure',
-            'stored_procedure_config' => {
-              'schema_name' => 'SCHEMA',
-              'create_binding_credential_procedure_name' => 'CREATE_BINDING_CREDENTIAL',
-              'drop_binding_credential_procedure_name' => 'DROP_BINDING_CREDENTIAL',
-              'drop_all_binding_credential_procedure_name' => 'DROP_ALL_BINDING_CREDENTIALS',
-              'validate_binding_credential_procedure_name' => 'VALIDATE_BINDING_CREDENTIALS'
-            }
+    it "has a cred helper impl configured for stored procedures" do
+      properties["autoscaler"]["metricsforwarder"] = {
+        "cred_helper" => {
+          "impl" => "stored_procedure",
+          "stored_procedure_config" => {
+            "schema_name" => "SCHEMA",
+            "create_binding_credential_procedure_name" => "CREATE_BINDING_CREDENTIAL",
+            "drop_binding_credential_procedure_name" => "DROP_BINDING_CREDENTIAL",
+            "drop_all_binding_credential_procedure_name" => "DROP_ALL_BINDING_CREDENTIALS",
+            "validate_binding_credential_procedure_name" => "VALIDATE_BINDING_CREDENTIALS"
           }
         }
-      )
+      }
 
       rendered_template = YAML.safe_load(template.render(properties))
       expect(rendered_template).to include(
-                                     {
-                                       'cred_helper_impl' => 'stored_procedure',
-                                       'stored_procedure_binding_credential_config' => {
-                                         'schema_name' => 'SCHEMA',
-                                         'create_binding_credential_procedure_name' => 'CREATE_BINDING_CREDENTIAL',
-                                         'drop_binding_credential_procedure_name' => 'DROP_BINDING_CREDENTIAL',
-                                         'drop_all_binding_credential_procedure_name' => 'DROP_ALL_BINDING_CREDENTIALS',
-                                         'validate_binding_credential_procedure_name' => 'VALIDATE_BINDING_CREDENTIALS'
-                                       }
-                                     }
-                                   )
+        {
+          "cred_helper_impl" => "stored_procedure",
+          "stored_procedure_binding_credential_config" => {
+            "schema_name" => "SCHEMA",
+            "create_binding_credential_procedure_name" => "CREATE_BINDING_CREDENTIAL",
+            "drop_binding_credential_procedure_name" => "DROP_BINDING_CREDENTIAL",
+            "drop_all_binding_credential_procedure_name" => "DROP_ALL_BINDING_CREDENTIALS",
+            "validate_binding_credential_procedure_name" => "VALIDATE_BINDING_CREDENTIALS"
+          }
+        }
+      )
     end
   end
 end
-

--- a/spec/jobs/metricsgateway/metricsgateway_spec.rb
+++ b/spec/jobs/metricsgateway/metricsgateway_spec.rb
@@ -1,12 +1,12 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'yaml'
+require "rspec"
+require "json"
+require "bosh/template/test"
+require "yaml"
 
-describe 'metricsgateway' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
-  let(:job) { release.job('metricsgateway') }
-  let(:template) { job.template('config/metricsgateway.yml') }
+describe "metricsgateway" do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), "../../..")) }
+  let(:job) { release.job("metricsgateway") }
+  let(:template) { job.template("config/metricsgateway.yml") }
   let(:properties) do
     YAML.safe_load(%(
       autoscaler:
@@ -31,61 +31,53 @@ describe 'metricsgateway' do
     ))
   end
 
-  context 'config/metricsgateway.yml' do
-
-    it 'does not set username nor password if not configured' do
-      properties['autoscaler'].merge!(
-        'metricsgateway' => {
-          'health' => {
-            'port' => 1234
-          },
-          'nozzle' => {
-            'rlp_addr' => 'localhost'
-          }
+  context "config/metricsgateway.yml" do
+    it "does not set username nor password if not configured" do
+      properties["autoscaler"]["metricsgateway"] = {
+        "health" => {
+          "port" => 1234
+        },
+        "nozzle" => {
+          "rlp_addr" => "localhost"
         }
-      )
+      }
       links = [
         Bosh::Template::Test::Link.new(
-          name: 'metricsserver'
+          name: "metricsserver"
         )
       ]
       rendered_template = YAML.safe_load(template.render(properties, consumes: links))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234,
-             }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234}
+        )
     end
 
-    it 'check metricsgateway basic auth username and password' do
-      properties['autoscaler'].merge!(
-        'metricsgateway' => {
-          'health' => {
-            'port' => 1234,
-            'username' => 'test-user',
-            'password' => 'test-user-password'
-          },
-          'nozzle' => {
-            'rlp_addr' => 'localhost'
-          }
+    it "check metricsgateway basic auth username and password" do
+      properties["autoscaler"]["metricsgateway"] = {
+        "health" => {
+          "port" => 1234,
+          "username" => "test-user",
+          "password" => "test-user-password"
+        },
+        "nozzle" => {
+          "rlp_addr" => "localhost"
         }
-      )
+      }
       links = [
         Bosh::Template::Test::Link.new(
-          name: 'metricsserver'
+          name: "metricsserver"
         )
       ]
       rendered_template = YAML.safe_load(template.render(properties, consumes: links))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234,
-               'username' => 'test-user',
-               'password' => 'test-user-password'
-             }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234,
+           "username" => "test-user",
+           "password" => "test-user-password"}
+        )
     end
   end
 end
-

--- a/spec/jobs/metricsserver/metricsserver_spec.rb
+++ b/spec/jobs/metricsserver/metricsserver_spec.rb
@@ -1,12 +1,12 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'yaml'
+require "rspec"
+require "json"
+require "bosh/template/test"
+require "yaml"
 
-describe 'metricsserver' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
-  let(:job) { release.job('metricsserver') }
-  let(:template) { job.template('config/metricsserver.yml') }
+describe "metricsserver" do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), "../../..")) }
+  let(:job) { release.job("metricsserver") }
+  let(:template) { job.template("config/metricsserver.yml") }
   let(:properties) do
     YAML.safe_load(%(
       autoscaler:
@@ -44,54 +44,47 @@ describe 'metricsserver' do
     ))
   end
 
-  context 'config/metricsserver.yml' do
-
-    it 'does not set username nor password if not configured' do
-      properties['autoscaler'].merge!(
-        'metricsserver' => {
-          'health' => {
-            'port' => 1234
-          }
+  context "config/metricsserver.yml" do
+    it "does not set username nor password if not configured" do
+      properties["autoscaler"]["metricsserver"] = {
+        "health" => {
+          "port" => 1234
         }
-      )
+      }
       links = [
         Bosh::Template::Test::Link.new(
-          name: 'metricsserver'
+          name: "metricsserver"
         )
       ]
       rendered_template = YAML.safe_load(template.render(properties, consumes: links))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234 }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234}
+        )
     end
 
-    it 'check metricsserver basic auth username and password' do
-      properties['autoscaler'].merge!(
-        'metricsserver' => {
-          'health' => {
-            'port' => 1234,
-            'username' => 'test-user',
-            'password' => 'test-user-password'
-          }
+    it "check metricsserver basic auth username and password" do
+      properties["autoscaler"]["metricsserver"] = {
+        "health" => {
+          "port" => 1234,
+          "username" => "test-user",
+          "password" => "test-user-password"
         }
-      )
+      }
       links = [
         Bosh::Template::Test::Link.new(
-          name: 'metricsserver'
+          name: "metricsserver"
         )
       ]
       rendered_template = YAML.safe_load(template.render(properties, consumes: links))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234,
-               'username' => 'test-user',
-               'password' => 'test-user-password'
-             }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234,
+           "username" => "test-user",
+           "password" => "test-user-password"}
+        )
     end
   end
 end
-

--- a/spec/jobs/operator/operator_spec.rb
+++ b/spec/jobs/operator/operator_spec.rb
@@ -1,12 +1,12 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'yaml'
+require "rspec"
+require "json"
+require "bosh/template/test"
+require "yaml"
 
-describe 'operator' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
-  let(:job) { release.job('operator') }
-  let(:template) { job.template('config/operator.yml') }
+describe "operator" do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), "../../..")) }
+  let(:job) { release.job("operator") }
+  let(:template) { job.template("config/operator.yml") }
   let(:properties) do
     YAML.safe_load(%(
       autoscaler:
@@ -76,46 +76,39 @@ describe 'operator' do
     ))
   end
 
-  context 'config/operator.yml' do
-
-    it 'does not set username nor password if not configured' do
-      properties['autoscaler'].merge!(
-        'operator' => {
-          'health' => {
-            'port' => 1234
-          }
+  context "config/operator.yml" do
+    it "does not set username nor password if not configured" do
+      properties["autoscaler"]["operator"] = {
+        "health" => {
+          "port" => 1234
         }
-      )
+      }
 
       rendered_template = YAML.safe_load(template.render(properties))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234 }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234}
+        )
     end
 
-    it 'check operator basic auth username and password' do
-      properties['autoscaler'].merge!(
-        'operator' => {
-          'health' => {
-            'port' => 1234,
-            'username' => 'test-user',
-            'password' => 'test-user-password'
-          }
+    it "check operator basic auth username and password" do
+      properties["autoscaler"]["operator"] = {
+        "health" => {
+          "port" => 1234,
+          "username" => "test-user",
+          "password" => "test-user-password"
         }
-      )
+      }
 
       rendered_template = YAML.safe_load(template.render(properties))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234,
-               'username' => 'test-user',
-               'password' => 'test-user-password'
-             }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234,
+           "username" => "test-user",
+           "password" => "test-user-password"}
+        )
     end
   end
 end
-

--- a/spec/jobs/scalingengine/scalingengine_spec.rb
+++ b/spec/jobs/scalingengine/scalingengine_spec.rb
@@ -1,12 +1,12 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'yaml'
+require "rspec"
+require "json"
+require "bosh/template/test"
+require "yaml"
 
-describe 'scalingengine' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
-  let(:job) { release.job('scalingengine') }
-  let(:template) { job.template('config/scalingengine.yml') }
+describe "scalingengine" do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), "../../..")) }
+  let(:job) { release.job("scalingengine") }
+  let(:template) { job.template("config/scalingengine.yml") }
   let(:properties) do
     YAML.safe_load(%(
       autoscaler:
@@ -86,44 +86,37 @@ describe 'scalingengine' do
     ))
   end
 
-  context 'config/scalingengine.yml' do
-
-    it 'does not set username nor password if not configured' do
-      properties['autoscaler'].merge!(
-        'scalingengine' => {
-          'health' => {
-            'port' => 1234
-          }
+  context "config/scalingengine.yml" do
+    it "does not set username nor password if not configured" do
+      properties["autoscaler"]["scalingengine"] = {
+        "health" => {
+          "port" => 1234
         }
-      )
+      }
       rendered_template = YAML.safe_load(template.render(properties))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234 }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234}
+        )
     end
 
-    it 'check scalingengine basic auth username and password' do
-      properties['autoscaler'].merge!(
-        'scalingengine' => {
-          'health' => {
-            'port' => 1234,
-            'username' => 'test-user',
-            'password' => 'test-user-password'
-          }
+    it "check scalingengine basic auth username and password" do
+      properties["autoscaler"]["scalingengine"] = {
+        "health" => {
+          "port" => 1234,
+          "username" => "test-user",
+          "password" => "test-user-password"
         }
-      )
+      }
       rendered_template = YAML.safe_load(template.render(properties))
 
-      expect(rendered_template['health']).
-        to include(
-             { 'port' => 1234,
-               'username' => 'test-user',
-               'password' => 'test-user-password'
-             }
-           )
+      expect(rendered_template["health"])
+        .to include(
+          {"port" => 1234,
+           "username" => "test-user",
+           "password" => "test-user-password"}
+        )
     end
   end
 end
-

--- a/spec/jobs/scheduler/scheduler_spec.rb
+++ b/spec/jobs/scheduler/scheduler_spec.rb
@@ -1,12 +1,12 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'yaml'
+require "rspec"
+require "json"
+require "bosh/template/test"
+require "yaml"
 
-describe 'scheduler' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
-  let(:job) { release.job('scheduler') }
-  let(:template) { job.template('config/application.properties') }
+describe "scheduler" do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), "../../..")) }
+  let(:job) { release.job("scheduler") }
+  let(:template) { job.template("config/application.properties") }
   let(:properties) do
     YAML.safe_load(%(
       autoscaler:
@@ -37,42 +37,36 @@ describe 'scheduler' do
     ))
   end
 
-  context 'config/application.properties' do
-
-    it 'does not set username nor password if not configured' do
-      properties['autoscaler'].merge!(
-        'scheduler' => {
-          'health' => {
-            'port' => 1234,
-          }
+  context "config/application.properties" do
+    it "does not set username nor password if not configured" do
+      properties["autoscaler"]["scheduler"] = {
+        "health" => {
+          "port" => 1234
         }
-      )
+      }
       rendered_template = template.render(properties)
 
-      expect(rendered_template).to include('scheduler.healthserver.port=1234')
-      expect(rendered_template).to include('scheduler.healthserver.basicAuthEnabled=false')
-      expect(rendered_template).to include('scheduler.healthserver.username=')
-      expect(rendered_template).to include('scheduler.healthserver.password=')
+      expect(rendered_template).to include("scheduler.healthserver.port=1234")
+      expect(rendered_template).to include("scheduler.healthserver.basicAuthEnabled=false")
+      expect(rendered_template).to include("scheduler.healthserver.username=")
+      expect(rendered_template).to include("scheduler.healthserver.password=")
     end
 
-    it 'check scheduler username and password' do
-      properties['autoscaler'].merge!(
-        'scheduler' => {
-          'health' => {
-            'port' => 1234,
-            'basicAuthEnabled' => 'true',
-            'username' => 'test-user',
-            'password' => 'test-user-password'
-          }
+    it "check scheduler username and password" do
+      properties["autoscaler"]["scheduler"] = {
+        "health" => {
+          "port" => 1234,
+          "basicAuthEnabled" => "true",
+          "username" => "test-user",
+          "password" => "test-user-password"
         }
-      )
+      }
       rendered_template = template.render(properties)
 
-      expect(rendered_template).to include('scheduler.healthserver.port=1234')
-      expect(rendered_template).to include('scheduler.healthserver.basicAuthEnabled=true')
-      expect(rendered_template).to include('scheduler.healthserver.username=test-user')
-      expect(rendered_template).to include('scheduler.healthserver.password=test-user-password')
-
+      expect(rendered_template).to include("scheduler.healthserver.port=1234")
+      expect(rendered_template).to include("scheduler.healthserver.basicAuthEnabled=true")
+      expect(rendered_template).to include("scheduler.healthserver.username=test-user")
+      expect(rendered_template).to include("scheduler.healthserver.password=test-user-password")
     end
   end
 end


### PR DESCRIPTION
The API server specs already had the necessary config options, but they were not evaluated and set in the API server config.

As I had to touch the Ruby templates and tests I also added a `rubocop` `make` target and added a GitHub action to check PRs.

`rubocop` was configured with the `StandardRB` preset.