### PR TITLE
use buildpack option as var (instead the one defined in app manifest)

### DIFF
--- a/src/acceptance/assets/app/nodeApp/app_manifest.yml
+++ b/src/acceptance/assets/app/nodeApp/app_manifest.yml
@@ -7,8 +7,6 @@ applications:
       SERVICE_NAME: ((service_name))
       NODE_ENV: production
       MEMORY_MAX: ((memory_mb))
-    buildpacks:
-      - ((buildpack))
     stack: cflinuxfs3
     routes:
       - route: ((app_name)).((app_domain))


### PR DESCRIPTION
Upon pushing a cf app, buildpack options is used. Previously, the sample node JS app uses the buildpack option from he manifest. 

The current implementation used buidpack options as cli var 

**Usage** 
[https://github.com/cloudfoundry/app-autoscaler-release/blob/main/src/acceptance/helpers/apps.go#L97](https://github.com/cloudfoundry/app-autoscaler-release/blob/main/src/acceptance/helpers/apps.go#L97)