### PR TITLE
POC: deploy event generator with consul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,10 @@ cleanup-concourse:
 cf-login:
 	@${CI_DIR}/autoscaler/scripts/cf-login.sh
 
+.PHONY: ssh-autoscaler
+ssh-autoscaler:
+	@${CI_DIR}/autoscaler/scripts/ssh-autoscaler.sh
+
 .PHONY: setup-performance
 setup-performance:
 	export GINKGO_OPTS="";\

--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -76,6 +76,7 @@ function deploy () {
     -v deployment_name="${deployment_name}" \
     -v app_autoscaler_version="${bosh_release_version}" \
     -v admin_password="${CF_ADMIN_PASSWORD}" \
+    -v eventgenerator_max_in_flight=50 \
     -v cf_client_id=autoscaler_client_id \
     -v cf_client_secret=autoscaler_client_secret \
     -v skip_ssl_validation=true

--- a/ci/autoscaler/scripts/ssh-autoscaler.sh
+++ b/ci/autoscaler/scripts/ssh-autoscaler.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+set -euo pipefail
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${script_dir}/common.sh"
+deployment_name="autoscaler-${PR_NUMBER}"
+bosh_login
+vms=$(bosh vms -d $deployment_name --json | jq '.Tables[0].Rows | .[] | .instance'  -r)
+
+select vm in ${vms[@]}; do
+		bosh ssh -d $deployment_name $vm
+  break;
+done

--- a/operations/add-releases.yml
+++ b/operations/add-releases.yml
@@ -25,3 +25,5 @@
     url: https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18
     version: 1.1.18
     sha1: 86675f90d66f7018c57f4ae0312f1b3834dd58c9
+  - name: consul
+    version: 23.0.4+dev.1

--- a/src/autoscaler/eventgenerator/aggregator/appManager.go
+++ b/src/autoscaler/eventgenerator/aggregator/appManager.go
@@ -13,7 +13,6 @@ import (
 	"code.cloudfoundry.org/lager"
 )
 
-type Consumer func(map[string]*models.AppPolicy, chan *models.AppMonitor)
 type GetPoliciesFunc func() map[string]*models.AppPolicy
 type SaveAppMetricToCacheFunc func(*models.AppMetric) bool
 type QueryAppMetricsFunc func(appID string, metricType string, start int64, end int64, orderType db.OrderType) ([]*models.AppMetric, error)

--- a/templates/app-autoscaler.yml
+++ b/templates/app-autoscaler.yml
@@ -14,6 +14,8 @@ releases:
   version: latest
 - name: bpm
   version: latest
+- name: consul
+  version: latest
 
 domains:
   postgres: &postgres_domain ((deployment_name)).autoscalerpostgres.service.cf.internal
@@ -552,9 +554,16 @@ instance_groups:
   instances: 1
   vm_type: minimal
   stemcell: default
+  update:
+    canaries: 0
+    canary_watch_time: 1000-30000
+    max_in_flight: ((eventgenerator_max_in_flight)) # 50 if first time deploying consul, 1 for existing deployments
+    update_watch_time: 1000-30000
+    serial: false
   networks:
   - name: default
   jobs:
+
   - name: eventgenerator
     release: app-autoscaler
     properties:
@@ -587,6 +596,20 @@ instance_groups:
             client_key: ((!metricsserver_client_cert.private_key))
             port: *metricsserverPort
             host: *metricsserver_domain
+  - release: consul
+    name: consul
+    provides:
+      consul_servers:
+        as: consul_leaders
+        shared: true
+    consumes:
+      consul_servers: { from: consul_leaders }
+    properties:
+      consul:
+        ssl_ca: ((consul-ca.ca))
+        ssl_cert: ((consul-tls.certificate))
+        ssl_key: ((consul-tls.private_key))
+
   - name: route_registrar
     release: routing
     consumes:
@@ -928,3 +951,20 @@ variables:
       - loggregator_agent_server
     extended_key_usage:
       - server_auth
+- name: consul-ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: consulCA
+- name: consul-tls
+  type: certificate
+  options:
+    ca: consul-ca
+    common_name: consul
+    extended_key_usage:
+    - client_auth
+    - server_auth
+    alternative_names:
+    - 127.0.0.1
+    - "*.consul.default.consul.bosh"
+


### PR DESCRIPTION
Supporting an availability zone fault requires the autoscaler cluster to know, elect and return a set of working nodes. This could be implemented in Autoscaler source or with an out-of-the-box service networking solution like consul.

In this PoC we will try to:
- Identify the tradeoff of deploying an out-of-the-box solution for service vs a custom solution
- Implement changes necessary in autocaler to use consul to resolve sharding for eventgenerator

