### PR TITLE
acceptance tests: allow overriding of component health endpoints

### DIFF
--- a/src/acceptance/api/basic_auth_test.go
+++ b/src/acceptance/api/basic_auth_test.go
@@ -11,7 +11,25 @@ import (
 var _ = Describe("AutoScaler Basic Auth Tests", func() {
 
 	urlfor := func(name string) func() string {
-		return func() string { return strings.Replace(healthURL, cfg.ServiceName, cfg.ServiceName+"-"+name, 1) }
+		return func() string {
+			override := ""
+			switch name {
+			case "eventgenerator":
+				override = cfg.EventgeneratorHealthEndpoint
+			case "scalingengine":
+				override = cfg.ScalingengineHealthEndpoint
+			case "operator":
+				override = cfg.OperatorHealthEndpoint
+			case "metricsforwarder":
+				override = cfg.MetricsforwarderHealthEndpoint
+			case "scheduler":
+				override = cfg.SchedulerHealthEndpoint
+			}
+			if override != "" {
+				return override
+			}
+			return strings.Replace(healthURL, cfg.ServiceName, cfg.ServiceName+"-"+name, 1)
+		}
 	}
 	DescribeTable("basic auth tests",
 		func(url func() string, statusCode func() int) {

--- a/src/acceptance/config/config.go
+++ b/src/acceptance/config/config.go
@@ -75,6 +75,12 @@ type Config struct {
 	ServiceOfferingEnabled bool   `json:"service_offering_enabled"`
 	EnableServiceAccess    bool   `json:"enable_service_access"`
 
+	EventgeneratorHealthEndpoint   string `json:"eventgenerator_health_endpoint"`
+	ScalingengineHealthEndpoint    string `json:"scalingengine_health_endpoint"`
+	OperatorHealthEndpoint         string `json:"operator_health_endpoint"`
+	MetricsforwarderHealthEndpoint string `json:"metricsforwarder_health_endpoint"`
+	SchedulerHealthEndpoint        string `json:"scheduler_health_endpoint"`
+
 	HealthEndpointsBasicAuthEnabled bool `json:"health_endpoints_basic_auth_enabled"`
 
 	CPUUpperThreshold int64 `json:"cpu_upper_threshold"`
@@ -112,6 +118,12 @@ var defaults = Config{
 
 	UseExistingOrganization: false,
 	ExistingOrganization:    "",
+
+	EventgeneratorHealthEndpoint:   "",
+	ScalingengineHealthEndpoint:    "",
+	OperatorHealthEndpoint:         "",
+	MetricsforwarderHealthEndpoint: "",
+	SchedulerHealthEndpoint:        "",
 
 	Performance: PerformanceConfig{
 		AppCount:                      100,
@@ -178,15 +190,55 @@ func validate(c *Config) {
 	if c.ASApiEndpoint == "" {
 		AbortSuite("missing configuration 'autoscaler_api'")
 	} else {
-		c.ASApiEndpoint = strings.TrimSuffix(c.ASApiEndpoint, "/")
-		if !strings.HasPrefix(c.ASApiEndpoint, "http") {
-			if c.UseHttp {
-				c.ASApiEndpoint = "http://" + c.ASApiEndpoint
-			} else {
-				c.ASApiEndpoint = "https://" + c.ASApiEndpoint
-			}
+		c.ASApiEndpoint = normalizeURL(c.ASApiEndpoint, c.UseHttp)
+	}
+
+	if c.EventgeneratorHealthEndpoint != "" {
+		c.EventgeneratorHealthEndpoint = normalizeURL(
+			c.EventgeneratorHealthEndpoint,
+			c.UseHttp,
+		)
+	}
+
+	if c.ScalingengineHealthEndpoint != "" {
+		c.ScalingengineHealthEndpoint = normalizeURL(
+			c.ScalingengineHealthEndpoint,
+			c.UseHttp,
+		)
+	}
+
+	if c.OperatorHealthEndpoint != "" {
+		c.OperatorHealthEndpoint = normalizeURL(
+			c.OperatorHealthEndpoint,
+			c.UseHttp,
+		)
+	}
+
+	if c.MetricsforwarderHealthEndpoint != "" {
+		c.MetricsforwarderHealthEndpoint = normalizeURL(
+			c.MetricsforwarderHealthEndpoint,
+			c.UseHttp,
+		)
+	}
+
+	if c.SchedulerHealthEndpoint != "" {
+		c.SchedulerHealthEndpoint = normalizeURL(
+			c.SchedulerHealthEndpoint,
+			c.UseHttp,
+		)
+	}
+}
+
+func normalizeURL(url string, useHttp bool) string {
+	url = strings.TrimSuffix(url, "/")
+	if !strings.HasPrefix(url, "http") {
+		if useHttp {
+			url = "http://" + url
+		} else {
+			url = "https://" + url
 		}
 	}
+	return url
 }
 
 func loadConfigFromPath(path string, config *Config) error {


### PR DESCRIPTION
Hi,

The way the basic-auth tests currently determine their target urls is only ever going to work if the endpoints follow a very specific naming scheme (curiously, related to the autoscaler service plan name of the deployment).

This change allows these urls to be explicitly overridden via the e.g. `eventgenerator_health_endpoint` config parameter. Not particularly pretty, but retains the old attempt at autodiscovery when these parameters aren't specified.