### PR TITLE
Fix #1059: Tweak the mem util test limits to work on more environments

### DIFF
--- a/src/acceptance/app/dynamic_policy_test.go
+++ b/src/acceptance/app/dynamic_policy_test.go
@@ -36,7 +36,7 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 		Context("There is a scale out and scale in policy", func() {
 			var heapToUse int64
 			BeforeEach(func() {
-				heapToUse = int64(math.Min(float64(cfg.NodeMemoryLimit-20), 200))
+				heapToUse = int64(math.Min(float64(cfg.NodeMemoryLimit-28), 200))
 
 				if AppResidentSize+30 >= heapToUse {
 					Fail("There is not enough app memory in the app to run this test.\n - app resident size %d\n - app memory limit: %d\n - heap to use: %d", AppResidentSize, cfg.NodeMemoryLimit, int(heapToUse))


### PR DESCRIPTION
Tweaking the limits of the memory utilisation tests to work on more environments.
#1059 