### PR TITLE
run `scripts/update`

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -19,12 +19,11 @@ jobs:
             git status
           popd
 
-      - name: Check if there are changes
-        id: changes
-        uses: UnicornGlobal/has-changes-action@v1.0.12
-
+      - name: Check if there is any change
+        id: get_changes
+        run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
       - name: Process changes
-        if: steps.changes.outputs.changed == 1
+        if: steps.get_changes.outputs.changed != 0
         run: |
           echo "::error::Fakes are out of date, run make generate to update"
           exit 1

--- a/.github/workflows/tidy-go-mod.yaml
+++ b/.github/workflows/tidy-go-mod.yaml
@@ -1,0 +1,23 @@
+name: Check if go.mod is tidy
+on:
+  pull_request:
+jobs:
+  check-tidy-go-mod:
+    name: ensure that go mod tidy has run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup_go
+      - uses: ./.github/actions/setup_java
+
+      - name: Run scripts/update
+        run: scripts/update
+
+      - name: Check if there is any change
+        id: get_changes
+        run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
+      - name: Process changes
+        if: steps.get_changes.outputs.changed != 0
+        run: |
+          echo "::error::go.mod is not tidy, run scripts/update to tidy"
+          exit 1

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,6 @@ ruby 2.7.5
 maven 3.6.3
 nodejs 16.14.0
 ginkgo 2.1.3
-golangci-lint 1.47.1
 shellcheck 0.8.0
 act 0.2.26
 concourse 7.8.1

--- a/Makefile
+++ b/Makefile
@@ -191,23 +191,16 @@ integration: build init-db test-certs
 	make -C src/autoscaler integration DBURL="${DBURL}" OPTS="${OPTS}"
 
 .PHONY:lint $(addprefix lint_,$(go_modules))
-lint: golangci-lint_check $(addprefix lint_,$(go_modules))
-
-golangci-lint_check:
-	@current_version=$(shell golangci-lint version | cut -d " " -f 4);\
-	current_major_version=$(shell golangci-lint version | cut -d " " -f 4| sed -E 's/v*([0-9]+\.[0-9]+)\..*/\1/');\
-	expected_version=$(shell cat src/autoscaler/go.mod | grep golangci-lint  | cut -d " " -f 2 | sed -E 's/v([0-9]+\.[0-9]+)\..*/\1/');\
-	if [ "$${current_major_version}" != "$${expected_version}" ]; then \
-        echo "ERROR: Expected to have golangci-lint version '$${expected_version}.x' but we have $${current_version}";\
-        exit 1;\
-    fi
+lint: $(addprefix lint_,$(go_modules))
 
 rubocop:
 	bundle exec rubocop -a
 
 $(addprefix lint_,$(go_modules)): lint_%:
-	@echo " - linting: $(patsubst lint_%,%,$@)"
-	@pushd src/$(patsubst lint_%,%,$@) >/dev/null && golangci-lint --config ${lint_config} run ${OPTS}
+	@golangci_version=$(shell cat src/autoscaler/go.mod | grep golangci-lint  | cut -d " " -f 2);\
+	echo " - linting: $(patsubst lint_%,%,$@)";\
+	pushd src/$(patsubst lint_%,%,$@) >/dev/null;\
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$${golangci_version} --config ${lint_config} run ${OPTS}
 
 .PHONY: spec-test
 spec-test:

--- a/jobs/golangapiserver/spec
+++ b/jobs/golangapiserver/spec
@@ -226,7 +226,6 @@ properties:
     default: 10
   autoscaler.storedprocedure_db_connection_config.connection_max_lifetime:
     default: 60s
-
   autoscaler.cf.api:
     description: "the Cloud Foundry API endpoint"
   autoscaler.cf.client_id:
@@ -242,7 +241,6 @@ properties:
   autoscaler.cf.max_retry_wait_ms:
     description: "The maximum amount of time in milliseconds to wait between retries. 0 leaves it to the implementation to decide"
     default: 0
-
   autoscaler.changeloglock_timeout_seconds:
     default: 180
     description: "Liquibase changelog lock timeout duration in seconds"

--- a/src/autoscaler/go.mod
+++ b/src/autoscaler/go.mod
@@ -48,6 +48,7 @@ require (
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	google.golang.org/grpc v1.48.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -225,7 +226,6 @@ require (
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.3.3 // indirect
 	mvdan.cc/gofumpt v0.3.1 // indirect
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect


### PR DESCRIPTION
- `go run` the right `golangci-lint` version
- Run `scripts/update` and ensure that it has been run via GHA
- Replace UnicornGlobal/has-changes-action (see https://github.com/UnicornGlobal/has-changes-action/issues/5#issuecomment-1126126476)
