### PR TITLE
add go.work for multimodule gopls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dev_releases
 blobs
 .dev_builds
 .idea
+.vscode
 .DS_Store
 .final_builds/jobs/**/*.tgz
 .final_builds/packages/**/*.tgz

--- a/go.work
+++ b/go.work
@@ -1,0 +1,8 @@
+go 1.18
+
+use (
+	./src/acceptance
+	./src/autoscaler
+	./src/changelog
+	./src/changeloglockcleaner
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,5 @@
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
Multi-module repos are nativelly supported in go1.18
https://github.com/golang/tools/blob/master/gopls/doc/workspace.md

add .gitignore for vscode