### PR TITLE
Refactor some common funcs from application mains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,8 @@ test-autoscaler-suite: check-db_type init init-db test-certs
 	@echo " - using DBURL=${DBURL} TEST=${TEST} OPTS=${OPTS}"
 	@make -C src/autoscaler testsuite TEST=${TEST} DBURL="${DBURL}" OPTS="${OPTS}"
 test-scheduler: check-db_type init init-db test-certs
-	@cd src && mvn test --no-transfer-progress -Dspring.profiles.include=${db_type} && cd ..
+	@export DB_HOST=${DB_HOST}; \
+	cd src && mvn test --no-transfer-progress -Dspring.profiles.include=${db_type} && cd ..
 test-changelog: init
 	@make -C src/changelog test
 test-changeloglockcleaner: init init-db test-certs

--- a/src/autoscaler/db/sqldb/factories.go
+++ b/src/autoscaler/db/sqldb/factories.go
@@ -1,0 +1,17 @@
+package sqldb
+
+import (
+	"os"
+
+	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"
+	"code.cloudfoundry.org/lager"
+)
+
+func CreatePolicyDb(dbConf db.DatabaseConfig, logger lager.Logger) *PolicySQLDB {
+	policyDB, err := NewPolicySQLDB(dbConf, logger.Session("policy-db"))
+	if err != nil {
+		logger.Fatal("Failed To connect to policyDB", err, lager.Data{"dbConfig": dbConf})
+		os.Exit(1)
+	}
+	return policyDB
+}

--- a/src/autoscaler/operator/cmd/operator/operator_test.go
+++ b/src/autoscaler/operator/cmd/operator/operator_test.go
@@ -329,12 +329,12 @@ var _ = Describe("Operator", Serial, func() {
 			})
 
 			AfterEach(func() {
-				os.Remove(runner.configPath)
+				_ = os.Remove(runner.configPath)
 			})
 
 			It("should error", func() {
-				Eventually(runner.Session).Should(Exit(1))
-				Expect(runner.Session.Buffer()).To(Say("failed to connect policy db"))
+				Eventually(runner.Session).Should(Exit())
+				Expect(runner.Session.Buffer()).To(Say("Failed To connect to policyDB"))
 			})
 
 		})


### PR DESCRIPTION
- Disabling readiness by default untill cache is available to prevent DOS
- Fixing up the tests and merging main
- Update server.go
- Update health_readiness.go
- Update health_readiness_test.go
- Addition of Thread safe cacheing with a ttl of 30s for the /health/readiness endpoint
- initial_refactors
- refactoring policyDB and credentialProvider
