### PR TITLE
Audit on Db connetions lead to fix for returning DB errors correctly

### DIFF
--- a/src/autoscaler/db/sqldb/appmetric_sqldb.go
+++ b/src/autoscaler/db/sqldb/appmetric_sqldb.go
@@ -169,10 +169,7 @@ func (adb *AppMetricSQLDB) RetrieveAppMetrics(appIdP string, metricTypeP string,
 		adb.logger.Error("retrieve-app-metric-list-from-app_metric-table", err, lager.Data{"query": query})
 		return nil, err
 	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 	var appId string
 	var metricType string
 	var unit string
@@ -193,7 +190,7 @@ func (adb *AppMetricSQLDB) RetrieveAppMetrics(appIdP string, metricTypeP string,
 		}
 		appMetricList = append(appMetricList, appMetric)
 	}
-	return appMetricList, nil
+	return appMetricList, rows.Err()
 }
 
 func (adb *AppMetricSQLDB) PruneAppMetrics(before int64) error {

--- a/src/autoscaler/db/sqldb/binding_sqldb.go
+++ b/src/autoscaler/db/sqldb/binding_sqldb.go
@@ -165,10 +165,7 @@ func (bdb *BindingSQLDB) DeleteServiceInstance(serviceInstanceId string) error {
 		return err
 	}
 
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	if rows.Next() {
 		query = bdb.sqldb.Rebind("DELETE FROM service_instance WHERE service_instance_id =?")
@@ -177,6 +174,12 @@ func (bdb *BindingSQLDB) DeleteServiceInstance(serviceInstanceId string) error {
 		if err != nil {
 			bdb.logger.Error("delete-service-instance", err, lager.Data{"query": query, "serviceinstanceid": serviceInstanceId})
 		}
+		return err
+	}
+
+	err = rows.Err()
+	if err != nil {
+		bdb.logger.Error("delete-service-instance-row", err, lager.Data{"query": query, "serviceinstanceid": serviceInstanceId})
 		return err
 	}
 
@@ -191,13 +194,16 @@ func (bdb *BindingSQLDB) CreateServiceBinding(bindingId string, serviceInstanceI
 		return err
 	}
 
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	if rows.Next() {
 		return db.ErrAlreadyExists
+	}
+
+	err = rows.Err()
+	if err != nil {
+		bdb.logger.Error("create-service-binding", err, lager.Data{"query": query, "appId": appId, "serviceId": serviceInstanceId, "bindingId": bindingId})
+		return err
 	}
 
 	query = bdb.sqldb.Rebind("INSERT INTO binding" +
@@ -218,10 +224,7 @@ func (bdb *BindingSQLDB) DeleteServiceBinding(bindingId string) error {
 		return err
 	}
 
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	if rows.Next() {
 		query = bdb.sqldb.Rebind("DELETE FROM binding WHERE binding_id =?")
@@ -230,6 +233,12 @@ func (bdb *BindingSQLDB) DeleteServiceBinding(bindingId string) error {
 		if err != nil {
 			bdb.logger.Error("delete-service-binding", err, lager.Data{"query": query, "bindingid": bindingId})
 		}
+		return err
+	}
+
+	err = rows.Err()
+	if err != nil {
+		bdb.logger.Error("delete-service-binding-row", err, lager.Data{"query": query, "bindingId": bindingId})
 		return err
 	}
 
@@ -277,10 +286,7 @@ func (bdb *BindingSQLDB) GetAppIdsByInstanceId(instanceId string) ([]string, err
 		return appIds, err
 	}
 
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	var appId string
 	for rows.Next() {
@@ -291,7 +297,7 @@ func (bdb *BindingSQLDB) GetAppIdsByInstanceId(instanceId string) ([]string, err
 		appIds = append(appIds, appId)
 	}
 
-	return appIds, nil
+	return appIds, rows.Err()
 }
 
 func (bdb *BindingSQLDB) CountServiceInstancesInOrg(orgId string) (int, error) {
@@ -313,10 +319,7 @@ func (bdb *BindingSQLDB) GetBindingIdsByInstanceId(instanceId string) ([]string,
 		bdb.logger.Error("get-appids-from-binding-table", err, lager.Data{"query": query, "instanceId": instanceId})
 		return bindingIds, err
 	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	var appId string
 	for rows.Next() {
@@ -327,5 +330,5 @@ func (bdb *BindingSQLDB) GetBindingIdsByInstanceId(instanceId string) ([]string,
 		bindingIds = append(bindingIds, appId)
 	}
 
-	return bindingIds, nil
+	return bindingIds, rows.Err()
 }

--- a/src/autoscaler/db/sqldb/instancemetrics_sqldb.go
+++ b/src/autoscaler/db/sqldb/instancemetrics_sqldb.go
@@ -198,10 +198,7 @@ func (idb *InstanceMetricsSQLDB) RetrieveInstanceMetrics(appid string, instanceI
 		}
 	}
 
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	mtrcs := []*models.AppInstanceMetric{}
 	var index uint32
@@ -230,7 +227,7 @@ func (idb *InstanceMetricsSQLDB) RetrieveInstanceMetrics(appid string, instanceI
 		}
 		mtrcs = append(mtrcs, &metric)
 	}
-	return mtrcs, nil
+	return mtrcs, rows.Err()
 }
 func (idb *InstanceMetricsSQLDB) PruneInstanceMetrics(before int64) error {
 	query := idb.sqldb.Rebind("DELETE FROM appinstancemetrics WHERE timestamp <= ?")

--- a/src/autoscaler/db/sqldb/policy_sqldb.go
+++ b/src/autoscaler/db/sqldb/policy_sqldb.go
@@ -75,10 +75,7 @@ func (pdb *PolicySQLDB) GetAppIds() (map[string]bool, error) {
 		pdb.logger.Error("get-appids-from-policy-table", err, lager.Data{"query": query})
 		return nil, err
 	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	var id string
 	for rows.Next() {
@@ -88,7 +85,7 @@ func (pdb *PolicySQLDB) GetAppIds() (map[string]bool, error) {
 		}
 		appIds[id] = true
 	}
-	return appIds, nil
+	return appIds, rows.Err()
 }
 
 func (pdb *PolicySQLDB) RetrievePolicies() ([]*models.PolicyJson, error) {
@@ -101,10 +98,7 @@ func (pdb *PolicySQLDB) RetrievePolicies() ([]*models.PolicyJson, error) {
 		return policyList, err
 	}
 
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	var appId string
 	var policyStr string
@@ -120,7 +114,7 @@ func (pdb *PolicySQLDB) RetrievePolicies() ([]*models.PolicyJson, error) {
 		}
 		policyList = append(policyList, &policyJson)
 	}
-	return policyList, nil
+	return policyList, rows.Err()
 }
 
 func (pdb *PolicySQLDB) GetAppPolicy(appId string) (*models.ScalingPolicy, error) {

--- a/src/autoscaler/db/sqldb/scalingengine_sqldb.go
+++ b/src/autoscaler/db/sqldb/scalingengine_sqldb.go
@@ -100,10 +100,7 @@ func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int6
 		return nil, err
 	}
 
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	var timestamp int64
 	var scalingType, status, oldInstances, newInstances int
@@ -131,7 +128,7 @@ func (sdb *ScalingEngineSQLDB) RetrieveScalingHistories(appId string, start int6
 			histories = append(histories, &history)
 		}
 	}
-	return histories, nil
+	return histories, rows.Err()
 }
 
 func (sdb *ScalingEngineSQLDB) PruneScalingHistories(before int64) error {
@@ -150,10 +147,7 @@ func (sdb *ScalingEngineSQLDB) CanScaleApp(appId string) (bool, int64, error) {
 		sdb.logger.Error("can-scale-app-query-record", err, lager.Data{"query": query, "appid": appId})
 		return false, 0, err
 	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	var expireAt int64 = 0
 	if rows.Next() {
@@ -167,7 +161,7 @@ func (sdb *ScalingEngineSQLDB) CanScaleApp(appId string) (bool, int64, error) {
 			return false, expireAt, nil
 		}
 	}
-	return true, expireAt, nil
+	return true, expireAt, rows.Err()
 }
 
 func (sdb *ScalingEngineSQLDB) UpdateScalingCooldownExpireTime(appId string, expireAt int64) error {
@@ -216,10 +210,7 @@ func (sdb *ScalingEngineSQLDB) GetActiveSchedules() (map[string]string, error) {
 		sdb.logger.Error("failed-get-active-schedules", err, lager.Data{"query": query})
 		return nil, err
 	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	schedules := make(map[string]string)
 	var id, appId string
@@ -230,7 +221,7 @@ func (sdb *ScalingEngineSQLDB) GetActiveSchedules() (map[string]string, error) {
 		}
 		schedules[appId] = id
 	}
-	return schedules, nil
+	return schedules, rows.Err()
 }
 
 func (sdb *ScalingEngineSQLDB) RemoveActiveSchedule(appId string) error {

--- a/src/autoscaler/db/sqldb/scheduler_sqldb.go
+++ b/src/autoscaler/db/sqldb/scheduler_sqldb.go
@@ -64,10 +64,7 @@ func (sdb *SchedulerSQLDB) GetActiveSchedules() (map[string]*models.ActiveSchedu
 		sdb.logger.Error("failed-get-active-schedules-query", err, lager.Data{"query": query})
 		return nil, err
 	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 
 	schedules := make(map[string]*models.ActiveSchedule)
 	var id int64
@@ -92,7 +89,7 @@ func (sdb *SchedulerSQLDB) GetActiveSchedules() (map[string]*models.ActiveSchedu
 		}
 		schedules[appId] = &schedule
 	}
-	return schedules, nil
+	return schedules, rows.Err()
 }
 
 func (sdb *SchedulerSQLDB) GetDBStatus() sql.DBStats {

--- a/src/autoscaler/db/sqldb/sqldb_suite_test.go
+++ b/src/autoscaler/db/sqldb/sqldb_suite_test.go
@@ -95,14 +95,11 @@ func cleanInstanceMetricsTableForApp(appId string) {
 func hasInstanceMetric(appId string, index int, name string, timestamp int64) bool {
 	query := dbHelper.Rebind("SELECT * FROM appinstancemetrics WHERE appid = ? AND instanceindex = ? AND name = ? AND timestamp = ?")
 	rows, e := dbHelper.Query(query, appId, index, name, timestamp)
-	if e != nil {
-		Fail("can not query table appinstancemetrics: " + e.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
-	return rows.Next()
+	FailOnError("can not query table appinstancemetrics: ", e)
+	defer func() { _ = rows.Close() }()
+	item := rows.Next()
+	FailOnError("can not query table appinstancemetrics: ", rows.Err())
+	return item
 }
 
 func getNumberOfInstanceMetricsForApp(appId string) int {
@@ -117,41 +114,31 @@ func getNumberOfInstanceMetricsForApp(appId string) int {
 func hasServiceInstance(serviceInstanceId string) bool {
 	query := dbHelper.Rebind("SELECT * FROM service_instance WHERE service_instance_id = ?")
 	rows, e := dbHelper.Query(query, serviceInstanceId)
-	if e != nil {
-		Fail("can not query table service_instance: " + e.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
-	return rows.Next()
+	FailOnError("can not query table service_instance: ", e)
+	defer func() { _ = rows.Close() }()
+	item := rows.Next()
+	FailOnError("can not query table appinstancemetrics: ", rows.Err())
+	return item
 }
 
 func hasServiceInstanceWithNullDefaultPolicy(serviceInstanceId string) bool {
 	query := dbHelper.Rebind("SELECT * FROM service_instance WHERE service_instance_id = ? AND default_policy IS NULL AND default_policy_guid IS NULL")
 	rows, e := dbHelper.Query(query, serviceInstanceId)
-	if e != nil {
-		Fail("can not query table service_instance: " + e.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
-
-	return rows.Next()
+	FailOnError("can not query table service_instance: ", e)
+	defer func() { _ = rows.Close() }()
+	item := rows.Next()
+	FailOnError("can not query table appinstancemetrics: ", rows.Err())
+	return item
 }
 
 func hasServiceBinding(bindingId string, serviceInstanceId string) bool {
 	query := dbHelper.Rebind("SELECT * FROM binding WHERE binding_id = ? AND service_instance_id = ? ")
 	rows, e := dbHelper.Query(query, bindingId, serviceInstanceId)
-	if e != nil {
-		Fail("can not query table binding: " + e.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
-	return rows.Next()
+	FailOnError("can not query table binding: ", e)
+	defer func() { _ = rows.Close() }()
+	item := rows.Next()
+	FailOnError("can not query table binding: ", rows.Err())
+	return item
 }
 
 func cleanPolicyTable() {
@@ -194,15 +181,13 @@ func getAppPolicy(appId string) string {
 	query := dbHelper.Rebind("SELECT policy_json FROM policy_json WHERE app_id=? ")
 	rows, err := dbHelper.Query(query, appId)
 	FailOnError("failed to get policy", err)
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 	var policyJsonStr string
 	if rows.Next() {
 		err = rows.Scan(&policyJsonStr)
 		FailOnError("failed to scan policy", err)
 	}
+	FailOnError("failed to scan policy rows", rows.Err())
 	return policyJsonStr
 }
 
@@ -214,14 +199,10 @@ func cleanAppMetricTable(appId string) {
 
 func hasAppMetric(appId, metricType string, timestamp int64, value string) bool {
 	query := dbHelper.Rebind("SELECT * FROM app_metric WHERE app_id = ? AND metric_type = ? AND timestamp = ? AND value = ?")
-	rows, e := dbHelper.Query(query, appId, metricType, timestamp, value)
-	if e != nil {
-		Fail("can not query table app_metric: " + e.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	rows, err := dbHelper.Query(query, appId, metricType, timestamp, value)
+	FailOnError("can not query table app_metric", err)
+	defer func() { _ = rows.Close() }()
+	FailOnError("can not query table app_metric", rows.Err())
 	return rows.Next()
 }
 
@@ -253,14 +234,11 @@ func removeActiveScheduleForApp(appId string) {
 func hasScalingHistory(appId string, timestamp int64) bool {
 	query := dbHelper.Rebind("SELECT * FROM scalinghistory WHERE appid = ? AND timestamp = ?")
 	rows, e := dbHelper.Query(query, appId, timestamp)
-	if e != nil {
-		Fail("can not query table scalinghistory: " + e.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
-	return rows.Next()
+	FailOnError("can not query table scalinghistory: ", e)
+	defer func() { _ = rows.Close() }()
+	next := rows.Next()
+	FailOnError("can not query table scalinghistory: ", rows.Err())
+	return next
 }
 
 func getScalingHistoryForApp(appId string) int {
@@ -275,14 +253,11 @@ func getScalingHistoryForApp(appId string) int {
 func hasScalingCooldownRecord(appId string, expireAt int64) bool {
 	query := dbHelper.Rebind("SELECT * FROM scalingcooldown WHERE appid = ? AND expireat = ?")
 	rows, e := dbHelper.Query(query, appId, expireAt)
-	if e != nil {
-		Fail("can not query table scalingcooldown: " + e.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
-	return rows.Next()
+	FailOnError("can not query table scalingcooldown: ", e)
+	defer func() { _ = rows.Close() }()
+	item := rows.Next()
+	FailOnError("can not query table scalingcooldown:", rows.Err())
+	return item
 }
 
 func insertActiveSchedule(appId, scheduleId string, instanceMin, instanceMax, instanceMinInitial int) error {
@@ -323,28 +298,22 @@ func getCredential(appId string) (string, string, error) {
 	query := dbHelper.Rebind("SELECT username,password FROM credentials WHERE id=? ")
 	rows, err := dbHelper.Query(query, appId)
 	FailOnError("failed to get credential", err)
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
+	defer func() { _ = rows.Close() }()
 	var username, password string
 	if rows.Next() {
 		err = rows.Scan(&username, &password)
 		FailOnError("failed to scan credential", err)
 	}
-	return username, password, nil
+	return username, password, rows.Err()
 }
 func hasCredential(appId string) bool {
 	query := dbHelper.Rebind("SELECT * FROM credentials WHERE id=?")
 	rows, e := dbHelper.Query(query, appId)
-	if e != nil {
-		Fail("can not query table credentials: " + e.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-		_ = rows.Err()
-	}()
-	return rows.Next()
+	FailOnError("can not query table credentials: ", e)
+	defer func() { _ = rows.Close() }()
+	item := rows.Next()
+	FailOnError("hasCredential failed", rows.Err())
+	return item
 }
 
 func insertLockDetails(lock *models.Lock) (sql.Result, error) {


### PR DESCRIPTION
While iterating over a query table it is possible to get an error while retrieving the next row. 
This is only reported in the row.Err() function and the next returns false. 
This means that you need to return the error from the row.Err if you itterate so that you know if you iterated over all the results for the query.