### PR TITLE
Setting a minimum file handle limits to 16k

### DIFF
--- a/jobs/Gemfile
+++ b/jobs/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+group :development, :test do
+  gem "bosh-template"
+  gem "rspec"
+  gem "rspec-its"
+  gem "standard"
+  gem "rspec-file_fixtures", "~> 0.1.6"
+end

--- a/jobs/Gemfile.lock
+++ b/jobs/Gemfile.lock
@@ -1,0 +1,64 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    bosh-template (2.2.1)
+      semi_semantic (~> 1.2.0)
+    diff-lcs (1.4.4)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
+    regexp_parser (2.3.0)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-file_fixtures (0.1.6)
+      rspec (~> 3.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.27.0)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.16.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.17.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.13.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.11.0)
+    semi_semantic (1.2.0)
+    standard (1.10.0)
+      rubocop (= 1.27.0)
+      rubocop-performance (= 1.13.3)
+    unicode-display_width (2.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bosh-template
+  rspec
+  rspec-file_fixtures (~> 0.1.6)
+  rspec-its
+  standard
+
+BUNDLED WITH
+   2.1.4

--- a/jobs/eventgenerator/templates/eventgenerator_ctl
+++ b/jobs/eventgenerator/templates/eventgenerator_ctl
@@ -29,6 +29,7 @@ case $1 in
     $COMMON_DIR/call-hooks.sh "eventgenerator" "pre-start"
     <% end %>
 
+    set_ulimits
     exec /var/vcap/packages/eventgenerator/eventgenerator -c $CONF_DIR/eventgenerator.yml >>$LOG_DIR/eventgenerator.stdout.log 2>>$LOG_DIR/eventgenerator.stderr.log
   
     <% unless p("autoscaler.eventgenerator.hooks.post_start").empty? %>

--- a/jobs/golangapiserver/templates/apiserver_ctl.erb
+++ b/jobs/golangapiserver/templates/apiserver_ctl.erb
@@ -31,6 +31,7 @@ case $1 in
     $COMMON_DIR/call-hooks.sh "golangapiserver" "pre-start"
     <% end %>
 
+    set_ulimits
     exec /var/vcap/packages/golangapiserver/api -c $CONF_DIR/apiserver.yml >>$LOG_DIR/golangapiserver.stdout.log 2>>$LOG_DIR/golangapiserver.stderr.log
 
     <% unless p("autoscaler.apiserver.hooks.post_start").empty? %>

--- a/jobs/metricsforwarder/templates/metricsforwarder_ctl
+++ b/jobs/metricsforwarder/templates/metricsforwarder_ctl
@@ -31,6 +31,7 @@ case $1 in
     $COMMON_DIR/call-hooks.sh "metricsforwarder" "pre-start"
     <% end %>
 
+    set_ulimits
     exec /var/vcap/packages/metricsforwarder/metricsforwarder -c $CONF_DIR/metricsforwarder.yml >>$LOG_DIR/metricsforwarder.stdout.log 2>>$LOG_DIR/metricsforwarder.stderr.log
 
     <% unless p("autoscaler.metricsforwarder.hooks.post_start").empty? %>

--- a/jobs/metricsgateway/templates/metricsgateway_ctl
+++ b/jobs/metricsgateway/templates/metricsgateway_ctl
@@ -31,6 +31,7 @@ case $1 in
     $COMMON_DIR/call-hooks.sh "metricsgateway" "pre-start"
     <% end %>
 
+    set_ulimits
     exec /var/vcap/packages/metricsgateway/metricsgateway -c $CONF_DIR/metricsgateway.yml >>$LOG_DIR/metricsgateway.stdout.log 2>>$LOG_DIR/metricsgateway.stderr.log
 
     <% unless p("autoscaler.metricsgateway.hooks.post_start").empty? %>

--- a/jobs/metricsserver/templates/metricsserver_ctl
+++ b/jobs/metricsserver/templates/metricsserver_ctl
@@ -31,6 +31,7 @@ case $1 in
     $COMMON_DIR/call-hooks.sh "metricsserver" "pre-start"
     <% end %>
 
+    set_ulimits
     exec /var/vcap/packages/metricsserver/metricsserver -c $CONF_DIR/metricsserver.yml >>$LOG_DIR/metricsserver.stdout.log 2>>$LOG_DIR/metricsserver.stderr.log
 
     <% unless p("autoscaler.metricsserver.hooks.post_start").empty? %>

--- a/jobs/operator/templates/operator_ctl
+++ b/jobs/operator/templates/operator_ctl
@@ -29,6 +29,7 @@ case $1 in
     $COMMON_DIR/call-hooks.sh "operator" "pre-start"
     <% end %>
 
+    set_ulimits
     exec /var/vcap/packages/operator/operator -c $CONF_DIR/operator.yml >>$LOG_DIR/operator.stdout.log 2>>$LOG_DIR/operator.stderr.log
 
     <% unless p("autoscaler.operator.hooks.post_start").empty? %>

--- a/jobs/scalingengine/templates/scalingengine_ctl
+++ b/jobs/scalingengine/templates/scalingengine_ctl
@@ -27,8 +27,9 @@ case $1 in
 
     <% unless p("autoscaler.scalingengine.hooks.pre_start").empty? %>
     $COMMON_DIR/call-hooks.sh "scalingengine" "pre-start"
-    <% end %>    
+    <% end %>
 
+    set_ulimits
     exec /var/vcap/packages/scalingengine/scalingengine -c $CONF_DIR/scalingengine.yml >>$LOG_DIR/scalingengine.stdout.log 2>>$LOG_DIR/scalingengine.stderr.log
 
     <% unless p("autoscaler.scalingengine.hooks.post_start").empty? %>

--- a/jobs/scheduler/templates/scheduler.erb
+++ b/jobs/scheduler/templates/scheduler.erb
@@ -24,8 +24,9 @@ case $1 in
 
     <% unless p("autoscaler.scheduler.hooks.pre_start").empty? %>
     $COMMON_DIR/call-hooks.sh "scheduler" "pre-start"
-    <% end %>    
+    <% end %>
 
+    set_ulimits
     cd /var/vcap/packages/scheduler/
     exec java -Dspring.config.location=/var/vcap/jobs/scheduler/config/application.properties -jar /var/vcap/packages/scheduler/scheduler-*.war \
       <%= p("autoscaler.scheduler.jvm_options") %> \

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -1,30 +1,31 @@
+#!/bin/bash
 
 # enable deep monitoring by relying on the rule set-up
 export DT_MONITOR="true"
 
-# set the number of file handles to a sensible 16k(base2)
-max_file_handles=16384
+# set the minimum number of file handles to a sensible 16k(base2)
+minimum_file_handles=16384
 
 mkdir -p /var/vcap/sys/log
-
-exec > >(tee -a >(logger -p user.info -t vcap.$(basename $0).stdout) | awk -W interactive '{ system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).log)
-exec 2> >(tee -a >(logger -p user.error -t vcap.$(basename $0).stderr) | awk -W interactive '{ system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).err.log)
+script_name=$(basename "$0")
+exec > >(tee -a >(logger -p user.info -t "vcap.${script_name}.stdout") | awk -W interactive '{ system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >> "/var/vcap/sys/log/${script_name}.log")
+exec 2> >(tee -a >(logger -p user.error -t "vcap.${script_name}.stderr") | awk -W interactive '{ system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >> "/var/vcap/sys/log/${script_name}.err.log")
 
 pid_guard() {
-  echo "------------ STARTING `basename $0` at `date` --------------" | tee /dev/stderr
+  echo "------------ STARTING ${script_name} at $(date) --------------" | tee /dev/stderr
   pidfile=$1
   name=$2
 
   if [ -f "$pidfile" ]; then
-    pid="$(head -1 $pidfile)"
-    echo "pidno $pid"
-    if [ -n "$pid" ] && [ -e "/proc/$pid" ] && grep -q "/var/vcap/packages/$name" "/proc/$pid/cmdline"; then
-      echo "$name is already running, please stop it first"
+    pid="$(head -1 "${pidfile}")"
+    echo "pidno ${pid}"
+    if [ -n "${pid}" ] && [ -e "/proc/$pid" ] && grep -q "/var/vcap/packages/$name" "/proc/$pid/cmdline"; then
+      echo "${name} is already running, please stop it first"
       exit 1
     fi
 
     echo "Removing stale pidfile..."
-    rm $pidfile
+    rm "${pidfile}"
   fi
 }
 
@@ -33,7 +34,7 @@ wait_pidfile() {
   try_kill=$2
   timeout=${3:-0}
   force=${4:-0}
-  countdown=$(( $timeout * 10 ))
+  countdown=$(( timeout * 10 ))
 
   if [ -f "$pidfile" ]; then
     pid=$(head -1 "$pidfile")
@@ -43,28 +44,28 @@ wait_pidfile() {
       exit 1
     fi
 
-    if [ -e /proc/$pid ]; then
+    if [ -e "/proc/${pid}" ]; then
       if [ "$try_kill" = "1" ]; then
         echo "Killing $pidfile: $pid "
-        kill $pid
+        kill "${pid}"
       fi
-      while [ -e /proc/$pid ]; do
+      while [ -e "/proc/${pid}" ]; do
         sleep 0.1
-        [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
-        if [ $timeout -gt 0 ]; then
+        [ "$countdown" != '0' ] && [ $(( countdown % 10 )) = '0' ] && echo -n .
+        if [ "${timeout}" -gt 0 ]; then
           if [ $countdown -eq 0 ]; then
             if [ "$force" = "1" ]; then
               echo -ne "\nKill timed out, using kill -9 on $pid... "
-              kill -9 $pid
+              kill -9 "$pid"
               sleep 0.5
             fi
             break
           else
-            countdown=$(( $countdown - 1 ))
+            countdown=$(( countdown - 1 ))
           fi
         fi
       done
-      if [ -e /proc/$pid ]; then
+      if [ -e "/proc/$pid" ]; then
         echo "Timed Out"
       else
         echo "Stopped"
@@ -73,7 +74,7 @@ wait_pidfile() {
       echo "Process $pid is not running"
     fi
 
-    rm -f $pidfile
+    rm -f "$pidfile"
   else
     echo "Pidfile $pidfile doesn't exist"
   fi
@@ -86,9 +87,15 @@ kill_and_wait() {
   timeout=${2:-25}
   force=${3:-1}
 
-  wait_pidfile $pidfile 1 $timeout $force
+  wait_pidfile "${pidfile}" 1 "${timeout}" "${force}"
 }
 
 set_ulimits(){
-  ulimit -n ${max_file_handles}
+  #If the defaults of 1024 are set then use our default file limits
+  file_limit=$(ulimit -n)
+  if [ "${file_limit}" == "unlimited"  ]; then
+     return
+  elif [ "${file_limit}" -lt "${minimum_file_handles}" ]; then
+    ulimit -n ${minimum_file_handles}
+  fi
 }

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -2,6 +2,9 @@
 # enable deep monitoring by relying on the rule set-up
 export DT_MONITOR="true"
 
+# set the number of file handles to a sensible 16k(base2)
+max_file_handles=16384
+
 mkdir -p /var/vcap/sys/log
 
 exec > >(tee -a >(logger -p user.info -t vcap.$(basename $0).stdout) | awk -W interactive '{ system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).log)
@@ -84,4 +87,8 @@ kill_and_wait() {
   force=${3:-1}
 
   wait_pidfile $pidfile 1 $timeout $force
+}
+
+set_ulimits(){
+  ulimit -n ${max_file_handles}
 }

--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -91,7 +91,7 @@ kill_and_wait() {
 }
 
 set_ulimits(){
-  #If the defaults of 1024 are set then use our default file limits
+  #Set the minimum file handle limit to $minimum_file_handles
   file_limit=$(ulimit -n)
   if [ "${file_limit}" == "unlimited"  ]; then
      return


### PR DESCRIPTION
If there is no ulimits set on the system the default ulimit is normally 1024.
This pr checks that the file handles limit (tcp connecions) is minimum 16k. If it is currently unlimited then it does not change this.

This fix is to help reduce the effect of https://github.com/cloudfoundry/app-autoscaler-release/issues/814

As evidence:
```
scalingengine/x:/var/vcap/bosh_ssh/x5# monit status scalingengine
The Monit daemon 5.2.5 uptime: 8m 

Process 'scalingengine'
  status                            running
  monitoring status                 monitored
  pid                               7845
  parent pid                        1
  uptime                            8m 
  children                          2
  memory kilobytes                  15972
  memory kilobytes total            15972
  memory percent                    0.7%
  memory percent total              0.7%
  cpu percent                       0.0%
  cpu percent total                 0.0%
  data collected                    Tue Sep  6 17:32:21 2022


scalingengine/x:/var/vcap/bosh_ssh/x# cat /proc/7845/limits
Limit                     Soft Limit           Hard Limit           Units     
Max cpu time              unlimited            unlimited            seconds   
Max file size             unlimited            unlimited            bytes     
Max data size             unlimited            unlimited            bytes     
Max stack size            8388608              unlimited            bytes     
Max core file size        0                    unlimited            bytes     
Max resident set          unlimited            unlimited            bytes     
Max processes             7629                 7629                 processes 
Max open files            16384                16384                files     
Max locked memory         65536                65536                bytes     
Max address space         unlimited            unlimited            bytes     
Max file locks            unlimited            unlimited            locks     
Max pending signals       7629                 7629                 signals   
Max msgqueue size         819200               819200               bytes     
Max nice priority         0                    0                    
Max realtime priority     0                    0                    
Max realtime timeout      unlimited            unlimited            us        
scalingengine/e49b1d13-dc4f-4240-9a5d-4c176619055b:/var/vcap/bosh_ssh/bosh_0a5273e7f42a455# 
       
```