### PR TITLE
fixed stale ci paths

### DIFF
--- a/ci/autoscaler/tasks/deploy-previous-autoscaler.yml
+++ b/ci/autoscaler/tasks/deploy-previous-autoscaler.yml
@@ -29,4 +29,4 @@ inputs:
 outputs:
 
 run:
-  path: app-autoscaler-ci/autoscaler/scripts/deploy-previous-autoscaler.sh
+  path: app-autoscaler-release/ci/autoscaler/scripts/deploy-previous-autoscaler.sh

--- a/ci/autoscaler/tasks/release-autoscaler.yml
+++ b/ci/autoscaler/tasks/release-autoscaler.yml
@@ -22,7 +22,6 @@ params:
 
 inputs:
 - name: app-autoscaler-release
-- name: app-autoscaler-ci
 - name: gh-release
 
 outputs:
@@ -30,4 +29,4 @@ outputs:
 - name: pushme  
 
 run:
-  path: app-autoscaler-ci/autoscaler/scripts/release-autoscaler.sh
+  path: app-autoscaler-release/ci/autoscaler/scripts/release-autoscaler.sh

--- a/ci/autoscaler/tasks/update-sdk/task.yml
+++ b/ci/autoscaler/tasks/update-sdk/task.yml
@@ -9,7 +9,6 @@ image_resource:
 
 inputs:
 - name: app-autoscaler-release
-- name: app-autoscaler-ci
 - name: golang-release
 - name: java-release
 
@@ -22,5 +21,5 @@ params:
   type:
 
 run:
-  path: app-autoscaler-ci/autoscaler/tasks/update-sdk/update_package.sh
+  path: app-autoscaler-release/ci/autoscaler/tasks/update-sdk/update_package.sh
 


### PR DESCRIPTION
At someplaces, old ci paths were used which caused the ci to broke. This PR corrects those references
