### PR TITLE
fix: use sonar token as cli parameters

### DIFF
--- a/.github/workflows/java-ci-lint.yaml
+++ b/.github/workflows/java-ci-lint.yaml
@@ -54,5 +54,5 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           pushd src/scheduler
-            mvn --no-transfer-progress compile spotbugs:spotbugs org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+            mvn --no-transfer-progress compile spotbugs:spotbugs org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.login=${{ secrets.SONAR_TOKEN }}
           popd


### PR DESCRIPTION
Since Sonar Cloud Maven plugin is used to scan scheduler project, SONAR_TOKEN should be passed as CLI argument/ or in pom.xml

**Resolution**
Pass SONAR_TOKEN as part of cli argument


[Failed sonar check](https://github.com/cloudfoundry/app-autoscaler-release/runs/6448812939?check_suite_focus=true#step:6:226)