### PR TITLE
Revert prometheus deployment with ubuntu-jammy change

### DIFF
--- a/ci/infrastructure/scripts/deploy-prometheus.sh
+++ b/ci/infrastructure/scripts/deploy-prometheus.sh
@@ -26,7 +26,6 @@ ops_files=${OPS_FILES:-"${prometheus_ops}/monitor-bosh.yml\
                         ${prometheus_ops}/enable-cf-loggregator-v2.yml\
                         ${prometheus_ops}/monitor-bosh-director.yml\
                         ${prometheus_ops}/alertmanager-slack-receiver.yml\
-                        ${prometheus_ops}/use-jammy-stemcell.yml\
                         ${ci_dir}/operations/prometheus-customize-alerts.yml\
                         ${ci_dir}/operations/slack-receiver-template.yml\
                         ${ci_dir}/operations/prometheus-nats-tls.yml\


### PR DESCRIPTION
Prometheus deployment continue to use ubuntu-bionic stemcell 

Revert [de44df72fa9d51db1f96bf3c0b4fbc36606e28de](https://github.com/cloudfoundry/app-autoscaler-release/commit/de44df72fa9d51db1f96bf3c0b4fbc36606e28de)