### PR TITLE
fix: use sonar token as cli parameters

### DIFF
--- a/.github/workflows/java-ci-lint.yaml
+++ b/.github/workflows/java-ci-lint.yaml
@@ -53,6 +53,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
+          echo "SONAR TOKEN IS : ${{ secrets.SONAR_TOKEN }}"
+          echo "SONAR TOKEN in env IS : ${{ env.SONAR_TOKEN }}"
           pushd src/scheduler
-            mvn --no-transfer-progress compile spotbugs:spotbugs org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+            mvn --no-transfer-progress compile spotbugs:spotbugs org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.login=${{ secrets.SONAR_TOKEN }}
           popd


### PR DESCRIPTION
Since Sonar Cloud Maven plugin is used to scan scheduler project, SONAR_TOKEN should be passed as CLI argument/ or in pom.xml

**Resolution**
Pass SONAR_TOKEN as part of cli argument


[Failed sonar check](https://github.com/cloudfoundry/app-autoscaler-release/runs/6448812939?check_suite_focus=true#step:6:226)