### PR TITLE
Replace `go get` and `brew install` with `go run`

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,16 @@
+name: shellcheck
+on: [pull_request]
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          reporter: github-pr-review # Default is github-pr-check # github-pr-review

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,4 +5,4 @@ maven 3.6.3
 nodejs 16.14.0
 ginkgo 2.1.3
 golangci-lint 1.46.1
-
+shellcheck 0.8.0

--- a/scripts/generate_test_certs.sh
+++ b/scripts/generate_test_certs.sh
@@ -5,99 +5,93 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Place keys and certificates here
 depot_path="${script_dir}/../test-certs"
-rm -rf ${depot_path}
-mkdir -p ${depot_path}
+rm -rf "${depot_path}"
+mkdir -p "${depot_path}"
 
-OS=$(uname || "Win")
-if [ ${OS} = "Darwin" ]; then
-  which certstrap >/dev/null || brew install certstrap
-else
-  # Install certstrap
-  which certstrap >/dev/null || go get -v github.com/square/certstrap
-fi
+CERTSTRAP="go run github.com/square/certstrap@v1.2.0"
 
 # CA to distribute to autoscaler certs
-certstrap --depot-path ${depot_path} init --passphrase '' --common-name autoscalerCA --years "20"
-mv -f ${depot_path}/autoscalerCA.crt ${depot_path}/autoscaler-ca.crt
-mv -f ${depot_path}/autoscalerCA.key ${depot_path}/autoscaler-ca.key
+${CERTSTRAP} --depot-path "${depot_path}" init --passphrase '' --common-name autoscalerCA --years "20"
+mv -f "${depot_path}"/autoscalerCA.crt "${depot_path}"/autoscaler-ca.crt
+mv -f "${depot_path}"/autoscalerCA.key "${depot_path}"/autoscaler-ca.key
 
 # CA to distribute to dummy loggregator_agent certs
-certstrap --depot-path ${depot_path} init --passphrase '' --common-name loggregatorCA --years "20"
-mv -f ${depot_path}/loggregatorCA.crt ${depot_path}/loggregator-ca.crt
-mv -f ${depot_path}/loggregatorCA.key ${depot_path}/loggregator-ca.key
+${CERTSTRAP} --depot-path "${depot_path}" init --passphrase '' --common-name loggregatorCA --years "20"
+mv -f "${depot_path}"/loggregatorCA.crt "${depot_path}"/loggregator-ca.crt
+mv -f "${depot_path}"/loggregatorCA.key "${depot_path}"/loggregator-ca.key
 
 # CA for local testing mTLS certs
-certstrap --depot-path ${depot_path} init --passphrase '' --common-name validMTLSLocalCA --years "20"
-mv -f ${depot_path}/validMTLSLocalCA.crt ${depot_path}/valid-mtls-local-ca-1.crt
-mv -f ${depot_path}/validMTLSLocalCA.key ${depot_path}/valid-mtls-local-ca-1.key
-rm -f ${depot_path}/validMTLSLocalCA.crl
-certstrap --depot-path ${depot_path} init --passphrase '' --common-name validMTLSLocalCA --years "20"
-mv -f ${depot_path}/validMTLSLocalCA.crt ${depot_path}/valid-mtls-local-ca-2.crt
-mv -f ${depot_path}/validMTLSLocalCA.key ${depot_path}/valid-mtls-local-ca-2.key
+${CERTSTRAP} --depot-path "${depot_path}" init --passphrase '' --common-name validMTLSLocalCA --years "20"
+mv -f "${depot_path}"/validMTLSLocalCA.crt "${depot_path}"/valid-mtls-local-ca-1.crt
+mv -f "${depot_path}"/validMTLSLocalCA.key "${depot_path}"/valid-mtls-local-ca-1.key
+rm -f "${depot_path}"/validMTLSLocalCA.crl
+${CERTSTRAP} --depot-path "${depot_path}" init --passphrase '' --common-name validMTLSLocalCA --years "20"
+mv -f "${depot_path}"/validMTLSLocalCA.crt "${depot_path}"/valid-mtls-local-ca-2.crt
+mv -f "${depot_path}"/validMTLSLocalCA.key "${depot_path}"/valid-mtls-local-ca-2.key
 
 # CA for local testing mTLS certs (another CA for validating verification)
-certstrap --depot-path ${depot_path} init --passphrase '' --common-name invalidMTLSLocalCA --years "20"
-mv -f ${depot_path}/invalidMTLSLocalCA.crt ${depot_path}/invalid-mtls-local-ca.crt
-mv -f ${depot_path}/invalidMTLSLocalCA.key ${depot_path}/invalid-mtls-local-ca.key
+${CERTSTRAP} --depot-path "${depot_path}" init --passphrase '' --common-name invalidMTLSLocalCA --years "20"
+mv -f "${depot_path}"/invalidMTLSLocalCA.crt "${depot_path}"/invalid-mtls-local-ca.crt
+mv -f "${depot_path}"/invalidMTLSLocalCA.key "${depot_path}"/invalid-mtls-local-ca.key
 
 # metricscollector certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain metricscollector --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign metricscollector --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain metricscollector --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign metricscollector --CA autoscaler-ca --years "20"
 
 # scalingengine certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain scalingengine --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign scalingengine --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain scalingengine --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign scalingengine --CA autoscaler-ca --years "20"
 
 # eventgenerator certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain eventgenerator --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign eventgenerator --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain eventgenerator --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign eventgenerator --CA autoscaler-ca --years "20"
 
 # servicebroker certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain servicebroker --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign servicebroker --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain servicebroker --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign servicebroker --CA autoscaler-ca --years "20"
 # servicebroker certificate for internal
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain servicebroker_internal --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign servicebroker_internal --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain servicebroker_internal --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign servicebroker_internal --CA autoscaler-ca --years "20"
 
 # api certificate for internal connection
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain api --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign api --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain api --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign api --CA autoscaler-ca --years "20"
 
 # api certificate for public api
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain api_public --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign api_public --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain api_public --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign api_public --CA autoscaler-ca --years "20"
 
 # scheduler certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain scheduler --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign scheduler --CA autoscaler-ca --years "20"
-openssl pkcs12 -export -in ${depot_path}/scheduler.crt -inkey ${depot_path}/scheduler.key -out ${depot_path}/scheduler.p12 -name scheduler -password pass:123456
-keytool -importcert -alias autoscaler -file ${depot_path}/autoscaler-ca.crt -keystore ${depot_path}/autoscaler.truststore -storeType pkcs12 -storepass 123456 -noprompt
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain scheduler --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign scheduler --CA autoscaler-ca --years "20"
+openssl pkcs12 -export -in "${depot_path}"/scheduler.crt -inkey "${depot_path}"/scheduler.key -out "${depot_path}"/scheduler.p12 -name scheduler -password pass:123456
+keytool -importcert -alias autoscaler -file "${depot_path}"/autoscaler-ca.crt -keystore "${depot_path}"/autoscaler.truststore -storeType pkcs12 -storepass 123456 -noprompt
 
 
 # # loggregator test server certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain reverselogproxy
-certstrap --depot-path ${depot_path} sign reverselogproxy --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain reverselogproxy
+${CERTSTRAP} --depot-path "${depot_path}" sign reverselogproxy --CA autoscaler-ca --years "20"
 
 # loggregator test client certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain reverselogproxy_client
-certstrap --depot-path ${depot_path} sign reverselogproxy_client --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain reverselogproxy_client
+${CERTSTRAP} --depot-path "${depot_path}" sign reverselogproxy_client --CA autoscaler-ca --years "20"
 
 # metricserver test client certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain metricserver --ip 127.0.0.1
-certstrap --depot-path ${depot_path} sign metricserver --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain metricserver --ip 127.0.0.1
+${CERTSTRAP} --depot-path "${depot_path}" sign metricserver --CA autoscaler-ca --years "20"
 
 # metricserver test client certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain metricserver_client
-certstrap --depot-path ${depot_path} sign metricserver_client --CA autoscaler-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain metricserver_client
+${CERTSTRAP} --depot-path "${depot_path}" sign metricserver_client --CA autoscaler-ca --years "20"
 
 # metricsforwarder certificate for loggregator_agent
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain metron
-certstrap --depot-path ${depot_path} sign metron --CA loggregator-ca --years "20"
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain metron
+${CERTSTRAP} --depot-path "${depot_path}" sign metron --CA loggregator-ca --years "20"
 
 # mTLS client certificate for local testing
 ## certstrap with multiple OU not working at the moment. Pull request is created in the upstream. Therefore, using openssl at the moment
 ## https://github.com/square/certstrap/pull/120
-#certstrap --depot-path ${depot_path} request-cert --passphrase '' --domain local_client --ou "app-id:an-app-id,organization:ORG-GUID,space:SPACE-GUID"
+#${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --domain local_client --ou "app-id:an-app-id,organization:ORG-GUID,space:SPACE-GUID"
 
 OPENSSL_VERSION=$(openssl version)
 if [[ "$OPENSSL_VERSION" == LibreSSL* ]]; then
@@ -105,10 +99,10 @@ if [[ "$OPENSSL_VERSION" == LibreSSL* ]]; then
 	exit 1
 fi
 # valid certificate
-echo ${depot_path}
-openssl  req -new -newkey rsa:2048  -nodes -subj "/CN=sap.com/O=SAP SE/OU=organization:AB1234ORG/OU=app:an-app-id/OU=space:AB1234SPACE" -out ${depot_path}/validmtls_client-1.csr
+echo "${depot_path}"
+openssl  req -new -newkey rsa:2048  -nodes -subj "/CN=sap.com/O=SAP SE/OU=organization:AB1234ORG/OU=app:an-app-id/OU=space:AB1234SPACE" -out "${depot_path}"/validmtls_client-1.csr
 openssl x509 -req -in "${depot_path}"/validmtls_client-1.csr -CA "${depot_path}"/valid-mtls-local-ca-1.crt -CAkey "${depot_path}"/valid-mtls-local-ca-1.key -CAcreateserial -out "${depot_path}"/validmtls_client-1.crt -days 365 -sha256
-openssl  req -new -newkey rsa:2048  -nodes -subj "/CN=sap.com/O=SAP SE/OU=organization:AB1234ORG/OU=app:an-app-id/OU=space:AB1234SPACE" -out ${depot_path}/validmtls_client-2.csr
+openssl  req -new -newkey rsa:2048  -nodes -subj "/CN=sap.com/O=SAP SE/OU=organization:AB1234ORG/OU=app:an-app-id/OU=space:AB1234SPACE" -out "${depot_path}"/validmtls_client-2.csr
 openssl x509 -req -in "${depot_path}"/validmtls_client-2.csr -CA "${depot_path}"/valid-mtls-local-ca-2.crt -CAkey "${depot_path}"/valid-mtls-local-ca-2.key -CAcreateserial -out "${depot_path}"/validmtls_client-2.crt -days 365 -sha256
 
 # remove the generated key

--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -70,12 +70,9 @@ generate:
 	@echo "# Generating counterfeits"
 	@COUNTERFEITER_NO_GENERATE_WARNING=true go generate ./...
 
-get-fmt-deps:
-	go get golang.org/x/tools/cmd/goimports
-
-importfmt: get-fmt-deps
+importfmt:
 	@echo "# Formatting the imports"
-	@goimports -w $(GO_DEPENDENCIES)
+	@go run golang.org/x/tools/cmd/goimports@latest -w $(GO_DEPENDENCIES)
 
 fmt: importfmt
 	@FORMATTED=`go fmt $(PACKAGE_DIRS)`

--- a/src/scheduler/scripts/generate_unit_test_certs.sh
+++ b/src/scheduler/scripts/generate_unit_test_certs.sh
@@ -8,30 +8,24 @@ depot_path="${script_dir}/../src/test/resources/certs"
 rm -rf "${depot_path}"
 mkdir -p "${depot_path}"
 
-OS=$(uname || "Win")
-if [ "${OS}" = "Darwin" ]; then
-  which certstrap >/dev/null || brew install certstrap
-else
-  # Install certstrap
-  which certstrap >/dev/null || go get -v github.com/square/certstrap
-fi
+CERTSTRAP="go run github.com/square/certstrap@v1.2.0"
 
 # CA to distribute to autoscaler certs
-certstrap --depot-path ${depot_path} init --passphrase '' --common-name testCA
-mv -f ${depot_path}/testCA.crt ${depot_path}/test-ca.crt
-mv -f ${depot_path}/testCA.key ${depot_path}/test-ca.key
+${CERTSTRAP} --depot-path "${depot_path}" init --passphrase '' --common-name testCA
+mv -f "${depot_path}"/testCA.crt "${depot_path}"/test-ca.crt
+mv -f "${depot_path}"/testCA.key "${depot_path}"/test-ca.key
 
 
 # scalingengine certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name test-scalingengine --domain localhost
-certstrap --depot-path ${depot_path} sign test-scalingengine --CA test-ca
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --common-name test-scalingengine --domain localhost
+${CERTSTRAP} --depot-path "${depot_path}" sign test-scalingengine --CA test-ca
 
 # scheduler certificate
-certstrap --depot-path ${depot_path} request-cert --passphrase '' --common-name test-scheduler --domain localhost
-certstrap --depot-path ${depot_path} sign test-scheduler --CA test-ca
+${CERTSTRAP} --depot-path "${depot_path}" request-cert --passphrase '' --common-name test-scheduler --domain localhost
+${CERTSTRAP} --depot-path "${depot_path}" sign test-scheduler --CA test-ca
 
-keytool -importcert -alias autoscaler -file ${depot_path}/test-ca.crt -keystore ${depot_path}/test.truststore -storeType pkcs12 -storepass 123456 -noprompt
+keytool -importcert -alias autoscaler -file "${depot_path}"/test-ca.crt -keystore "${depot_path}"/test.truststore -storeType pkcs12 -storepass 123456 -noprompt
 
-openssl pkcs12 -export -in ${depot_path}/test-scheduler.crt -inkey ${depot_path}/test-scheduler.key -out ${depot_path}/test-scheduler.p12 -name test-scheduler -password pass:123456
-openssl pkcs12 -export -in ${depot_path}/test-scalingengine.crt -inkey ${depot_path}/test-scalingengine.key -out ${depot_path}/fake-scalingengine.p12 -name fake-scalingengine -password pass:123456
+openssl pkcs12 -export -in "${depot_path}"/test-scheduler.crt -inkey "${depot_path}"/test-scheduler.key -out "${depot_path}"/test-scheduler.p12 -name test-scheduler -password pass:123456
+openssl pkcs12 -export -in "${depot_path}"/test-scalingengine.crt -inkey "${depot_path}"/test-scalingengine.key -out "${depot_path}"/fake-scalingengine.p12 -name fake-scalingengine -password pass:123456
 


### PR DESCRIPTION
- Replace `go get` and `brew install` with `go run`
  Instead of installing tools such as `certstrap` in an OS-dependent way,
  use `go run` to [run them directly](https://www.alexedwards.net/blog/using-go-run-to-manage-tool-dependencies).
- Add `shellcheck` GHA
