### PR TITLE
Improve pid_guard() logic

### DIFF
--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -15,7 +15,7 @@ pid_guard() {
   if [ -f "$pidfile" ]; then
     pid=$(head -1 "$pidfile")
     echo "pidno" $pid
-    if [ -n "$pid" ] && [ -e /proc/$pid ]; then
+    if [ -n "$pid" ] && [ -e /proc/$pid ] && [[ $(readlink /proc/$pid/exe) =~ $name ]]; then
       echo "$name is already running, please stop it first"
       exit 1
     fi

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -15,7 +15,7 @@ pid_guard() {
   if [ -f "$pidfile" ]; then
     pid="$(head -1 $pidfile)"
     echo "pidno $pid"
-    if [ -n "$pid" ] && [ -e "/proc/$pid" ] && [[ "$(readlink /proc/$pid/exe)" =~ "$name" ]]; then
+    if [ -n "$pid" ] && [ -e "/proc/$pid" ] && [[ "$(readlink /proc/$pid/exe)" =~ ^(.*/)?$name$ ]]; then
       echo "$name is already running, please stop it first"
       exit 1
     fi

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -15,7 +15,7 @@ pid_guard() {
   if [ -f "$pidfile" ]; then
     pid="$(head -1 $pidfile)"
     echo "pidno $pid"
-    if [ -n "$pid" ] && [ -e "/proc/$pid" ] && [[ "$(readlink /proc/$pid/exe)" =~ ^(.*/)?$name$ ]]; then
+    if [ -n "$pid" ] && [ -e "/proc/$pid" ] && grep -q "/var/vcap/packages/$name" "/proc/$pid/cmdline"; then
       echo "$name is already running, please stop it first"
       exit 1
     fi

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -15,7 +15,7 @@ pid_guard() {
   if [ -f "$pidfile" ]; then
     pid="$(head -1 $pidfile)"
     echo "pidno $pid"
-    if [ -n "$pid" ] && [ -e "/proc/$pid" ] && [[ "$(readlink /proc/$pid/exe)" =~ $name ]]; then
+    if [ -n "$pid" ] && [ -e "/proc/$pid" ] && [[ "$(readlink /proc/$pid/exe)" =~ "$name" ]]; then
       echo "$name is already running, please stop it first"
       exit 1
     fi

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -13,9 +13,9 @@ pid_guard() {
   name=$2
 
   if [ -f "$pidfile" ]; then
-    pid=$(head -1 "$pidfile")
-    echo "pidno" $pid
-    if [ -n "$pid" ] && [ -e /proc/$pid ] && [[ $(readlink /proc/$pid/exe) =~ $name ]]; then
+    pid="$(head -1 $pidfile)"
+    echo "pidno $pid"
+    if [ -n "$pid" ] && [ -e "/proc/$pid" ] && [[ "$(readlink /proc/$pid/exe)" =~ $name ]]; then
       echo "$name is already running, please stop it first"
       exit 1
     fi


### PR DESCRIPTION
In a context like K8s,  where a job is a container the following check could be not accurate
https://github.com/cloudfoundry/app-autoscaler-release/blob/064e00649a8b8db86b63b2428c6515aace418c30/src/common/utils.sh#L18

In general inside the container a number of processes really small exist...
```
/:/var/vcap/jobs/operator# ps -ef
UID         PID   PPID  C STIME TTY          TIME CMD
root          1      0  0 08:37 ?        00:00:00 /usr/bin/dumb-init -- /var/vcap/all-releases/container-run/container-run --post-start-name /var/vcap/jobs/operator/bin/post-start --job-name operator --process-n
root          6      1  0 08:37 ?        00:00:00 /var/vcap/all-releases/container-run/container-run --post-start-name /var/vcap/jobs/operator/bin/post-start --job-name operator --process-name operator -- /var/v
root         12      6  0 08:37 ?        00:00:04 /var/vcap/packages/operator/operator -c /var/vcap/jobs/operator/config/operator.yml
root         15     12  0 08:37 ?        00:00:00 [operator_ctl] <defunct>
root         16     12  0 08:37 ?        00:00:00 [operator_ctl] <defunct>
root       3348      0  0 10:09 pts/0    00:00:00 bash
root       3374   3348  0 10:09 pts/0    00:00:00 ps -ef
```
So may happen that if the container crashes and k8s restarts it then PIDFILE could point to a process that is not really the one that we think is. 
And pid_guard() will exit with return code 1 https://github.com/cloudfoundry/app-autoscaler-release/blob/064e00649a8b8db86b63b2428c6515aace418c30/src/common/utils.sh#L20
After that the container will be in CrashLoopBackOff state
`kube-c2nraggl083co6imrip0-deveugbcont-commong-000099ed kubelet.log E0728 19:35:32.805457    5786 pod_workers.go:951] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"operator-operator\" with CrashLoopBackOff: \"back-off 5m0s restarting failed container=operator-operator pod=asactors-0_cf-autoscaler(76c589db-7e5e-4672-b791-e715d027aac8)\"" pod="cf-autoscaler/asactors-0" podUID=76c589db-7e5e-4672-b791-e715d027aac8`

This PR fixes #798 by checking the `cmdline` as well.