### PR TITLE
Security fix: Health endpoint not secured if just hashes supplied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,8 +182,8 @@ stop-db: check-db_type
 integration: build init-db test-certs
 	make -C src/autoscaler integration DBURL="${DBURL}"
 
-.PHONY: golangci-lint lint $(addprefix lint_,$(go_modules))
-lint: golangci-lint_check golangci-lint $(addprefix lint_,$(go_modules))
+.PHONY:lint $(addprefix lint_,$(go_modules))
+lint: golangci-lint_check $(addprefix lint_,$(go_modules))
 
 golangci-lint_check:
 	@current_version=$(shell golangci-lint version | cut -d " " -f 4);\
@@ -193,9 +193,6 @@ golangci-lint_check:
         echo "ERROR: Expected to have golangci-lint version '$${expected_version}.x' but we have $${current_version}";\
         exit 1;\
     fi
-
-golangci-lint:
-	@make -C src/autoscaler golangci-lint
 
 rubocop:
 	bundle exec rubocop -a

--- a/src/autoscaler/healthendpoint/server.go
+++ b/src/autoscaler/healthendpoint/server.go
@@ -57,12 +57,12 @@ func NewHealthRouter(healthCheckers []Checker, logger lager.Logger, gatherer pro
 	logger.Info("new-health-server", lager.Data{"####username": username, "####password": password})
 	var healthRouter *mux.Router
 	var err error
-	if username == "" && password == "" {
+	if username == "" && password == "" && usernameHash == "" && passwordHash == "" {
 		//when username and password are not set then don't use basic authentication
 		healthRouter = mux.NewRouter()
 		r := promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
-		healthRouter.PathPrefix("").Handler(r)
 		healthRouter.Handle("/health/readiness", common.VarsFunc(readiness(healthCheckers)))
+		healthRouter.PathPrefix("").Handler(r)
 	} else {
 		healthRouter, err = healthBasicAuthRouter(healthCheckers, logger, gatherer, username, password, usernameHash, passwordHash)
 		if err != nil {


### PR DESCRIPTION
If the username and password are empty then basic auth is not applied to the health/prometheus endpoint.
This means if onlu the username_hash and password_hash are supplied then basic auth is not configured the health/prometheus endpoint