### PR TITLE
Restore previous handling of long passwords

### DIFF
--- a/src/autoscaler/healthendpoint/server.go
+++ b/src/autoscaler/healthendpoint/server.go
@@ -135,6 +135,10 @@ func getPasswordHashBytes(logger lager.Logger, passwordHash string, password str
 	var passwordHashByte []byte
 	var err error
 	if passwordHash == "" {
+		if len(password) > 72 {
+			logger.Error("warning-configured-password-too-long-using-only-first-72-characters", bcrypt.ErrPasswordTooLong, lager.Data{"password-length": len(password)})
+			password = password[:72]
+		}
 		passwordHashByte, err = bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost) // use MinCost as the config already provided it as cleartext
 		if err != nil {
 			logger.Error("failed-new-server-password", err)
@@ -150,6 +154,10 @@ func getUserHashBytes(logger lager.Logger, usernameHash string, username string)
 	var usernameHashByte []byte
 	var err error
 	if usernameHash == "" {
+		if len(username) > 72 {
+			logger.Error("warning-configured-username-too-long-using-only-first-72-characters", bcrypt.ErrPasswordTooLong, lager.Data{"username-length": len(username)})
+			username = username[:72]
+		}
 		// when username and password are set for health check
 		usernameHashByte, err = bcrypt.GenerateFromPassword([]byte(username), bcrypt.MinCost) // use MinCost as the config already provided it as cleartext
 		if err != nil {

--- a/templates/app-autoscaler.yml
+++ b/templates/app-autoscaler.yml
@@ -706,11 +706,11 @@ variables:
 - name: service_broker_password
   type: password
   options:
-    length: 72
+    length: 128
 - name: service_broker_password_blue
   type: password
   options:
-    length: 72
+    length: 128
 - name: autoscaler_metricsforwarder_health_password
   type: password
 - name: autoscaler_metricsgateway_health_password


### PR DESCRIPTION
Configured passwords for the servicebroker and the healthendpoints were
previously (before #1249) [silently truncated to the first 72 bytes][1].

This change restores the truncation to the first 72 bytes, but adds an
error level warning (as `lager` does not have a dedicated warning
level), documenting this truncation, so previously configured passwords
longer than 72 bytes will continue to work unchanged.

Prior to this PR, since #1249, passwords longer than 72 bytes would cause an error.

[1]: https://github.com/golang/go/issues/36546
