### PR TITLE
Fixes not reusing tcp connections by reading all bytes from the response body #814

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ lint: $(addprefix lint_,$(go_modules)) eslint rubocop
 .PHONY: rubocop
 rubocop:
 	@echo " - ruby scripts"
+	@bundle install
 	@bundle exec rubocop ./spec ./packages
 
 .PHONY: eslint

--- a/src/autoscaler/cf/client.go
+++ b/src/autoscaler/cf/client.go
@@ -104,7 +104,7 @@ func NewCFClient(conf *Config, logger lager.Logger, clk clock.Clock) *Client {
 		cfhttp.WithTLSConfig(&tls.Config{InsecureSkipVerify: conf.SkipSSLValidation}),
 		cfhttp.WithDialTimeout(30*time.Second),
 	)
-
+	c.httpClient.Transport = DrainingTransport{c.httpClient.Transport}
 	c.retryClient = createRetryClient(conf, c.httpClient, logger)
 	c.lock = &sync.Mutex{}
 

--- a/src/autoscaler/cf/drain_transport.go
+++ b/src/autoscaler/cf/drain_transport.go
@@ -1,0 +1,35 @@
+package cf
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+type TripBody struct {
+	io.ReadCloser
+}
+
+func (t TripBody) Close() error {
+	_, _ = io.Copy(ioutil.Discard, t.ReadCloser)
+
+	return t.ReadCloser.Close()
+}
+
+var _ io.ReadCloser = TripBody{}
+
+var _ http.RoundTripper = DrainingTransport{}
+
+type DrainingTransport struct {
+	Transport http.RoundTripper
+}
+
+func (d DrainingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	resp, err := d.Transport.RoundTrip(request)
+
+	if err != nil {
+		return resp, err
+	}
+	resp.Body = TripBody{resp.Body}
+	return resp, nil
+}

--- a/src/autoscaler/cf/drain_transport_test.go
+++ b/src/autoscaler/cf/drain_transport_test.go
@@ -1,0 +1,85 @@
+package cf_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/cf"
+	"github.com/stretchr/testify/assert"
+)
+
+type FakeReadCloser struct {
+	io.Reader
+	io.Closer
+
+	numBytes       int
+	closeWasCalled bool
+}
+
+func (f *FakeReadCloser) Read(p []byte) (int, error) {
+	n, err := f.Reader.Read(p)
+
+	f.numBytes += n
+
+	return n, err
+}
+
+func (f *FakeReadCloser) Close() error {
+	f.closeWasCalled = true
+	return nil
+}
+
+var _ io.ReadCloser = &FakeReadCloser{}
+
+type testRoundTripper struct {
+	req *http.Request
+	res *http.Response
+	err error
+}
+
+func (t *testRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	t.req = request
+	return t.res, t.err
+}
+
+var _ http.RoundTripper = &testRoundTripper{}
+
+func TestRoundTripper(t *testing.T) {
+	tripResp := &http.Response{}
+	testT := &testRoundTripper{res: tripResp}
+
+	transport := cf.DrainingTransport{Transport: testT}
+	req, _ := http.NewRequest("GET", "some-url", nil)
+	resp, _ := transport.RoundTrip(req)
+
+	assert.Equal(t, testT.req, req)
+	assert.Equal(t, resp, tripResp)
+}
+
+func TestTripBodyClose(t *testing.T) {
+	tripResp := &http.Response{}
+	req, _ := http.NewRequest("GET", "some-url", nil)
+	data := "some buffer data"
+	body := FakeReadCloser{Reader: strings.NewReader(data)}
+	tripResp.Body = &body
+	testT := &testRoundTripper{res: tripResp}
+	transport := cf.DrainingTransport{Transport: testT}
+	resp, _ := transport.RoundTrip(req)
+	_ = resp.Body.Close()
+	assert.Equal(t, body.numBytes, len(data))
+	assert.True(t, body.closeWasCalled)
+}
+
+func TestRoundTripperError(t *testing.T) {
+	testT := &testRoundTripper{res: nil, err: errors.New("some-error")}
+
+	transport := cf.DrainingTransport{Transport: testT}
+	req, _ := http.NewRequest("GET", "some-url", nil)
+	resp, err := transport.RoundTrip(req)
+
+	assert.Equal(t, err.Error(), "some-error")
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
Fix for https://github.com/cloudfoundry/app-autoscaler-release/issues/814

We added a DrainTransport Wrapper for the CF Client, as advised here https://github.com/google/go-github/pull/317. It makes sure, that all bytes are read from the response before the body is closed.

co-authored: @KevinJCross 