### PR TITLE
Establish eventgenerator connection with logcache via UAA

### DIFF
--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -19,7 +19,8 @@ ops_files=${OPS_FILES:-"${autoscaler_dir}/operations/add-releases.yml\
  ${autoscaler_dir}/operations/enable-log-cache.yml\
  ${autoscaler_dir}/operations/log-cache-syslog-server.yml\
  ${autoscaler_dir}/operations/remove-metricsserver.yml\
- ${autoscaler_dir}/operations/remove-metricsgateway.yml"}
+ ${autoscaler_dir}/operations/remove-metricsgateway.yml\
+ ${autoscaler_dir}/operations/enable-log-cache-via-uaa.yml"}
 
 if [[ ! -d ${bbl_state_path} ]]; then
   echo "FAILED: Did not find bbl-state folder at ${bbl_state_path}"
@@ -108,6 +109,8 @@ function deploy() {
       -v admin_password="${CF_ADMIN_PASSWORD}" \
       -v cf_client_id=autoscaler_client_id \
       -v cf_client_secret=autoscaler_client_secret \
+      -v eventgenerator_client_id=admin \
+      -v eventgenerator_client_secret="${UAA_CLIENT_SECRET}" \
       -v skip_ssl_validation=true \
       > "${tmp_manifest_file}"
 

--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -111,7 +111,8 @@ function deploy() {
       -v cf_client_secret=autoscaler_client_secret \
       -v eventgenerator_client_id=admin \
       -v eventgenerator_client_secret="${UAA_CLIENT_SECRET}" \
-      -v skip_ssl_validation=true \
+      -v eventgenerator_uaa_skip_ssl_validation=true \
+    -v skip_ssl_validation=true \
       > "${tmp_manifest_file}"
 
   if [ -z "${DEBUG+}" ] && [ "${DEBUG}" != 'false' ]

--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -40,6 +40,7 @@ popd > /dev/null
 echo "> Deploying autoscaler '${bosh_release_version}' with name '${deployment_name}' "
 
 UAA_CLIENT_SECRET=$(credhub get -n /bosh-autoscaler/cf/uaa_admin_client_secret --quiet)
+UAA_FIREHOST_EXPORTER_CLIENT_SECRET=$(credhub get -n /bosh-autoscaler/cf/uaa_clients_firehose_exporter_secret --quiet)
 export UAA_CLIENT_SECRET
 CF_ADMIN_PASSWORD=$(credhub get -n /bosh-autoscaler/cf/cf_admin_password -q)
 
@@ -109,8 +110,8 @@ function deploy() {
       -v admin_password="${CF_ADMIN_PASSWORD}" \
       -v cf_client_id=autoscaler_client_id \
       -v cf_client_secret=autoscaler_client_secret \
-      -v eventgenerator_client_id=admin \
-      -v eventgenerator_client_secret="${UAA_CLIENT_SECRET}" \
+      -v eventgenerator_uaa_client_id=firehose_exporter \
+      -v eventgenerator_uaa_client_secret="${UAA_FIREHOST_EXPORTER_CLIENT_SECRET}" \
       -v eventgenerator_uaa_skip_ssl_validation=true \
     -v skip_ssl_validation=true \
       > "${tmp_manifest_file}"

--- a/jobs/eventgenerator/spec
+++ b/jobs/eventgenerator/spec
@@ -198,6 +198,15 @@ properties:
   autoscaler.eventgenerator.metricscollector.client_key:
     description: "PEM-encoded client key"
 
+  autoscaler.eventgenerator.metricscollector.uaa.url:
+    description: "UAA Url to perform oauth authentication"
+
+  autoscaler.eventgenerator.metricscollector.uaa.client_id:
+    description: "UAA client id"
+
+  autoscaler.eventgenerator.metricscollector.uaa.client_secret:
+    description: "UAA client secret"
+
   autoscaler.eventgenerator.defaultStatWindowSecs:
     description: "Default value for stat_window_secs"
     default: 120

--- a/jobs/eventgenerator/spec
+++ b/jobs/eventgenerator/spec
@@ -183,7 +183,7 @@ properties:
 
   autoscaler.eventgenerator.metricscollector.host:
     description: "Host where the metrics collector is running"
-    default: "metricscollector.service.cf.internal"
+    default: "https://metricscollector.service.cf.internal"
 
   autoscaler.eventgenerator.metricscollector.port:
     description: "Port where the metrics collector will listen"

--- a/jobs/eventgenerator/spec
+++ b/jobs/eventgenerator/spec
@@ -207,6 +207,9 @@ properties:
   autoscaler.eventgenerator.metricscollector.uaa.client_secret:
     description: "UAA client secret"
 
+  autoscaler.eventgenerator.metricscollector.uaa.skip_ssl_validation:
+    description: "UAA skip ssl authentication"
+
   autoscaler.eventgenerator.defaultStatWindowSecs:
     description: "Default value for stat_window_secs"
     default: 120

--- a/jobs/eventgenerator/spec
+++ b/jobs/eventgenerator/spec
@@ -183,7 +183,7 @@ properties:
 
   autoscaler.eventgenerator.metricscollector.host:
     description: "Host where the metrics collector is running"
-    default: "https://metricscollector.service.cf.internal"
+    default: "metricscollector.service.cf.internal"
 
   autoscaler.eventgenerator.metricscollector.port:
     description: "Port where the metrics collector will listen"
@@ -209,6 +209,7 @@ properties:
 
   autoscaler.eventgenerator.metricscollector.uaa.skip_ssl_validation:
     description: "UAA skip ssl authentication"
+    default: false
 
   autoscaler.eventgenerator.defaultStatWindowSecs:
     description: "Default value for stat_window_secs"

--- a/jobs/eventgenerator/templates/eventgenerator.yml.erb
+++ b/jobs/eventgenerator/templates/eventgenerator.yml.erb
@@ -40,7 +40,12 @@ end
   policy_db_url = build_db_url('policy_db', job_name)
   app_metrics_db_url = build_db_url('appmetrics_db', job_name)
 
-  metric_collector_url = p("autoscaler.eventgenerator.metricscollector.host") + ":" + p("autoscaler.eventgenerator.metricscollector.port").to_s
+
+  metric_collector_url = p("autoscaler.eventgenerator.metricscollector.host")
+  metrics_collector_port = p("autoscaler.eventgenerator.metricscollector.port")
+  if metrics_collector_port.empty?
+    metric_collector_url += ":" + metrics_collector_port
+  end
 
   sorted_instances=link("eventgenerator").instances.sort_by {|i|i.address}
   nodeIndex=sorted_instances.index(sorted_instances.find{|i|i.id == spec.id})

--- a/jobs/eventgenerator/templates/eventgenerator.yml.erb
+++ b/jobs/eventgenerator/templates/eventgenerator.yml.erb
@@ -41,9 +41,14 @@ end
   app_metrics_db_url = build_db_url('appmetrics_db', job_name)
 
 
-  metric_collector_url = p("autoscaler.eventgenerator.metricscollector.host")
-  metrics_collector_port = p("autoscaler.eventgenerator.metricscollector.port")
-  if metrics_collector_port.empty?
+  unless p("autoscaler.eventgenerator.metricscollector.use_log_cache")
+    metric_collector_url = "https://" + p("autoscaler.eventgenerator.metricscollector.host")
+  else
+    metric_collector_url = p("autoscaler.eventgenerator.metricscollector.host")
+  end
+
+  metrics_collector_port = p("autoscaler.eventgenerator.metricscollector.port").to_s
+  unless metrics_collector_port.empty?
     metric_collector_url += ":" + metrics_collector_port
   end
 
@@ -111,7 +116,7 @@ metricCollector:
     key_file: /var/vcap/jobs/eventgenerator/config/certs/metricscollector/client.key
     cert_file: /var/vcap/jobs/eventgenerator/config/certs/metricscollector/client.crt
     ca_file: /var/vcap/jobs/eventgenerator/config/certs/metricscollector/ca.crt
-  <% if_p("autoscaler.eventgenerator.metricscollector.uaa") do %>
+  <% if_p("autoscaler.eventgenerator.metricscollector.uaa.url") do %>
   uaa:
     url: <%= p("autoscaler.eventgenerator.metricscollector.uaa.url") %>
     client_id: <%= p("autoscaler.eventgenerator.metricscollector.uaa.client_id") %>

--- a/jobs/eventgenerator/templates/eventgenerator.yml.erb
+++ b/jobs/eventgenerator/templates/eventgenerator.yml.erb
@@ -109,7 +109,12 @@ metricCollector:
     key_file: /var/vcap/jobs/eventgenerator/config/certs/metricscollector/client.key
     cert_file: /var/vcap/jobs/eventgenerator/config/certs/metricscollector/client.crt
     ca_file: /var/vcap/jobs/eventgenerator/config/certs/metricscollector/ca.crt
-
+  <% if_p("autoscaler.eventgenerator.metricscollector.uaa") do %>
+  uaa:
+    url: <%= p("autoscaler.eventgenerator.metricscollector.uaa.url") %>
+    client_id: <%= p("autoscaler.eventgenerator.metricscollector.uaa.client_id") %>
+    client_secret: <%= p("autoscaler.eventgenerator.metricscollector.uaa.client_secret") %>
+  <% end %>
 
 defaultStatWindowSecs: <%= p("autoscaler.eventgenerator.defaultStatWindowSecs") %>
 defaultBreachDurationSecs: <%= p("autoscaler.eventgenerator.defaultBreachDurationSecs") %>

--- a/jobs/eventgenerator/templates/eventgenerator.yml.erb
+++ b/jobs/eventgenerator/templates/eventgenerator.yml.erb
@@ -114,6 +114,7 @@ metricCollector:
     url: <%= p("autoscaler.eventgenerator.metricscollector.uaa.url") %>
     client_id: <%= p("autoscaler.eventgenerator.metricscollector.uaa.client_id") %>
     client_secret: <%= p("autoscaler.eventgenerator.metricscollector.uaa.client_secret") %>
+    skip_ssl_validation: <%= p("autoscaler.eventgenerator.metricscollector.uaa.skip_ssl_validation") %>
   <% end %>
 
 defaultStatWindowSecs: <%= p("autoscaler.eventgenerator.defaultStatWindowSecs") %>

--- a/jobs/eventgenerator/templates/eventgenerator.yml.erb
+++ b/jobs/eventgenerator/templates/eventgenerator.yml.erb
@@ -40,10 +40,7 @@ end
   policy_db_url = build_db_url('policy_db', job_name)
   app_metrics_db_url = build_db_url('appmetrics_db', job_name)
 
-  metric_collector_url = "https://" + p("autoscaler.eventgenerator.metricscollector.host") + ":" + p("autoscaler.eventgenerator.metricscollector.port").to_s
-  if p("autoscaler.eventgenerator.metricscollector.use_log_cache")
-    metric_collector_url.gsub!("https://", "")
-  end
+  metric_collector_url = p("autoscaler.eventgenerator.metricscollector.host") + ":" + p("autoscaler.eventgenerator.metricscollector.port").to_s
 
   sorted_instances=link("eventgenerator").instances.sort_by {|i|i.address}
   nodeIndex=sorted_instances.index(sorted_instances.find{|i|i.id == spec.id})

--- a/operations/enable-log-cache-via-uaa.yml
+++ b/operations/enable-log-cache-via-uaa.yml
@@ -4,7 +4,7 @@
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/port
-  value: 8083
+  value:
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/url?

--- a/operations/enable-log-cache-via-uaa.yml
+++ b/operations/enable-log-cache-via-uaa.yml
@@ -4,7 +4,7 @@
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/port
-  value: 8080
+  value: 8083
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/url?

--- a/operations/enable-log-cache-via-uaa.yml
+++ b/operations/enable-log-cache-via-uaa.yml
@@ -7,13 +7,13 @@
   value: 8083
 
 - type: replace
-  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/url
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/url?
   value: uaa.((system_domain))
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/client_id?
-  value: ((eventgenerator_client_id))
+  value: ((eventgenerator_uaa_client_id))
 
 - type: replace
-  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/client_id?
-  value: ((eventgenerator_client_secret))
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/client_secret?
+  value: ((eventgenerator_uaa_client_secret))

--- a/operations/enable-log-cache-via-uaa.yml
+++ b/operations/enable-log-cache-via-uaa.yml
@@ -4,7 +4,7 @@
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/port
-  value:
+  value: ""
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/url?
@@ -18,7 +18,6 @@
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/client_secret?
   value: ((eventgenerator_uaa_client_secret))
 
-# TODO : SHOULD be removed later
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/skip_ssl_validation?
   value: ((eventgenerator_uaa_skip_ssl_validation))

--- a/operations/enable-log-cache-via-uaa.yml
+++ b/operations/enable-log-cache-via-uaa.yml
@@ -1,14 +1,14 @@
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/host
-  value: log-cache.((system_domain))
+  value: https://log-cache.((system_domain))
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/port
-  value: 8083
+  value: 8080
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/url?
-  value: uaa.((system_domain))
+  value: https://uaa.((system_domain))
 
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/client_id?
@@ -17,3 +17,8 @@
 - type: replace
   path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/client_secret?
   value: ((eventgenerator_uaa_client_secret))
+
+# TODO : SHOULD be removed later
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/skip_ssl_validation?
+  value: ((eventgenerator_uaa_skip_ssl_validation))

--- a/operations/enable-log-cache-via-uaa.yml
+++ b/operations/enable-log-cache-via-uaa.yml
@@ -1,0 +1,19 @@
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/host
+  value: log-cache.((system_domain))
+
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/port
+  value: 8083
+
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/url
+  value: uaa.((system_domain))
+
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/client_id?
+  value: ((eventgenerator_client_id))
+
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/metricscollector/uaa?/client_id?
+  value: ((eventgenerator_client_secret))

--- a/spec/jobs/eventgenerator/eventgenerator_spec.rb
+++ b/spec/jobs/eventgenerator/eventgenerator_spec.rb
@@ -67,6 +67,8 @@ describe "eventgenerator" do
         before do
           properties["autoscaler"]["eventgenerator"] = {
             "metricscollector" => {
+              "host" => "logcache",
+              "port" => "8080",
               "use_log_cache" => true
             }
           }
@@ -80,6 +82,40 @@ describe "eventgenerator" do
         it "should not add https protocol to metric_collector_url" do
           expect(rendered_template["metricCollector"]["metric_collector_url"])
             .not_to include("http")
+        end
+
+        describe "when using log-cache via https/uaa" do
+          before do
+            properties["autoscaler"]["eventgenerator"] = {
+              "metricscollector" => {
+                "host" => "logcache.cf.test.com",
+                "port" => "",
+                "use_log_cache" => true,
+                "uaa" => {
+                  "client_id" => "logs_admin_client_id",
+                  "client_secret" => "logs_admin_client_secret",
+                  "url" => "uaa.cf.test.com"
+                }
+              }
+            }
+          end
+
+          it "should not add metric_collector_port to metric_collector_url" do
+            expect(rendered_template["metricCollector"]["metric_collector_url"])
+              .not_to include(":")
+          end
+
+          it "should add uaa credentials" do
+            expect(rendered_template["metricCollector"]["uaa"]).to include({
+              "client_id" => "logs_admin_client_id",
+              "client_secret" => "logs_admin_client_secret",
+              "url" => "uaa.cf.test.com"
+            })
+          end
+
+          it "should set uaa skip ssl validation to false by default" do
+            expect(rendered_template["metricCollector"]["uaa"]["skip_ssl_validation"]).to be_falsey
+          end
         end
       end
     end

--- a/src/autoscaler/eventgenerator/client/log_cache_client.go
+++ b/src/autoscaler/eventgenerator/client/log_cache_client.go
@@ -131,7 +131,7 @@ func getEnvelopeType(metricType string) rpc.EnvelopeType {
 	return metricName
 }
 
-func NewTLSCredentials(caPath string, certPath string, keyPath string) (credentials.TransportCredentials, error) {
+func newTLSCredentials(caPath string, certPath string, keyPath string) (credentials.TransportCredentials, error) {
 	cfg, err := NewTLSConfig(caPath, certPath, keyPath)
 	if err != nil {
 		return nil, err

--- a/src/autoscaler/eventgenerator/client/log_cache_client.go
+++ b/src/autoscaler/eventgenerator/client/log_cache_client.go
@@ -42,6 +42,7 @@ type GoLogCacheClient interface {
 	WithViaGRPC(opts ...grpc.DialOption) logcache.ClientOption
 	WithHTTPClient(h logcache.HTTPClient) logcache.ClientOption
 	NewOauth2HTTPClient(oauth2Addr, client, clientSecret string, opts ...logcache.Oauth2Option) *logcache.Oauth2HTTPClient
+	WithOauth2HTTPClient(client logcache.HTTPClient) logcache.Oauth2Option
 }
 
 type LogCacheClientCreator interface {

--- a/src/autoscaler/eventgenerator/client/log_cache_client.go
+++ b/src/autoscaler/eventgenerator/client/log_cache_client.go
@@ -40,6 +40,8 @@ type LogCacheClientReader interface {
 type GoLogCacheClient interface {
 	NewClient(addr string, opts ...logcache.ClientOption) *logcache.Client
 	WithViaGRPC(opts ...grpc.DialOption) logcache.ClientOption
+	WithHTTPClient(h logcache.HTTPClient) logcache.ClientOption
+	NewOauth2HTTPClient(oauth2Addr, client, clientSecret string, opts ...logcache.Oauth2Option) *logcache.Oauth2HTTPClient
 }
 
 type LogCacheClientCreator interface {

--- a/src/autoscaler/eventgenerator/client/metric_client_factory.go
+++ b/src/autoscaler/eventgenerator/client/metric_client_factory.go
@@ -101,12 +101,12 @@ func createHttpClient(skipSSLValidation bool) *http.Client {
 	return &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
+			//nolint:gosec
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipSSLValidation},
 		},
 	}
 }
 func createGRPCLogCacheClient(conf *config.Config) *logcache.Client {
-	// GRPC based logCacheClient
 	creds, err := NewTLSCredentials(conf.MetricCollector.TLSClientCerts.CACertFile,
 		conf.MetricCollector.TLSClientCerts.CertFile, conf.MetricCollector.TLSClientCerts.KeyFile)
 	if err != nil {

--- a/src/autoscaler/eventgenerator/client/metric_client_factory.go
+++ b/src/autoscaler/eventgenerator/client/metric_client_factory.go
@@ -22,9 +22,11 @@ type MetricClient interface {
 type newLogCacheClient func(logger lager.Logger, getTime func() time.Time, client LogCacheClientReader, envelopeProcessor envelopeprocessor.EnvelopeProcessor) *LogCacheClient
 type newMetricServerClient func(logger lager.Logger, metricCollectorUrl string, httpClient *http.Client) *MetricServerClient
 
-var NewGoLogCacheClient = logcache.NewClient
+var GoLogCacheNewClient = logcache.NewClient
+var GoLogCacheNewOauth2HTTPClient = logcache.NewOauth2HTTPClient
+var GoLogCacheWithViaGRPC = logcache.WithViaGRPC
+
 var NewProcessor = envelopeprocessor.NewProcessor
-var LogCacheClientWithGRPC = logcache.WithViaGRPC
 var GRPCWithTransportCredentials = gogrpc.WithTransportCredentials
 
 type grpcDialOptions interface {
@@ -52,25 +54,54 @@ func NewMetricClientFactory(newMetricLogCacheClient newLogCacheClient, newMetric
 }
 
 func (mc *MetricClientFactory) GetMetricClient(logger lager.Logger, conf *config.Config) MetricClient {
-	var metricClient MetricClient
-
 	if conf.MetricCollector.UseLogCache {
-		creds, err := NewTLSCredentials(conf.MetricCollector.TLSClientCerts.CACertFile, conf.MetricCollector.TLSClientCerts.CertFile, conf.MetricCollector.TLSClientCerts.KeyFile)
-
-		logCacheClient := NewGoLogCacheClient(conf.MetricCollector.MetricCollectorURL, LogCacheClientWithGRPC(new(grpcCreds).WithTransportCredentials(creds)))
-		if err != nil {
-			log.Fatalf("failed to load TLS config: %s", err)
-		}
-
-		envelopeProcessor := NewProcessor(logger, conf.Aggregator.AggregatorExecuteInterval)
-		metricClient = mc.newLogCacheClient(logger, time.Now, logCacheClient, envelopeProcessor)
+		return mc.createLogCacheMetricClient(logger, conf)
 	} else {
-		httpClient, err := helpers.CreateHTTPClient(&conf.MetricCollector.TLSClientCerts)
-
-		if err != nil {
-			logger.Error("failed to create http client for MetricCollector", err, lager.Data{"metriccollectorTLS": httpClient})
-		}
-		metricClient = mc.newMetricServerClient(logger, conf.MetricCollector.MetricCollectorURL, httpClient)
+		return mc.createMetricServerMetricClient(logger, conf)
 	}
-	return metricClient
+}
+
+func (mc *MetricClientFactory) createLogCacheMetricClient(logger lager.Logger, conf *config.Config) MetricClient {
+	var logCacheClient LogCacheClientReader
+
+	if hasUAACreds(conf) {
+		logCacheClient = createHttpLogCacheClient(conf)
+	} else {
+		logCacheClient = createGRPCLogCacheClient(conf)
+	}
+
+	envelopeProcessor := NewProcessor(logger, conf.Aggregator.AggregatorExecuteInterval)
+	return mc.newLogCacheClient(logger, time.Now, logCacheClient, envelopeProcessor)
+}
+
+func (mc *MetricClientFactory) createMetricServerMetricClient(logger lager.Logger, conf *config.Config) MetricClient {
+	httpClient, err := helpers.CreateHTTPClient(&conf.MetricCollector.TLSClientCerts)
+
+	if err != nil {
+		logger.Error("failed to create http client for MetricCollector", err, lager.Data{"metriccollectorTLS": httpClient})
+	}
+	return mc.newMetricServerClient(logger, conf.MetricCollector.MetricCollectorURL, httpClient)
+}
+
+func createHttpLogCacheClient(conf *config.Config) *logcache.Client {
+	_ = GoLogCacheNewOauth2HTTPClient(conf.MetricCollector.UAACreds.URL,
+		conf.MetricCollector.UAACreds.ClientID, conf.MetricCollector.UAACreds.ClientSecret)
+
+	// do the oauth stuff
+
+	return &logcache.Client{}
+}
+func createGRPCLogCacheClient(conf *config.Config) *logcache.Client {
+	// GRPC based logCacheClient
+	creds, err := NewTLSCredentials(conf.MetricCollector.TLSClientCerts.CACertFile,
+		conf.MetricCollector.TLSClientCerts.CertFile, conf.MetricCollector.TLSClientCerts.KeyFile)
+	if err != nil {
+		log.Fatalf("failed to load TLS config: %s", err)
+	}
+	return GoLogCacheNewClient(conf.MetricCollector.MetricCollectorURL, GoLogCacheWithViaGRPC(new(grpcCreds).WithTransportCredentials(creds)))
+}
+
+func hasUAACreds(conf *config.Config) bool {
+	return conf.MetricCollector.UAACreds.URL != "" && conf.MetricCollector.UAACreds.ClientSecret != "" &&
+		conf.MetricCollector.UAACreds.ClientID != ""
 }

--- a/src/autoscaler/eventgenerator/client/metric_client_factory.go
+++ b/src/autoscaler/eventgenerator/client/metric_client_factory.go
@@ -107,7 +107,7 @@ func createHttpClient(skipSSLValidation bool) *http.Client {
 	}
 }
 func createGRPCLogCacheClient(conf *config.Config) *logcache.Client {
-	creds, err := NewTLSCredentials(conf.MetricCollector.TLSClientCerts.CACertFile,
+	creds, err := newTLSCredentials(conf.MetricCollector.TLSClientCerts.CACertFile,
 		conf.MetricCollector.TLSClientCerts.CertFile, conf.MetricCollector.TLSClientCerts.KeyFile)
 	if err != nil {
 		log.Fatalf("failed to load TLS config: %s", err)

--- a/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
+++ b/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
@@ -197,7 +197,7 @@ func createEvaluators(logger lager.Logger, conf *config.Config, triggersChan cha
 func createMetricPollers(logger lager.Logger, conf *config.Config, appMonitorsChan chan *models.AppMonitor, appMetricChan chan *models.AppMetric) ([]*aggregator.MetricPoller, error) {
 	var metricClient client.MetricClient
 
-	clientFactory := client.NewMetricClientFactory(client.NewLogCacheClient, client.NewMetricServerClient)
+	clientFactory := client.NewMetricClientFactory(client.GoLogCacheNewOauth2HTTPClient, client.NewLogCacheClient, client.NewMetricServerClient)
 	metricClient = clientFactory.GetMetricClient(logger, conf)
 
 	pollers := make([]*aggregator.MetricPoller, conf.Aggregator.MetricPollerCount)

--- a/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
+++ b/src/autoscaler/eventgenerator/cmd/eventgenerator/main.go
@@ -197,7 +197,7 @@ func createEvaluators(logger lager.Logger, conf *config.Config, triggersChan cha
 func createMetricPollers(logger lager.Logger, conf *config.Config, appMonitorsChan chan *models.AppMonitor, appMetricChan chan *models.AppMetric) ([]*aggregator.MetricPoller, error) {
 	var metricClient client.MetricClient
 
-	clientFactory := client.NewMetricClientFactory(client.GoLogCacheNewOauth2HTTPClient, client.NewLogCacheClient, client.NewMetricServerClient)
+	clientFactory := client.NewMetricClientFactory(client.NewLogCacheClient, client.NewMetricServerClient)
 	metricClient = clientFactory.GetMetricClient(logger, conf)
 
 	pollers := make([]*aggregator.MetricPoller, conf.Aggregator.MetricPollerCount)

--- a/src/autoscaler/eventgenerator/config/config.go
+++ b/src/autoscaler/eventgenerator/config/config.go
@@ -68,6 +68,7 @@ type MetricCollectorConfig struct {
 	UseLogCache        bool            `yaml:"use_log_cache"`
 	MetricCollectorURL string          `yaml:"metric_collector_url"`
 	TLSClientCerts     models.TLSCerts `yaml:"tls"`
+	UAACreds           models.UAACreds `yaml:"uaa"`
 }
 
 type CircuitBreakerConfig struct {

--- a/src/autoscaler/fakes/fake_go_log_cache_client.go
+++ b/src/autoscaler/fakes/fake_go_log_cache_client.go
@@ -47,6 +47,17 @@ type FakeGoLogCacheClient struct {
 	withHTTPClientReturnsOnCall map[int]struct {
 		result1 clienta.ClientOption
 	}
+	WithOauth2HTTPClientStub        func(clienta.HTTPClient) clienta.Oauth2Option
+	withOauth2HTTPClientMutex       sync.RWMutex
+	withOauth2HTTPClientArgsForCall []struct {
+		arg1 clienta.HTTPClient
+	}
+	withOauth2HTTPClientReturns struct {
+		result1 clienta.Oauth2Option
+	}
+	withOauth2HTTPClientReturnsOnCall map[int]struct {
+		result1 clienta.Oauth2Option
+	}
 	WithViaGRPCStub        func(...grpc.DialOption) clienta.ClientOption
 	withViaGRPCMutex       sync.RWMutex
 	withViaGRPCArgsForCall []struct {
@@ -135,7 +146,7 @@ func (fake *FakeGoLogCacheClient) NewOauth2HTTPClient(arg1 string, arg2 string, 
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.NewOauth2HTTPClientStub
 	fakeReturns := fake.newOauth2HTTPClientReturns
-	fake.recordInvocation("GoLogCacheNewOauth2HTTPClient", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("NewOauth2HTTPClient", []interface{}{arg1, arg2, arg3, arg4})
 	fake.newOauth2HTTPClientMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4...)
@@ -249,6 +260,67 @@ func (fake *FakeGoLogCacheClient) WithHTTPClientReturnsOnCall(i int, result1 cli
 	}{result1}
 }
 
+func (fake *FakeGoLogCacheClient) WithOauth2HTTPClient(arg1 clienta.HTTPClient) clienta.Oauth2Option {
+	fake.withOauth2HTTPClientMutex.Lock()
+	ret, specificReturn := fake.withOauth2HTTPClientReturnsOnCall[len(fake.withOauth2HTTPClientArgsForCall)]
+	fake.withOauth2HTTPClientArgsForCall = append(fake.withOauth2HTTPClientArgsForCall, struct {
+		arg1 clienta.HTTPClient
+	}{arg1})
+	stub := fake.WithOauth2HTTPClientStub
+	fakeReturns := fake.withOauth2HTTPClientReturns
+	fake.recordInvocation("WithOauth2HTTPClient", []interface{}{arg1})
+	fake.withOauth2HTTPClientMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeGoLogCacheClient) WithOauth2HTTPClientCallCount() int {
+	fake.withOauth2HTTPClientMutex.RLock()
+	defer fake.withOauth2HTTPClientMutex.RUnlock()
+	return len(fake.withOauth2HTTPClientArgsForCall)
+}
+
+func (fake *FakeGoLogCacheClient) WithOauth2HTTPClientCalls(stub func(clienta.HTTPClient) clienta.Oauth2Option) {
+	fake.withOauth2HTTPClientMutex.Lock()
+	defer fake.withOauth2HTTPClientMutex.Unlock()
+	fake.WithOauth2HTTPClientStub = stub
+}
+
+func (fake *FakeGoLogCacheClient) WithOauth2HTTPClientArgsForCall(i int) clienta.HTTPClient {
+	fake.withOauth2HTTPClientMutex.RLock()
+	defer fake.withOauth2HTTPClientMutex.RUnlock()
+	argsForCall := fake.withOauth2HTTPClientArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeGoLogCacheClient) WithOauth2HTTPClientReturns(result1 clienta.Oauth2Option) {
+	fake.withOauth2HTTPClientMutex.Lock()
+	defer fake.withOauth2HTTPClientMutex.Unlock()
+	fake.WithOauth2HTTPClientStub = nil
+	fake.withOauth2HTTPClientReturns = struct {
+		result1 clienta.Oauth2Option
+	}{result1}
+}
+
+func (fake *FakeGoLogCacheClient) WithOauth2HTTPClientReturnsOnCall(i int, result1 clienta.Oauth2Option) {
+	fake.withOauth2HTTPClientMutex.Lock()
+	defer fake.withOauth2HTTPClientMutex.Unlock()
+	fake.WithOauth2HTTPClientStub = nil
+	if fake.withOauth2HTTPClientReturnsOnCall == nil {
+		fake.withOauth2HTTPClientReturnsOnCall = make(map[int]struct {
+			result1 clienta.Oauth2Option
+		})
+	}
+	fake.withOauth2HTTPClientReturnsOnCall[i] = struct {
+		result1 clienta.Oauth2Option
+	}{result1}
+}
+
 func (fake *FakeGoLogCacheClient) WithViaGRPC(arg1 ...grpc.DialOption) clienta.ClientOption {
 	fake.withViaGRPCMutex.Lock()
 	ret, specificReturn := fake.withViaGRPCReturnsOnCall[len(fake.withViaGRPCArgsForCall)]
@@ -319,6 +391,8 @@ func (fake *FakeGoLogCacheClient) Invocations() map[string][][]interface{} {
 	defer fake.newOauth2HTTPClientMutex.RUnlock()
 	fake.withHTTPClientMutex.RLock()
 	defer fake.withHTTPClientMutex.RUnlock()
+	fake.withOauth2HTTPClientMutex.RLock()
+	defer fake.withOauth2HTTPClientMutex.RUnlock()
 	fake.withViaGRPCMutex.RLock()
 	defer fake.withViaGRPCMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/src/autoscaler/fakes/fake_go_log_cache_client.go
+++ b/src/autoscaler/fakes/fake_go_log_cache_client.go
@@ -22,6 +22,31 @@ type FakeGoLogCacheClient struct {
 	newClientReturnsOnCall map[int]struct {
 		result1 *clienta.Client
 	}
+	NewOauth2HTTPClientStub        func(string, string, string, ...clienta.Oauth2Option) *clienta.Oauth2HTTPClient
+	newOauth2HTTPClientMutex       sync.RWMutex
+	newOauth2HTTPClientArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 []clienta.Oauth2Option
+	}
+	newOauth2HTTPClientReturns struct {
+		result1 *clienta.Oauth2HTTPClient
+	}
+	newOauth2HTTPClientReturnsOnCall map[int]struct {
+		result1 *clienta.Oauth2HTTPClient
+	}
+	WithHTTPClientStub        func(clienta.HTTPClient) clienta.ClientOption
+	withHTTPClientMutex       sync.RWMutex
+	withHTTPClientArgsForCall []struct {
+		arg1 clienta.HTTPClient
+	}
+	withHTTPClientReturns struct {
+		result1 clienta.ClientOption
+	}
+	withHTTPClientReturnsOnCall map[int]struct {
+		result1 clienta.ClientOption
+	}
 	WithViaGRPCStub        func(...grpc.DialOption) clienta.ClientOption
 	withViaGRPCMutex       sync.RWMutex
 	withViaGRPCArgsForCall []struct {
@@ -99,6 +124,131 @@ func (fake *FakeGoLogCacheClient) NewClientReturnsOnCall(i int, result1 *clienta
 	}{result1}
 }
 
+func (fake *FakeGoLogCacheClient) NewOauth2HTTPClient(arg1 string, arg2 string, arg3 string, arg4 ...clienta.Oauth2Option) *clienta.Oauth2HTTPClient {
+	fake.newOauth2HTTPClientMutex.Lock()
+	ret, specificReturn := fake.newOauth2HTTPClientReturnsOnCall[len(fake.newOauth2HTTPClientArgsForCall)]
+	fake.newOauth2HTTPClientArgsForCall = append(fake.newOauth2HTTPClientArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 []clienta.Oauth2Option
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.NewOauth2HTTPClientStub
+	fakeReturns := fake.newOauth2HTTPClientReturns
+	fake.recordInvocation("GoLogCacheNewOauth2HTTPClient", []interface{}{arg1, arg2, arg3, arg4})
+	fake.newOauth2HTTPClientMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeGoLogCacheClient) NewOauth2HTTPClientCallCount() int {
+	fake.newOauth2HTTPClientMutex.RLock()
+	defer fake.newOauth2HTTPClientMutex.RUnlock()
+	return len(fake.newOauth2HTTPClientArgsForCall)
+}
+
+func (fake *FakeGoLogCacheClient) NewOauth2HTTPClientCalls(stub func(string, string, string, ...clienta.Oauth2Option) *clienta.Oauth2HTTPClient) {
+	fake.newOauth2HTTPClientMutex.Lock()
+	defer fake.newOauth2HTTPClientMutex.Unlock()
+	fake.NewOauth2HTTPClientStub = stub
+}
+
+func (fake *FakeGoLogCacheClient) NewOauth2HTTPClientArgsForCall(i int) (string, string, string, []clienta.Oauth2Option) {
+	fake.newOauth2HTTPClientMutex.RLock()
+	defer fake.newOauth2HTTPClientMutex.RUnlock()
+	argsForCall := fake.newOauth2HTTPClientArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeGoLogCacheClient) NewOauth2HTTPClientReturns(result1 *clienta.Oauth2HTTPClient) {
+	fake.newOauth2HTTPClientMutex.Lock()
+	defer fake.newOauth2HTTPClientMutex.Unlock()
+	fake.NewOauth2HTTPClientStub = nil
+	fake.newOauth2HTTPClientReturns = struct {
+		result1 *clienta.Oauth2HTTPClient
+	}{result1}
+}
+
+func (fake *FakeGoLogCacheClient) NewOauth2HTTPClientReturnsOnCall(i int, result1 *clienta.Oauth2HTTPClient) {
+	fake.newOauth2HTTPClientMutex.Lock()
+	defer fake.newOauth2HTTPClientMutex.Unlock()
+	fake.NewOauth2HTTPClientStub = nil
+	if fake.newOauth2HTTPClientReturnsOnCall == nil {
+		fake.newOauth2HTTPClientReturnsOnCall = make(map[int]struct {
+			result1 *clienta.Oauth2HTTPClient
+		})
+	}
+	fake.newOauth2HTTPClientReturnsOnCall[i] = struct {
+		result1 *clienta.Oauth2HTTPClient
+	}{result1}
+}
+
+func (fake *FakeGoLogCacheClient) WithHTTPClient(arg1 clienta.HTTPClient) clienta.ClientOption {
+	fake.withHTTPClientMutex.Lock()
+	ret, specificReturn := fake.withHTTPClientReturnsOnCall[len(fake.withHTTPClientArgsForCall)]
+	fake.withHTTPClientArgsForCall = append(fake.withHTTPClientArgsForCall, struct {
+		arg1 clienta.HTTPClient
+	}{arg1})
+	stub := fake.WithHTTPClientStub
+	fakeReturns := fake.withHTTPClientReturns
+	fake.recordInvocation("WithHTTPClient", []interface{}{arg1})
+	fake.withHTTPClientMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeGoLogCacheClient) WithHTTPClientCallCount() int {
+	fake.withHTTPClientMutex.RLock()
+	defer fake.withHTTPClientMutex.RUnlock()
+	return len(fake.withHTTPClientArgsForCall)
+}
+
+func (fake *FakeGoLogCacheClient) WithHTTPClientCalls(stub func(clienta.HTTPClient) clienta.ClientOption) {
+	fake.withHTTPClientMutex.Lock()
+	defer fake.withHTTPClientMutex.Unlock()
+	fake.WithHTTPClientStub = stub
+}
+
+func (fake *FakeGoLogCacheClient) WithHTTPClientArgsForCall(i int) clienta.HTTPClient {
+	fake.withHTTPClientMutex.RLock()
+	defer fake.withHTTPClientMutex.RUnlock()
+	argsForCall := fake.withHTTPClientArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeGoLogCacheClient) WithHTTPClientReturns(result1 clienta.ClientOption) {
+	fake.withHTTPClientMutex.Lock()
+	defer fake.withHTTPClientMutex.Unlock()
+	fake.WithHTTPClientStub = nil
+	fake.withHTTPClientReturns = struct {
+		result1 clienta.ClientOption
+	}{result1}
+}
+
+func (fake *FakeGoLogCacheClient) WithHTTPClientReturnsOnCall(i int, result1 clienta.ClientOption) {
+	fake.withHTTPClientMutex.Lock()
+	defer fake.withHTTPClientMutex.Unlock()
+	fake.WithHTTPClientStub = nil
+	if fake.withHTTPClientReturnsOnCall == nil {
+		fake.withHTTPClientReturnsOnCall = make(map[int]struct {
+			result1 clienta.ClientOption
+		})
+	}
+	fake.withHTTPClientReturnsOnCall[i] = struct {
+		result1 clienta.ClientOption
+	}{result1}
+}
+
 func (fake *FakeGoLogCacheClient) WithViaGRPC(arg1 ...grpc.DialOption) clienta.ClientOption {
 	fake.withViaGRPCMutex.Lock()
 	ret, specificReturn := fake.withViaGRPCReturnsOnCall[len(fake.withViaGRPCArgsForCall)]
@@ -165,6 +315,10 @@ func (fake *FakeGoLogCacheClient) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
+	fake.newOauth2HTTPClientMutex.RLock()
+	defer fake.newOauth2HTTPClientMutex.RUnlock()
+	fake.withHTTPClientMutex.RLock()
+	defer fake.withHTTPClientMutex.RUnlock()
 	fake.withViaGRPCMutex.RLock()
 	defer fake.withViaGRPCMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/src/autoscaler/models/uaa_creds.go
+++ b/src/autoscaler/models/uaa_creds.go
@@ -1,0 +1,7 @@
+package models
+
+type UAACreds struct {
+	ClientID     string `yaml:"client_id" json:"clientID"`
+	ClientSecret string `yaml:"client_secret" json:"clientSecret"`
+	URL          string `yaml:"url" json:"url"`
+}

--- a/src/autoscaler/models/uaa_creds.go
+++ b/src/autoscaler/models/uaa_creds.go
@@ -1,7 +1,8 @@
 package models
 
 type UAACreds struct {
-	URL          string `yaml:"url" json:"url"`
-	ClientID     string `yaml:"client_id" json:"clientID"`
-	ClientSecret string `yaml:"client_secret" json:"clientSecret"`
+	URL               string `yaml:"url" json:"url"`
+	ClientID          string `yaml:"client_id" json:"clientID"`
+	ClientSecret      string `yaml:"client_secret" json:"clientSecret"`
+	SkipSSLValidation bool   `yaml:"skip_ssl_validation" json:"skipSSLValidation"`
 }

--- a/src/autoscaler/models/uaa_creds.go
+++ b/src/autoscaler/models/uaa_creds.go
@@ -1,7 +1,7 @@
 package models
 
 type UAACreds struct {
+	URL          string `yaml:"url" json:"url"`
 	ClientID     string `yaml:"client_id" json:"clientID"`
 	ClientSecret string `yaml:"client_secret" json:"clientSecret"`
-	URL          string `yaml:"url" json:"url"`
 }


### PR DESCRIPTION
- Establish eventgenerator connection with logcache via UAA
-  If UAA creds are provided , we favor the OAUTH HTTP implementation for https://github.com/cloudfoundry/go-log-cache in eventgenerator. Otherwise, GPRS based with metricsforwarder
