### PR TITLE
FIx broken path while creating a PR

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -7,4 +7,4 @@ ginkgo 2.1.3
 golangci-lint 1.46.1
 shellcheck 0.8.0
 act 0.2.26
-concourse 7.7.0
+concourse 7.8.1

--- a/ci/autoscaler/tasks/update-sdk/create_pr.sh
+++ b/ci/autoscaler/tasks/update-sdk/create_pr.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-autoscaler_dir="${script_dir}/../../../../app-autoscaler-release"
+autoscaler_dir="${script_dir}/../../../../../app-autoscaler-release"
 
 
 function configure_git_credentials(){

--- a/ci/autoscaler/tasks/update-sdk/vendor_package.sh
+++ b/ci/autoscaler/tasks/update-sdk/vendor_package.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-root_dir="${script_dir}/../../../.."
+root_dir="${script_dir}/../../../../.."
 autoscaler_dir="${root_dir}/app-autoscaler-release"
 
 function vendor-package {
@@ -11,10 +11,10 @@ function vendor-package {
   local package=${2}
   local version=${3}
   local package_location
-  package_location=$(pwd)/${release}
+  package_location=${root_dir}/${release}
 
   echo "# Building package for ${release} for version '${version}'"
-  cat "${release}/.git/ref" > "${root_dir}/vendored-commit"
+  cat "${root_dir}/${release}/.git/ref" > "${root_dir}/vendored-commit"
 
   pushd "${autoscaler_dir}" > /dev/null
     # generate the private.yml file with the credentials


### PR DESCRIPTION
Fix broken path while creating PR in the concourse CI 
```
+fingerprint: 4c3c9f041ae80eb4373ed31efe56164d0f4733456c3e110d62dd92d310d6b86e
 - updating mod files with 1.18
 - updating .tool-version with 1.18.4
/tmp/build/2ec5f032/app-autoscaler-release/ci/autoscaler/tasks/update-sdk/create_pr.sh: line 24: pushd: /tmp/build/2ec5f032/app-autoscaler-release/ci/autoscaler/tasks/update-sdk/../../../../app-autoscaler-release: No such file or directory
```

Ref build: [https://bosh.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/update-golang/builds/57](https://bosh.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/update-golang/builds/57)