### PR TITLE
Use CF Rest API to Download Droplet

### DIFF
--- a/src/acceptance/helpers/cleanup.go
+++ b/src/acceptance/helpers/cleanup.go
@@ -18,8 +18,7 @@ func CleanupOrgs(cfg *config.Config, wfh *workflowhelpers.ReproducibleTestSuiteS
 	By("Clearing down existing test orgs/spaces... Complete")
 }
 
-func CleanupInExistingOrg(cfg *config.Config) {
-	setup := workflowhelpers.NewTestSuiteSetup(cfg)
+func CleanupInExistingOrg(cfg *config.Config, setup *workflowhelpers.ReproducibleTestSuiteSetup) {
 	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
 		if cfg.UseExistingOrganization {
 			targetOrgWithSpace(setup.GetOrganizationName(), "", cfg.DefaultTimeoutDuration())

--- a/src/acceptance/run_performance/run_performance_suite_test.go
+++ b/src/acceptance/run_performance/run_performance_suite_test.go
@@ -66,18 +66,19 @@ var _ = AfterSuite(func() {
 	if os.Getenv("SKIP_TEARDOWN") == "true" {
 		fmt.Println("Skipping Teardown...")
 	} else {
-		cleanup(cfg)
+		cleanup(cfg, setup)
 		setup.Teardown()
 	}
 })
 
-func cleanup(cfg *config.Config) {
-	fmt.Printf("\n\nCleaning up test leftovers...\n")
-	if cfg.UseExistingOrganization {
-		CleanupInExistingOrg(cfg)
-	} else {
-		DeleteOrgs(GetTestOrgs(cfg), time.Duration(120)*time.Second)
-	}
-
-	fmt.Printf("\n\nCleaning up test leftovers...completed")
+func cleanup(cfg *config.Config, setup *workflowhelpers.ReproducibleTestSuiteSetup) {
+	fmt.Printf("\nCleaning up test leftovers...")
+	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
+		if cfg.UseExistingOrganization {
+			CleanupInExistingOrg(cfg, setup)
+		} else {
+			DeleteOrgs(GetTestOrgs(cfg), time.Duration(120)*time.Second)
+		}
+	})
+	fmt.Printf("\nCleaning up test leftovers...completed")
 }

--- a/src/acceptance/setup_performance/setup_performance_suite_test.go
+++ b/src/acceptance/setup_performance/setup_performance_suite_test.go
@@ -35,7 +35,7 @@ var _ = BeforeSuite(func() {
 	if os.Getenv("SKIP_TEARDOWN") == "true" {
 		fmt.Println("Skipping Teardown...")
 	} else {
-		cleanup(cfg)
+		cleanup(cfg, setup)
 	}
 	setup = workflowhelpers.NewRunawayAppTestSuiteSetup(cfg)
 	setup.Setup()
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	fmt.Print("\ncreating droplet...")
-	nodeAppDropletPath = CreateDroplet(*cfg)
+	nodeAppDropletPath = CreateDroplet(cfg)
 	fmt.Println("done")
 })
 
@@ -73,12 +73,14 @@ func updateOrgQuotaForPerformanceTest(orgGuid string) {
 	}
 }
 
-func cleanup(cfg *config.Config) {
+func cleanup(cfg *config.Config, setup *workflowhelpers.ReproducibleTestSuiteSetup) {
 	fmt.Printf("\nCleaning up test leftovers...")
-	if cfg.UseExistingOrganization {
-		CleanupInExistingOrg(cfg)
-	} else {
-		DeleteOrgs(GetTestOrgs(cfg), time.Duration(120)*time.Second)
-	}
+	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
+		if cfg.UseExistingOrganization {
+			CleanupInExistingOrg(cfg, setup)
+		} else {
+			DeleteOrgs(GetTestOrgs(cfg), time.Duration(120)*time.Second)
+		}
+	})
 	fmt.Printf("\nCleaning up test leftovers...completed")
 }


### PR DESCRIPTION
`cf download-droplet` fails to download app droplet

```
<?xml version='1.0' encoding='UTF-8'?><Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your Google secret key and signing method.</Message><StringToSign>GET

  application/json
  1679504433
  /droplet-q_ioaqk91dw/41/c8/41c8e0f4-d92b-41ce-895b-4fdd7ae21751/97f60524ba3df900f4baa4b485f014fe8f0efc46</StringToSign></Error>
```

Use Cf curl for downloading droplet from blobstore

This issue was already reported [here](https://github.com/cloudfoundry/cli/issues/1165#issuecomment-310925846)