### PR TITLE
replace docker-image with registry-image (concourse 7.8.3)

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -87,12 +87,12 @@ groups:
 
 resource_types:
 - name: gcs-resource
-  type: docker-image
+  type: registry-image
   source:
     repository: frodenas/gcs-resource
 
 - name: pull-request
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/bonzofenix/github-pr-resource
     tag: master

--- a/ci/autoscaler/set-pipeline.sh
+++ b/ci/autoscaler/set-pipeline.sh
@@ -7,6 +7,15 @@
 # Then  `TARGET=local set-pipeline.sh`
 set -euo pipefail
 
+if "$(which gh)" > /dev/null; then
+  echo "gh cli found"
+  gh --version
+else
+  echo "no gh cli found!"  
+  exit 1
+fi
+
+
 export PR_NUMBER=${PR_NUMBER:-$(gh pr view --json number --jq '.number' )}
 
 fly_args=""

--- a/ci/autoscaler/tasks/check-diego-cell-count.yml
+++ b/ci/autoscaler/tasks/check-diego-cell-count.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main

--- a/ci/autoscaler/tasks/cleanup-autoscaler-deployments.yml
+++ b/ci/autoscaler/tasks/cleanup-autoscaler-deployments.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-tools
     tag: main

--- a/ci/autoscaler/tasks/cleanup-autoscaler.yml
+++ b/ci/autoscaler/tasks/cleanup-autoscaler.yml
@@ -2,8 +2,8 @@
 platform: linux
 
 image_resource:
-  type: docker-image
-  source: 
+  type: registry-image
+  source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main
 

--- a/ci/autoscaler/tasks/deploy-autoscaler.yml
+++ b/ci/autoscaler/tasks/deploy-autoscaler.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main

--- a/ci/autoscaler/tasks/deploy-previous-autoscaler.yml
+++ b/ci/autoscaler/tasks/deploy-previous-autoscaler.yml
@@ -2,8 +2,8 @@
 platform: linux
 
 image_resource:
-  type: docker-image
-  source: 
+  type: registry-image
+  source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main
 

--- a/ci/autoscaler/tasks/make/make.yml
+++ b/ci/autoscaler/tasks/make/make.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-tools
     tag: main

--- a/ci/autoscaler/tasks/register-broker.yml
+++ b/ci/autoscaler/tasks/register-broker.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main

--- a/ci/autoscaler/tasks/release-autoscaler.yml
+++ b/ci/autoscaler/tasks/release-autoscaler.yml
@@ -2,8 +2,8 @@
 platform: linux
 
 image_resource:
-  type: docker-image
-  source: 
+  type: registry-image
+  source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main
 

--- a/ci/autoscaler/tasks/run-acceptance-tests.yml
+++ b/ci/autoscaler/tasks/run-acceptance-tests.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-tools
     tag: main

--- a/ci/autoscaler/tasks/run-integration-tests.yml
+++ b/ci/autoscaler/tasks/run-integration-tests.yml
@@ -2,8 +2,8 @@
 platform: linux
 
 image_resource:
-  type: docker-image
-  source: 
+  type: registry-image
+  source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-test
     tag: main
 inputs:

--- a/ci/autoscaler/tasks/run-unit-tests.yml
+++ b/ci/autoscaler/tasks/run-unit-tests.yml
@@ -2,8 +2,8 @@
 platform: linux
 
 image_resource:
-  type: docker-image
-  source: 
+  type: registry-image
+  source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-test
     tag: main
 

--- a/ci/autoscaler/tasks/update-sdk/task.yml
+++ b/ci/autoscaler/tasks/update-sdk/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main

--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -15,7 +15,7 @@ groups:
 
 resource_types:
 - name: gcs-resource
-  type: docker-image
+  type: registry-image
   source:
     repository: frodenas/gcs-resource
 

--- a/ci/infrastructure/tasks/check-for-existing-deployments.yml
+++ b/ci/infrastructure/tasks/check-for-existing-deployments.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main

--- a/ci/infrastructure/tasks/combine-ops.yml
+++ b/ci/infrastructure/tasks/combine-ops.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main

--- a/ci/infrastructure/tasks/deploy-prometheus.yml
+++ b/ci/infrastructure/tasks/deploy-prometheus.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/app-autoscaler-release-deploy
     tag: main

--- a/ci/terragrunt/app-autoscaler/concourse/pipelines/api-tester/pipeline.yml
+++ b/ci/terragrunt/app-autoscaler/concourse/pipelines/api-tester/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: ghcr.io/cloudfoundry/app-autoscaler-ci-test
           tag: master


### PR DESCRIPTION
`docker-image` is failing on concourse 7.8.3
https://github.com/concourse/registry-image-resource