### PR TITLE
Add reviewers GH team as Concourse team owners

### DIFF
--- a/ci/terragrunt/app-autoscaler/concourse/teams.tf
+++ b/ci/terragrunt/app-autoscaler/concourse/teams.tf
@@ -3,7 +3,8 @@ resource "concourse_team" "app_autoscaler" {
 
   owners = [
     "group:github:sap-cloudfoundry:app-autoscaler",
-    "group:github:cloudfoundry:wg-app-runtime-interfaces-autoscaler-approvers"
+    "group:github:cloudfoundry:wg-app-runtime-interfaces-autoscaler-approvers",
+    "group:github:cloudfoundry:wg-app-runtime-interfaces-autoscaler-reviewers"
   ]
 }
 


### PR DESCRIPTION
Adds @wg-app-runtime-interfaces-autoscaler-reviewers to "app-autoscaler" Concourse team owners.