### PR TITLE
Bump `postgres` release to 36

### DIFF
--- a/operations/add-releases.yml
+++ b/operations/add-releases.yml
@@ -6,9 +6,9 @@
   - name: app-autoscaler
     version: latest
   - name: "postgres"
-    version: "35"
-    url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=35"
-    sha1: "8a30528f55a1add20562eff4bd9c11a3f970865e"
+    version: "36"
+    url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=36"
+    sha1: "3dd10b417b21cfa3257f1cc891e9e46f02fefe16"
   - name: bosh-dns-aliases
     url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
     version: '0.0.3'

--- a/templates/app-autoscaler-deployment.yml
+++ b/templates/app-autoscaler-deployment.yml
@@ -7,9 +7,9 @@ releases:
 - name: app-autoscaler
   version: latest
 - name: "postgres"
-  version: "35"
-  url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=35"
-  sha1: "8a30528f55a1add20562eff4bd9c11a3f970865e"
+  version: "36"
+  url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=36"
+  sha1: "3dd10b417b21cfa3257f1cc891e9e46f02fefe16"
 - name: bosh-dns-aliases
   url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-aliases-release?v=0.0.3
   version: '0.0.3'


### PR DESCRIPTION
Provides PostgreSQL 11.2 - see #478