### PR TITLE
fix bug in the acceptance test cleanup.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,14 +335,17 @@ deploy-prometheus:
 	export BBL_STATE_PATH=$${BBL_STATE_PATH:-$(shell realpath "../app-autoscaler-env-bbl-state/bbl-state/")};\
 	${CI_DIR}/infrastructure/scripts/deploy-prometheus.sh;
 
-.PHONY: acceptance-tests
-acceptance-tests: vendor-app
-	${CI_DIR}/autoscaler/scripts/run-acceptance-tests.sh;
-
 .PHONY: deploy-cleanup
 deploy-cleanup:
 	@echo " - Cleaning up deployment '${DEPLOYMENT_NAME}'";\
 	${CI_DIR}/autoscaler/scripts/cleanup-autoscaler.sh;
+
+.PHONY: acceptance-tests
+acceptance-tests: vendor-app
+	${CI_DIR}/autoscaler/scripts/run-acceptance-tests.sh;
+
+acceptance-cleanup:
+	${CI_DIR}/autoscaler/scripts/cleanup-acceptance.sh;
 
 
 .PHONY: cleanup-concourse
@@ -405,3 +408,4 @@ docker-image: docker-login
 .PHONY: build-tools
 build-tools:
 	make -C src/autoscaler buildtools
+

--- a/src/acceptance/cleanup.sh
+++ b/src/acceptance/cleanup.sh
@@ -33,9 +33,9 @@ fi
 function delete_org(){
   local ORG=$1
 
-  if ! cf delete-org "$ORG" -f; then
+  if ! cf delete-org -f "$ORG"; then
     cf target -o "$ORG"
-    SERVICES=$(cf services | grep "${SERVICE_PREFIX}" |  awk 'NR>1 { print $1}')
+    SERVICES=$(cf services | grep "${SERVICE_PREFIX}" |  awk '{ print $1}')
     for SERVICE in $SERVICES; do
       cf purge-service-instance "$SERVICE" -f || echo "ERROR: purge-service-instance '$SERVICE' failed"
     done


### PR DESCRIPTION
- adding acceptance cleanup target
- Fixing bug in acceptance cleanup script
- When there is an issue with deleting the service binding there was a bug in creating the list of services to purge. This resulted in a failure to delete the organisations