### PR TITLE
CI: Scale CF for parallel CATS

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -407,7 +407,7 @@ jobs:
       vars-files: autoscaler-env-vars-store
     params:
       SYSTEM_DOMAIN: autoscaler.ci.cloudfoundry.org
-      OPS_FILES: "operations/scale-to-one-az.yml operations/use-compiled-releases.yml operations/enable_mtls.yml"
+      OPS_FILES: "operations/scale-to-one-az.yml operations/test/scale-to-one-az-addon-parallel-cats.yml operations/use-compiled-releases.yml operations/enable_mtls.yml"
     ensure:
       put: autoscaler-env-vars-store
       params:


### PR DESCRIPTION
Add scale-to-one-az-addon-parallel-cats.yml:

> Use this after the scale-to-one-az ops file to scale up to minimal size
> in order to run CATS quickly without flakes and 12 threads

More context in https://github.com/cloudfoundry/cf-deployment/pull/981 - as far as I understand it, it more or less restores the sizing to what it was before.