### PR TITLE
Silence prometheus alerts for 8 hours using make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,3 +309,16 @@ deploy-cleanup:
 package-specs: mod-tidy vendor
 	@echo " - Updating the package specs"
 	@./scripts/sync-package-specs
+
+
+## Prometheus Alerts
+.PHONY: silence-alerts
+silence-alerts:
+	export SILENCE_TIME_MINS=480;\
+	echo " - Silencing deployment '${DEPLOYMENT_NAME} 8 hours'"
+	${CI_DIR}/autoscaler/scripts/silence_prometheus_alert.sh BOSHJobProcessExtendedUnhealthy ;\
+	${CI_DIR}/autoscaler/scripts/silence_prometheus_alert.sh BOSHJobProcessUnhealthy ;\
+	${CI_DIR}/autoscaler/scripts/silence_prometheus_alert.sh BOSHJobExtendedUnhealthy ;\
+	${CI_DIR}/autoscaler/scripts/silence_prometheus_alert.sh BOSHJobProcessUnhealthy ;\
+	${CI_DIR}/autoscaler/scripts/silence_prometheus_alert.sh BOSHJobEphemeralDiskPredictWillFill ;\
+	${CI_DIR}/autoscaler/scripts/silence_prometheus_alert.sh BOSHJobUnhealthy ;

--- a/ci/autoscaler/scripts/silence_prometheus_alert.sh
+++ b/ci/autoscaler/scripts/silence_prometheus_alert.sh
@@ -20,6 +20,7 @@ alert_manager=${ALERT_MANAGER:-"https://alertmanager.${system_domain}"}
 alert_pass=${ALERT_PASS:-$(credhub get -n /bosh-autoscaler/prometheus/alertmanager_password -q)}
 start_time=$(${DATE} --iso-8601=seconds --utc)
 end_time=$(${DATE} -d "+ ${silence_time_mins} minutes" --iso-8601=seconds --utc)
+
 curl -k -s -f -L -X 'POST' \
   "${alert_manager}/api/v2/silences" \
   -u "admin:${alert_pass}" \
@@ -62,3 +63,6 @@ curl -k -s -f -L -X 'POST' \
   "endsAt": "${end_time}"
 }
 EOF
+echo "==Alert created=="
+echo ">> start_time: ${start_time}"
+echo ">> end_time: ${end_time}"


### PR DESCRIPTION
This simple make target is used to silence prometheus alerts against a deployment for 8 hours.
Helpful for local development

usage

`make silence-alerts DEPLOYMENT_NAME=autoscaler-<PR_NUMBER>`