### PR TITLE
Addition of 30s cache on the /health/readiness endpoint

### DIFF
--- a/src/autoscaler/api/cmd/api/main.go
+++ b/src/autoscaler/api/cmd/api/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/cred_helper"
 
@@ -137,7 +138,7 @@ func main() {
 		logger.Error("failed to create public api http server", err)
 		os.Exit(1)
 	}
-	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry, time.Now)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/api/cmd/api/main.go
+++ b/src/autoscaler/api/cmd/api/main.go
@@ -137,9 +137,7 @@ func main() {
 		logger.Error("failed to create public api http server", err)
 		os.Exit(1)
 	}
-	healthServer, err := healthendpoint.NewServerWithBasicAuth([]healthendpoint.Checker{}, logger.Session("health-server"), conf.Health.Port,
-		promRegistry, conf.Health.HealthCheckUsername, conf.Health.HealthCheckPassword, conf.Health.HealthCheckUsernameHash,
-		conf.Health.HealthCheckPasswordHash)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/api/config/config.go
+++ b/src/autoscaler/api/config/config.go
@@ -199,7 +199,7 @@ func (c *Config) Validate() error {
 	if c.RateLimit.ValidDuration <= 0*time.Nanosecond {
 		return fmt.Errorf("Configuration error: RateLimit.ValidDuration is equal or less than zero nanosecond")
 	}
-	if err := c.Health.Validate("api"); err != nil {
+	if err := c.Health.Validate(); err != nil {
 		return err
 	}
 

--- a/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
+++ b/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db/sqldb"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/eventgenerator/aggregator"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/eventgenerator/config"
@@ -102,7 +104,7 @@ func main() {
 		logger.Error("failed to create http server", err)
 		os.Exit(1)
 	}
-	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry, time.Now)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
+++ b/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
@@ -102,7 +102,7 @@ func main() {
 		logger.Error("failed to create http server", err)
 		os.Exit(1)
 	}
-	healthServer, err := healthendpoint.NewServerWithBasicAuth([]healthendpoint.Checker{}, logger.Session("health-server"), conf.Health.Port, promRegistry, conf.Health.HealthCheckUsername, conf.Health.HealthCheckPassword, conf.Health.HealthCheckUsernameHash, conf.Health.HealthCheckPasswordHash)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/eventgenerator/config/config.go
+++ b/src/autoscaler/eventgenerator/config/config.go
@@ -195,7 +195,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("Configuration error: http_client_timeout is less-equal than 0")
 	}
 
-	if err := c.Health.Validate("eventgenerator"); err != nil {
+	if err := c.Health.Validate(); err != nil {
 		return err
 	}
 

--- a/src/autoscaler/healthendpoint/health_readiness.go
+++ b/src/autoscaler/healthendpoint/health_readiness.go
@@ -3,6 +3,9 @@ package healthendpoint
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -10,7 +13,6 @@ type (
 	Pinger interface {
 		Ping() error
 	}
-
 	ReadinessCheck struct {
 		Name   string `json:"name"`
 		Type   string `json:"type"`
@@ -28,28 +30,77 @@ const (
 	statusDown = "DOWN"
 )
 
-func readiness(checkers []Checker, timefunc func() time.Time) func(w http.ResponseWriter, r *http.Request, vars map[string]string) {
-	var response []byte
-	var responseTime time.Time
+type cacheEntry struct {
+	response     *http.Response
+	responseTime time.Time
+	body         []byte
+	sync.RWMutex
+}
+
+func (c *cacheEntry) send(w http.ResponseWriter) {
+	for k, v := range c.response.Header {
+		w.Header().Set(k, strings.Join(v, ","))
+	}
+	w.WriteHeader(c.response.StatusCode)
+	_, _ = w.Write(c.body)
+}
+
+func (c *cacheEntry) isNotStale(currentTime time.Time) bool {
+	return currentTime.Before(c.responseTime.Add(30 * time.Second))
+}
+
+type handler func(w http.ResponseWriter, r *http.Request, vars map[string]string)
+
+func cachedResponse(timefunc func() time.Time, next handler) handler {
+	cached := cacheEntry{}
+	return func(w http.ResponseWriter, r *http.Request, vars map[string]string) {
+		currentTime := timefunc()
+		cached.RLock()
+		if cached.isNotStale(currentTime) {
+			defer cached.RUnlock()
+			cached.send(w)
+			return
+		}
+		cached.RUnlock()
+
+		cached.Lock()
+		defer cached.Unlock()
+		if cached.isNotStale(currentTime) {
+			cached.send(w)
+			return
+		}
+		recorder := httptest.NewRecorder()
+		next(recorder, r, vars)
+		cached.save(currentTime, recorder)
+		cached.send(w)
+	}
+}
+
+func (c *cacheEntry) save(currentTime time.Time, recorder *httptest.ResponseRecorder) {
+	c.responseTime = currentTime
+	c.response = recorder.Result()
+	c.body = recorder.Body.Bytes()
+}
+
+func readiness(checkers []Checker, timefunc func() time.Time) handler {
+	return cachedResponse(timefunc, readinessHandler(checkers))
+}
+func readinessHandler(checkers []Checker) handler {
 	return func(w http.ResponseWriter, r *http.Request, vars map[string]string) {
 		w.Header().Set("Content-Type", "application/json")
-		if len(response) == 0 || timefunc().After(responseTime.Add(30*time.Second)) {
-			checks := make([]ReadinessCheck, 0, 8)
-			overallStatus := statusUp
-			for _, checker := range checkers {
-				check := checker()
-				checks = append(checks, check)
-				if check.Status == statusDown {
-					overallStatus = statusDown
-				}
+		checks := make([]ReadinessCheck, 0, 8)
+		overallStatus := statusUp
+		for _, checker := range checkers {
+			check := checker()
+			checks = append(checks, check)
+			if check.Status == statusDown {
+				overallStatus = statusDown
 			}
-			var err error
-			response, err = json.Marshal(readinessResponse{OverallStatus: overallStatus, Checks: checks})
-			responseTime = timefunc()
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte(`{"error":"Internal error"}`))
-			}
+		}
+		response, err := json.Marshal(readinessResponse{OverallStatus: overallStatus, Checks: checks})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"Internal error"}`))
 		}
 		_, _ = w.Write(response)
 	}

--- a/src/autoscaler/healthendpoint/health_readiness_test.go
+++ b/src/autoscaler/healthendpoint/health_readiness_test.go
@@ -1,8 +1,9 @@
 package healthendpoint_test
 
 import (
-	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 	"net/http"
+
+	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 
 	"github.com/pkg/errors"
 
@@ -40,6 +41,8 @@ var _ = Describe("Health Readiness", func() {
 
 		config.HealthCheckUsername = "test-user-name"
 		config.HealthCheckPassword = "test-user-password"
+		config.HealthCheckUsernameHash = ""
+		config.HealthCheckPasswordHash = ""
 		config.ReadinessCheckEnabled = true
 		checkers = []healthendpoint.Checker{}
 	})
@@ -76,7 +79,7 @@ var _ = Describe("Health Readiness", func() {
 				config.HealthCheckUsernameHash = "username_hash"
 				config.HealthCheckPasswordHash = "username_hash"
 			})
-			When("Prometheus Health endpoint is called", func() {
+			When("Prometheus Health endpoint is called without basic auth", func() {
 				It("should require basic auth", func() {
 					apitest.New().
 						Handler(healthRoute).
@@ -107,7 +110,7 @@ var _ = Describe("Health Readiness", func() {
 		})
 		When("/health/readiness endpoint is called", func() {
 			It("should response OK", func() {
-				apitest.New().Debug().
+				apitest.New().
 					Handler(healthRoute).
 					Get("/health/readiness").
 					Expect(t).

--- a/src/autoscaler/healthendpoint/server.go
+++ b/src/autoscaler/healthendpoint/server.go
@@ -1,6 +1,7 @@
 package healthendpoint
 
 import (
+	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 	"fmt"
 	"net/http"
 	"os"
@@ -37,33 +38,38 @@ func (bam *basicAuthenticationMiddleware) middleware(next http.Handler) http.Han
 
 // NewServerWithBasicAuth open the healthcheck port with basic authentication.
 // Make sure that username and password is not empty
-func NewServerWithBasicAuth(healthCheckers []Checker, logger lager.Logger, port int, gatherer prometheus.Gatherer, username string, password string, usernameHash string, passwordHash string) (ifrit.Runner, error) {
-	healthRouter, err := NewHealthRouter(healthCheckers, logger, gatherer, username, password, usernameHash, passwordHash)
+func NewServerWithBasicAuth(conf models.HealthConfig, healthCheckers []Checker, logger lager.Logger, gatherer prometheus.Gatherer) (ifrit.Runner, error) {
+	healthRouter, err := NewHealthRouter(conf, healthCheckers, logger, gatherer)
 	if err != nil {
 		return nil, err
 	}
 	var addr string
 	if os.Getenv("APP_AUTOSCALER_TEST_RUN") == "true" {
-		addr = fmt.Sprintf("localhost:%d", port)
+		addr = fmt.Sprintf("localhost:%d", conf.Port)
 	} else {
-		addr = fmt.Sprintf("0.0.0.0:%d", port)
+		addr = fmt.Sprintf("0.0.0.0:%d", conf.Port)
 	}
 
 	logger.Info("new-health-server-basic-auth", lager.Data{"addr": addr})
 	return http_server.New(addr, healthRouter), nil
 }
 
-func NewHealthRouter(healthCheckers []Checker, logger lager.Logger, gatherer prometheus.Gatherer, username string, password string, usernameHash string, passwordHash string) (*mux.Router, error) {
-	logger.Info("new-health-server", lager.Data{"####username": username, "####password": password})
+func NewHealthRouter(conf models.HealthConfig, healthCheckers []Checker, logger lager.Logger, gatherer prometheus.Gatherer) (*mux.Router, error) {
 	var healthRouter *mux.Router
 	var err error
-	if username == "" && password == "" && usernameHash == "" && passwordHash == "" {
+	username := conf.HealthCheckUsername
+	password := conf.HealthCheckPassword
+	usernameHash := conf.HealthCheckUsernameHash
+	passwordHash := conf.HealthCheckPasswordHash
+	if username == "" && password == "" && usernameHash == "" && passwordHash == ""{
 		//when username and password are not set then don't use basic authentication
 		healthRouter = mux.NewRouter()
-		r := promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
-		healthRouter.Handle("/health/readiness", common.VarsFunc(readiness(healthCheckers)))
-		healthRouter.PathPrefix("").Handler(r)
+		if conf.ReadinessCheckEnabled {
+			healthRouter.Handle("/health/readiness", common.VarsFunc(readiness(healthCheckers)))
+		}
+		healthRouter.PathPrefix("").Handler(promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}))
 	} else {
+
 		healthRouter, err = healthBasicAuthRouter(healthCheckers, logger, gatherer, username, password, usernameHash, passwordHash)
 		if err != nil {
 			return nil, err

--- a/src/autoscaler/healthendpoint/server.go
+++ b/src/autoscaler/healthendpoint/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 
@@ -39,8 +40,8 @@ func (bam *basicAuthenticationMiddleware) middleware(next http.Handler) http.Han
 
 // NewServerWithBasicAuth open the healthcheck port with basic authentication.
 // Make sure that username and password is not empty
-func NewServerWithBasicAuth(conf models.HealthConfig, healthCheckers []Checker, logger lager.Logger, gatherer prometheus.Gatherer) (ifrit.Runner, error) {
-	healthRouter, err := NewHealthRouter(conf, healthCheckers, logger, gatherer)
+func NewServerWithBasicAuth(conf models.HealthConfig, healthCheckers []Checker, logger lager.Logger, gatherer prometheus.Gatherer, time func() time.Time) (ifrit.Runner, error) {
+	healthRouter, err := NewHealthRouter(conf, healthCheckers, logger, gatherer, time)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,7 @@ func NewServerWithBasicAuth(conf models.HealthConfig, healthCheckers []Checker, 
 	return http_server.New(addr, healthRouter), nil
 }
 
-func NewHealthRouter(conf models.HealthConfig, healthCheckers []Checker, logger lager.Logger, gatherer prometheus.Gatherer) (*mux.Router, error) {
+func NewHealthRouter(conf models.HealthConfig, healthCheckers []Checker, logger lager.Logger, gatherer prometheus.Gatherer, time func() time.Time) (*mux.Router, error) {
 	var healthRouter *mux.Router
 	var err error
 	username := conf.HealthCheckUsername

--- a/src/autoscaler/metricsforwarder/cmd/metricsforwarder/main.go
+++ b/src/autoscaler/metricsforwarder/cmd/metricsforwarder/main.go
@@ -129,15 +129,7 @@ func createCustomMetricsServer(conf *config.Config, logger lager.Logger, policyD
 
 func createHealthServer(policyDB *sqldb.PolicySQLDB, credDb cred_helper.Credentials, logger lager.Logger, conf *config.Config, promRegistry *prometheus.Registry) ifrit.Runner {
 	checkers := []healthendpoint.Checker{healthendpoint.DbChecker(db.PolicyDb, policyDB), healthendpoint.DbChecker(db.StoredProcedureDb, credDb)}
-	healthServer, err := healthendpoint.NewServerWithBasicAuth(
-		checkers,
-		logger.Session("health-server"),
-		conf.Health.Port, promRegistry,
-		conf.Health.HealthCheckUsername,
-		conf.Health.HealthCheckPassword,
-		conf.Health.HealthCheckUsernameHash,
-		conf.Health.HealthCheckPasswordHash,
-	)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, checkers, logger.Session("health-server"), promRegistry)
 	if err != nil {
 		logger.Fatal("Failed to create health server:", err)
 		os.Exit(1)

--- a/src/autoscaler/metricsforwarder/cmd/metricsforwarder/main.go
+++ b/src/autoscaler/metricsforwarder/cmd/metricsforwarder/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/cred_helper"
 
@@ -129,7 +130,7 @@ func createCustomMetricsServer(conf *config.Config, logger lager.Logger, policyD
 
 func createHealthServer(policyDB *sqldb.PolicySQLDB, credDb cred_helper.Credentials, logger lager.Logger, conf *config.Config, promRegistry *prometheus.Registry) ifrit.Runner {
 	checkers := []healthendpoint.Checker{healthendpoint.DbChecker(db.PolicyDb, policyDB), healthendpoint.DbChecker(db.StoredProcedureDb, credDb)}
-	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, checkers, logger.Session("health-server"), promRegistry)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, checkers, logger.Session("health-server"), promRegistry, time.Now)
 	if err != nil {
 		logger.Fatal("Failed to create health server:", err)
 		os.Exit(1)

--- a/src/autoscaler/metricsforwarder/cmd/metricsforwarder/metricsforwarder_suite_test.go
+++ b/src/autoscaler/metricsforwarder/cmd/metricsforwarder/metricsforwarder_suite_test.go
@@ -137,6 +137,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	cfg.Health.HealthCheckUsername = "metricsforwarderhealthcheckuser"
 	cfg.Health.HealthCheckPassword = "metricsforwarderhealthcheckpassword"
+	cfg.Health.ReadinessCheckEnabled = true
 
 	cfg.Server.Port = 10000 + GinkgoParallelProcess()
 	healthport = 8000 + GinkgoParallelProcess()

--- a/src/autoscaler/metricsforwarder/config/config.go
+++ b/src/autoscaler/metricsforwarder/config/config.go
@@ -114,7 +114,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("Configuration error: CredHelperImpl is empty")
 	}
 
-	if err := c.Health.Validate("metricsforwarder"); err != nil {
+	if err := c.Health.Validate(); err != nil {
 		return err
 	}
 

--- a/src/autoscaler/metricsgateway/cmd/metricsgateway/main.go
+++ b/src/autoscaler/metricsgateway/cmd/metricsgateway/main.go
@@ -16,7 +16,7 @@ import (
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/helpers"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsgateway"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsgateway/config"
-	mg_helpers "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsgateway/helpers"
+	mgHelpers "code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsgateway/helpers"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/routes"
 
 	"code.cloudfoundry.org/clock"
@@ -107,7 +107,7 @@ func main() {
 		return nil
 	})
 
-	healthServer, err := healthendpoint.NewServerWithBasicAuth([]healthendpoint.Checker{}, logger.Session("health-server"), conf.Health.Port, promRegistry, conf.Health.HealthCheckUsername, conf.Health.HealthCheckPassword, conf.Health.HealthCheckUsernameHash, conf.Health.HealthCheckPasswordHash)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
 
 	if err != nil {
 		logger.Error("failed to create health server", err)
@@ -164,7 +164,7 @@ func createNozzles(logger lager.Logger, nozzleCount int, shardID string, rlpAddr
 func createEmitters(logger lager.Logger, bufferSize int, eclock clock.Clock, keepAliveInterval time.Duration, metricsServerAddrs []string, metricServerClientTLSConfig *tls.Config, handshakeTimeout time.Duration, maxSetupRetryCount int, maxCloseRetryCount int, retryDelay time.Duration) []metricsgateway.Emitter {
 	emitters := make([]metricsgateway.Emitter, len(metricsServerAddrs))
 	for i := 0; i < len(metricsServerAddrs); i++ {
-		emitter := metricsgateway.NewEnvelopeEmitter(logger, bufferSize, eclock, keepAliveInterval, mg_helpers.NewWSHelper(metricsServerAddrs[i]+routes.EnvelopePath, metricServerClientTLSConfig, handshakeTimeout, logger, maxSetupRetryCount, maxCloseRetryCount, retryDelay))
+		emitter := metricsgateway.NewEnvelopeEmitter(logger, bufferSize, eclock, keepAliveInterval, mgHelpers.NewWSHelper(metricsServerAddrs[i]+routes.EnvelopePath, metricServerClientTLSConfig, handshakeTimeout, logger, maxSetupRetryCount, maxCloseRetryCount, retryDelay))
 		emitters[i] = emitter
 	}
 	return emitters

--- a/src/autoscaler/metricsgateway/cmd/metricsgateway/main.go
+++ b/src/autoscaler/metricsgateway/cmd/metricsgateway/main.go
@@ -107,7 +107,7 @@ func main() {
 		return nil
 	})
 
-	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry, time.Now)
 
 	if err != nil {
 		logger.Error("failed to create health server", err)

--- a/src/autoscaler/metricsgateway/config/config.go
+++ b/src/autoscaler/metricsgateway/config/config.go
@@ -147,7 +147,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("Configuration error: emitter.metrics_server_client_tls.ca_file is empty")
 	}
 
-	if err := c.Health.Validate("metricsgateway"); err != nil {
+	if err := c.Health.Validate(); err != nil {
 		return err
 	}
 

--- a/src/autoscaler/metricsserver/cmd/metricsserver/main.go
+++ b/src/autoscaler/metricsserver/cmd/metricsserver/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db/sqldb"
@@ -122,7 +123,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry, time.Now)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/metricsserver/cmd/metricsserver/main.go
+++ b/src/autoscaler/metricsserver/cmd/metricsserver/main.go
@@ -122,7 +122,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	healthServer, err := healthendpoint.NewServerWithBasicAuth([]healthendpoint.Checker{}, logger.Session("health-server"), conf.Health.Port, promRegistry, conf.Health.HealthCheckUsername, conf.Health.HealthCheckPassword, conf.Health.HealthCheckUsernameHash, conf.Health.HealthCheckPasswordHash)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/metricsserver/config/config.go
+++ b/src/autoscaler/metricsserver/config/config.go
@@ -155,7 +155,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("Configuration error: metric_channel_size is less-equal than 0")
 	}
 
-	if err := c.Health.Validate("metricsserver"); err != nil {
+	if err := c.Health.Validate(); err != nil {
 		return err
 	}
 

--- a/src/autoscaler/models/health.go
+++ b/src/autoscaler/models/health.go
@@ -15,35 +15,35 @@ type HealthConfig struct {
 	ReadinessCheckEnabled   bool   `yaml:"readiness_enabled"`
 }
 
-var ConfigurationErr = fmt.Errorf("configuration error")
+var ErrConfiguration = fmt.Errorf("configuration error")
 
 func (c *HealthConfig) Validate() error {
 	if c.HealthCheckUsername != "" && c.HealthCheckUsernameHash != "" {
-		return fmt.Errorf("%w: both healthcheck username and healthcheck username_hash are set, please provide only one of them", ConfigurationErr)
+		return fmt.Errorf("%w: both healthcheck username and healthcheck username_hash are set, please provide only one of them", ErrConfiguration)
 	}
 
 	if c.HealthCheckPassword != "" && c.HealthCheckPasswordHash != "" {
-		return fmt.Errorf("%w: both healthcheck password and healthcheck password_hash are provided, please provide only one of them", ConfigurationErr)
+		return fmt.Errorf("%w: both healthcheck password and healthcheck password_hash are provided, please provide only one of them", ErrConfiguration)
 	}
 
 	if c.HealthCheckUsernameHash != "" {
 		if _, err := bcrypt.Cost([]byte(c.HealthCheckUsernameHash)); err != nil {
-			return fmt.Errorf("%w: healthcheck username_hash is not a valid bcrypt hash", ConfigurationErr)
+			return fmt.Errorf("%w: healthcheck username_hash is not a valid bcrypt hash", ErrConfiguration)
 		}
 	}
 
 	if c.HealthCheckPasswordHash != "" {
 		if _, err := bcrypt.Cost([]byte(c.HealthCheckPasswordHash)); err != nil {
-			return fmt.Errorf("%w: healthcheck password_hash is not a valid bcrypt hash", ConfigurationErr)
+			return fmt.Errorf("%w: healthcheck password_hash is not a valid bcrypt hash", ErrConfiguration)
 		}
 	}
 
 	if c.HealthCheckUsername == "" && c.HealthCheckPassword != "" {
-		return fmt.Errorf("%w: healthcheck username is empty", ConfigurationErr)
+		return fmt.Errorf("%w: healthcheck username is empty", ErrConfiguration)
 	}
 
 	if c.HealthCheckUsername != "" && c.HealthCheckPassword == "" {
-		return fmt.Errorf("%w: healthcheck password is empty", ConfigurationErr)
+		return fmt.Errorf("%w: healthcheck password is empty", ErrConfiguration)
 	}
 
 	return nil

--- a/src/autoscaler/models/health.go
+++ b/src/autoscaler/models/health.go
@@ -15,33 +15,35 @@ type HealthConfig struct {
 	ReadinessCheckEnabled   bool   `yaml:"readiness_enabled"`
 }
 
-func (c *HealthConfig) Validate(component string) error {
+var ConfigurationErr = fmt.Errorf("configuration error")
+
+func (c *HealthConfig) Validate() error {
 	if c.HealthCheckUsername != "" && c.HealthCheckUsernameHash != "" {
-		return fmt.Errorf("Configuration error: both %s healthcheck username and %s healthcheck username_hash are set, please provide only one of them", component, component)
+		return fmt.Errorf("%w: both healthcheck username and healthcheck username_hash are set, please provide only one of them", ConfigurationErr)
 	}
 
 	if c.HealthCheckPassword != "" && c.HealthCheckPasswordHash != "" {
-		return fmt.Errorf("Configuration error: both %s healthcheck password and %s healthcheck password_hash are empty, please provide one of them", component, component)
+		return fmt.Errorf("%w: both healthcheck password and healthcheck password_hash are provided, please provide only one of them", ConfigurationErr)
 	}
 
 	if c.HealthCheckUsernameHash != "" {
 		if _, err := bcrypt.Cost([]byte(c.HealthCheckUsernameHash)); err != nil {
-			return fmt.Errorf("Configuration error: %s healthcheck username_hash is not a valid bcrypt hash", component)
+			return fmt.Errorf("%w: healthcheck username_hash is not a valid bcrypt hash", ConfigurationErr)
 		}
 	}
 
 	if c.HealthCheckPasswordHash != "" {
 		if _, err := bcrypt.Cost([]byte(c.HealthCheckPasswordHash)); err != nil {
-			return fmt.Errorf("Configuration error: %s healthcheck password_hash is not a valid bcrypt hash", component)
+			return fmt.Errorf("%w: healthcheck password_hash is not a valid bcrypt hash", ConfigurationErr)
 		}
 	}
 
 	if c.HealthCheckUsername == "" && c.HealthCheckPassword != "" {
-		return fmt.Errorf("Configuration error: %s healthcheck username is empty", component)
+		return fmt.Errorf("%w: healthcheck username is empty", ConfigurationErr)
 	}
 
 	if c.HealthCheckUsername != "" && c.HealthCheckPassword == "" {
-		return fmt.Errorf("Configuration error: %s healthcheck password is empty", component)
+		return fmt.Errorf("%w: healthcheck password is empty", ConfigurationErr)
 	}
 
 	return nil

--- a/src/autoscaler/models/health_test.go
+++ b/src/autoscaler/models/health_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
+	"errors"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
@@ -13,31 +14,75 @@ var (
 )
 
 var _ = Describe("Health Config", func() {
-	Context("Readiness enabled", func() {
+	When("Readiness is not supplied", func() {
 		BeforeEach(func() {
 			healthConfigBytes = []byte(`
 port: 9999
 username: test-username
-username_hash: test-username-hash
 password: password
-password_hash: password-hash
 readiness_enabled: false
 `)
 		})
-		It("should have config set", func() {
+		It("should default to false", func() {
 			err := yaml.Unmarshal(healthConfigBytes, &healthConfig)
 			if err != nil {
 				Fail("unable to unmarshal to health config" + err.Error())
 			}
+			err = healthConfig.Validate()
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(healthConfig).To(Equal(models.HealthConfig{
-				Port:                    9999,
-				HealthCheckUsername:     "test-username",
-				HealthCheckUsernameHash: "test-username-hash",
-				HealthCheckPassword:     "password",
-				HealthCheckPasswordHash: "password-hash",
-				ReadinessCheckEnabled:   false,
+				Port:                  9999,
+				HealthCheckUsername:   "test-username",
+				HealthCheckPassword:   "password",
+				ReadinessCheckEnabled: false,
+			}))
+		})
+	})
+	When("readiness is set to true", func() {
+		BeforeEach(func() {
+			healthConfigBytes = []byte(`
+port: 9999
+username: test-username
+password: password
+readiness_enabled: true
+`)
+		})
+		It("should have readiness true when supplied", func() {
+			err := yaml.Unmarshal(healthConfigBytes, &healthConfig)
+			if err != nil {
+				Fail("unable to unmarshal to health config" + err.Error())
+			}
+			err = healthConfig.Validate()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(healthConfig).To(Equal(models.HealthConfig{
+				Port:                  9999,
+				HealthCheckUsername:   "test-username",
+				HealthCheckPassword:   "password",
+				ReadinessCheckEnabled: true,
 			}))
 		})
 	})
 
+	When("both password password_hash are supplied", func() {
+		BeforeEach(func() {
+			healthConfigBytes = []byte(`
+port: 9999
+username: test-username
+password: password
+password_hash: password_hash
+`)
+		})
+		It("should fail validation", func() {
+			err := yaml.Unmarshal(healthConfigBytes, &healthConfig)
+			if err != nil {
+				Fail("unable to unmarshal to health config" + err.Error())
+			}
+			err = healthConfig.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, models.ConfigurationErr)).To(BeTrue())
+			Expect(err.Error()).To(Equal("configuration error: both healthcheck password and healthcheck password_hash are provided, please provide only one of them"))
+		})
+	})
 })

--- a/src/autoscaler/models/health_test.go
+++ b/src/autoscaler/models/health_test.go
@@ -1,8 +1,9 @@
 package models_test
 
 import (
-	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 	"errors"
+
+	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
@@ -14,6 +15,11 @@ var (
 )
 
 var _ = Describe("Health Config", func() {
+	BeforeEach(func() {
+		healthConfigBytes = []byte{}
+		healthConfig = models.HealthConfig{}
+	})
+
 	When("Readiness is not supplied", func() {
 		BeforeEach(func() {
 			healthConfigBytes = []byte(`
@@ -81,7 +87,7 @@ password_hash: password_hash
 			}
 			err = healthConfig.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(errors.Is(err, models.ConfigurationErr)).To(BeTrue())
+			Expect(errors.Is(err, models.ErrConfiguration)).To(BeTrue())
 			Expect(err.Error()).To(Equal("configuration error: both healthcheck password and healthcheck password_hash are provided, please provide only one of them"))
 		})
 	})

--- a/src/autoscaler/operator/cmd/operator/main.go
+++ b/src/autoscaler/operator/cmd/operator/main.go
@@ -160,7 +160,7 @@ func main() {
 	})
 	members = append(grouper.Members{{"db-lock-maintainer", dbLockMaintainer}}, members...)
 
-	healthServer, err := healthendpoint.NewServerWithBasicAuth([]healthendpoint.Checker{}, logger.Session("health-server"), conf.Health.Port, promRegistry, conf.Health.HealthCheckUsername, conf.Health.HealthCheckPassword, conf.Health.HealthCheckUsernameHash, conf.Health.HealthCheckPasswordHash)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/operator/cmd/operator/main.go
+++ b/src/autoscaler/operator/cmd/operator/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/cf"
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"
@@ -160,7 +161,7 @@ func main() {
 	})
 	members = append(grouper.Members{{"db-lock-maintainer", dbLockMaintainer}}, members...)
 
-	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry, time.Now)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/operator/config/config.go
+++ b/src/autoscaler/operator/config/config.go
@@ -202,7 +202,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("Configuration error: http_client_timeout is less-equal than 0")
 	}
 
-	if err := c.Health.Validate("operator"); err != nil {
+	if err := c.Health.Validate(); err != nil {
 		return err
 	}
 

--- a/src/autoscaler/scalingengine/cmd/scalingengine/main.go
+++ b/src/autoscaler/scalingengine/cmd/scalingengine/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/helpers"
 
@@ -104,7 +105,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry, time.Now)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/scalingengine/cmd/scalingengine/main.go
+++ b/src/autoscaler/scalingengine/cmd/scalingengine/main.go
@@ -104,7 +104,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	healthServer, err := healthendpoint.NewServerWithBasicAuth([]healthendpoint.Checker{}, logger.Session("health-server"), conf.Health.Port, promRegistry, conf.Health.HealthCheckUsername, conf.Health.HealthCheckPassword, conf.Health.HealthCheckUsernameHash, conf.Health.HealthCheckPasswordHash)
+	healthServer, err := healthendpoint.NewServerWithBasicAuth(conf.Health, []healthendpoint.Checker{}, logger.Session("health-server"), promRegistry)
 	if err != nil {
 		logger.Error("failed to create health server", err)
 		os.Exit(1)

--- a/src/autoscaler/scalingengine/config/config.go
+++ b/src/autoscaler/scalingengine/config/config.go
@@ -115,7 +115,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("Configuration error: http_client_timeout is less-equal than 0")
 	}
 
-	if err := c.Health.Validate("scalingengine"); err != nil {
+	if err := c.Health.Validate(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- Disabling readiness by default untill cache is available to prevent DOS
- Fixing up the tests and merging main
- Update server.go
- Update health_readiness.go
- Update health_readiness_test.go
- Addition of Thread safe cacheing with a ttl of 30s for the /health/readiness endpoint
