### PR TITLE
update-sdk: only set `dependencies` label

### DIFF
--- a/ci/autoscaler/tasks/update-sdk/create_pr.sh
+++ b/ci/autoscaler/tasks/update-sdk/create_pr.sh
@@ -44,5 +44,5 @@ pushd "${autoscaler_dir}" > /dev/null
 
   git push --set-upstream origin "${update_branch}"
 
-  gh pr create --base main --head "${update_branch}" --title "${pr_title}" --body "${pr_description}" --label 'approved' --label 'dependencies'
+  gh pr create --base main --head "${update_branch}" --title "${pr_title}" --body "${pr_description}" --label 'dependencies'
 popd > /dev/null


### PR DESCRIPTION
to not confuse the acceptance tests workflows