### PR TITLE
Revert "Don't fail `setup-infrastructure` job o enable downstream job after manual action"

### DIFF
--- a/ci/autoscaler/scripts/update-dns-servers.sh
+++ b/ci/autoscaler/scripts/update-dns-servers.sh
@@ -23,4 +23,5 @@ if [ "${BBL_DNS_VALUES}" == "${GCP_DNS_VALUES}" ]; then
   echo "${BBL_DNS_VALUES} is correct"
 else
   echo "dns zone:${GCP_DNS_ZONE} name:${GCP_DNS_NAME} need to be updated to ${BBL_DNS_VALUES}"
+  exit 1
 fi


### PR DESCRIPTION
Removal was unnecessary: After fixing the DNS entries, the job can be retriggered.

Reverts cloudfoundry/app-autoscaler-release#777