### PR TITLE
Remove old ulimit setting which is obsoleted by #873

### DIFF
--- a/jobs/golangapiserver/templates/apiserver_ctl.erb
+++ b/jobs/golangapiserver/templates/apiserver_ctl.erb
@@ -18,8 +18,6 @@ case $1 in
   start)
     pid_guard $PIDFILE "golangapiserver"
 
-    ulimit -n 8192
-
     mkdir -p $RUN_DIR
     chown -R vcap:vcap $RUN_DIR
     mkdir -p $LOG_DIR

--- a/jobs/metricsforwarder/templates/metricsforwarder_ctl
+++ b/jobs/metricsforwarder/templates/metricsforwarder_ctl
@@ -18,8 +18,6 @@ case $1 in
   start)
     pid_guard $PIDFILE "metricsforwarder"
 
-    ulimit -n 8192
-
     mkdir -p $RUN_DIR
     chown -R vcap:vcap $RUN_DIR
     mkdir -p $LOG_DIR

--- a/jobs/metricsgateway/templates/metricsgateway_ctl
+++ b/jobs/metricsgateway/templates/metricsgateway_ctl
@@ -18,8 +18,6 @@ case $1 in
   start)
     pid_guard $PIDFILE "metricsgateway"
 
-    ulimit -n 8192
-
     mkdir -p $RUN_DIR
     chown -R vcap:vcap $RUN_DIR
     mkdir -p $LOG_DIR

--- a/jobs/metricsserver/templates/metricsserver_ctl
+++ b/jobs/metricsserver/templates/metricsserver_ctl
@@ -18,8 +18,6 @@ case $1 in
   start)
     pid_guard $PIDFILE "metricsserver"
 
-    ulimit -n 8192
-
     mkdir -p $RUN_DIR
     chown -R vcap:vcap $RUN_DIR
     mkdir -p $LOG_DIR


### PR DESCRIPTION
This is necessary since on k8s the corresponding jobs cannot start as I replicated manually below....
```
/:/var/vcap/jobs/metricsserver# ulimit -a
core file size          (blocks, -c) unlimited
data seg size           (kbytes, -d) unlimited
scheduling priority             (-e) 0
file size               (blocks, -f) unlimited
pending signals                 (-i) 127799
max locked memory       (kbytes, -l) 65536
max memory size         (kbytes, -m) unlimited
open files                      (-n) 1048576
pipe size            (512 bytes, -p) 8
POSIX message queues     (bytes, -q) 819200
real-time priority              (-r) 0
stack size              (kbytes, -s) 8192
cpu time               (seconds, -t) unlimited
max user processes              (-u) unlimited
virtual memory          (kbytes, -v) unlimited
file locks                      (-x) unlimited
/:/var/vcap/jobs/metricsserver# ulimit -n 8192
/:/var/vcap/jobs/metricsserver# ulimit -n 16384
bash: ulimit: open files: cannot modify limit: Operation not permitted
```
@KevinJCross please review asap since I want to update our envs to latest autoscaler release to solve  the #814 
Obsoleted by #873 