### PR TITLE
Misc supportability fixes

### DIFF
--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -2,8 +2,9 @@ SHELL := /bin/bash
 GO_VERSION := $(shell go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/')
 GO_DEPENDENCIES := $(shell find . -type f -name '*.go')
 PACKAGE_DIRS := $(shell go list ./... | grep -v /vendor/ | grep -v e2e)
-CGO_ENABLED = 0
+CGO_ENABLED = 1
 BUILDTAGS :=
+BUILDFLAGS := -ldflags '-linkmode=external'
 export GO111MODULE=on
 
 #TODO: https://github.com/cloudfoundry/app-autoscaler-release/issues/564 allow the tests to be run in parallel

--- a/src/autoscaler/cf/client.go
+++ b/src/autoscaler/cf/client.go
@@ -109,7 +109,7 @@ func createRetryClient(conf *Config, client *http.Client, logger lager.Logger) *
 	if conf.MaxRetryWaitMs != 0 {
 		retryClient.RetryWaitMax = time.Duration(conf.MaxRetryWaitMs) * time.Millisecond
 	}
-	retryClient.Logger = LeveledLoggerAdapter{logger}
+	retryClient.Logger = LeveledLoggerAdapter{logger.Session("retryablehttp")}
 	retryClient.HTTPClient = client
 	retryClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
 		return resp, err


### PR DESCRIPTION
- Mark logs by `retryablehttp`
- Ensure binaries are compiled dynamically
