### PR TITLE
Fix database migration for MySQL

### DIFF
--- a/src/common/databasechangelog-primarykey.yml
+++ b/src/common/databasechangelog-primarykey.yml
@@ -4,7 +4,7 @@ databaseChangeLog:
       - not:
         - primaryKeyExists:
             tableName: DATABASECHANGELOG
-            primaryKeyName: "PK_DATABASECHANGELOG"
+            primaryKeyName: "PRIMARY"
   - changeSet:
       id: 1
       author: aqan213

--- a/src/common/databasechangelog-primarykey.yml
+++ b/src/common/databasechangelog-primarykey.yml
@@ -1,17 +1,17 @@
 databaseChangeLog:
-  - preConditions:
-      - onFail: MARK_RAN
-      - not:
-        - primaryKeyExists:
-            tableName: DATABASECHANGELOG
-            primaryKeyName: "PRIMARY"
   - changeSet:
       id: 1
       author: aqan213
       dbms: mysql
+      preConditions:
+      - onFail: MARK_RAN
+      - not:
+        - primaryKeyExists:
+            tableName: DATABASECHANGELOG
+            primaryKeyName: PRIMARY
       changes: 
         - addPrimaryKey:
             columnNames: "id,author,filename"
-            constraintName: "PK_DATABASECHANGELOG"
+            constraintName: PK_DATABASECHANGELOG
             schemaName: autoscaler
             tableName: DATABASECHANGELOG

--- a/src/common/databasechangelog-primarykey.yml
+++ b/src/common/databasechangelog-primarykey.yml
@@ -1,14 +1,14 @@
 databaseChangeLog:
-  - changeSet:
-      id: 1
-      author: aqan213
-      dbms: mysql
-      preConditions:
+  - preConditions:
       - onFail: MARK_RAN
       - not:
         - primaryKeyExists:
             tableName: DATABASECHANGELOG
             primaryKeyName: "PK_DATABASECHANGELOG"
+  - changeSet:
+      id: 1
+      author: aqan213
+      dbms: mysql
       changes: 
         - addPrimaryKey:
             columnNames: "id,author,filename"


### PR DESCRIPTION
When using external mysql database the following error is logged:

```
Starting Liquibase at 11:50:14 (version 4.9.1 #1978 built at 2022-03-28 19:39+0000)
Running Changeset: databasechangelog-primarykey.yml::1::aqan213
Unexpected error running Liquibase: Migration failed for change set databasechangelog-primarykey.yml::1::aqan213:
     Reason: liquibase.exception.DatabaseException: Multiple primary key defined [Failed SQL: (1068) ALTER TABLE autoscaler.DATABASECHANGELOG ADD PRIMARY KEY (id, author, filename)]
```

Checking the database we do see the primary keys:

![Screenshot 2022-05-31 at 3 11 07 PM](https://user-images.githubusercontent.com/31104642/171430534-9911d543-83f5-4f09-bf05-1fdea12147a7.png)

and the change to be executed at least once:

![Screenshot 2022-06-01 at 9 51 46 AM](https://user-images.githubusercontent.com/31104642/171430704-8473f8f8-b93c-47f4-98c5-2ac5ba125a64.png)

Though the constraint name is `PRIMARY`

![Screenshot 2022-06-01 at 2 05 35 PM](https://user-images.githubusercontent.com/31104642/171430819-128397ce-04f5-4bd9-a53f-3fd93203cf03.png)

This is already disccussed [here](https://stackoverflow.com/a/60235230)

With that in mind, the following change updates the `preConditions` to match on `PRIMARY` instead of `PK_DATABASECHANGELOG`. Subsequent deploys honour that and go through fine.
