### PR TITLE
Use MySQL new mvn Coordinates starting from v8.0.31

### DIFF
--- a/src/scheduler/pom.xml
+++ b/src/scheduler/pom.xml
@@ -81,8 +81,8 @@
             <version>42.5.1</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>8.0.31</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Changed MySQL maven dependency in the scheduler pom (as listed in [affected Build ](https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/3893024545/jobs/6645365887#step:4:129))

```
....
[INFO] ---------------< org.cloudfoundry.autoscaler:scheduler >----------------
[INFO] Building scheduler 1.0-SNAPSHOT
[INFO] --------------------------------[ war ]---------------------------------
Warning:  The artifact mysql:mysql-connector-java:jar:8.0.31 has been relocated to com.mysql:mysql-connector-j:jar:8.0.31: MySQL Connector/J artifacts moved to reverse-DNS compliant Maven 2+ coordinates.
[INFO] ....
......
```

[Maven Docs](https://search.maven.org/artifact/mysql/mysql-connector-java/8.0.31/jar)
