### PR TITLE
Fix for missing scheduler host property in the manifest for the operator vm

### DIFF
--- a/templates/app-autoscaler.yml
+++ b/templates/app-autoscaler.yml
@@ -411,6 +411,7 @@ instance_groups:
             ca_cert: ((!scheduler_client_cert.ca))
             client_cert: ((!scheduler_client_cert.certificate))
             client_key: ((!scheduler_client_cert.private_key))
+            host: *scheduler_domain
           logging:
             level: info
   - name: route_registrar


### PR DESCRIPTION
The host property was missing in the manifest for the operator vm

**Problem**
```
{"data":{"error":"Put \"https://xxxxxxxxv1/syncSchedules\": dial tcp: lookup ......on 169.254.0.2:53: no such host","session":"15"},"log_level":2,"log_time":"2022-10-13T08:33:25Z","message":"operator.scheduler-sync.failed-to-send-sync-scheduler-request","source":"operator","timestamp":"1665650005.884648085"}
```
**solution**

Add the missing scheduler host property in the manifest