### PR TITLE
Fix Scheduler Database Credentials Syntax in  Bosh Jobs Template

### DIFF
--- a/jobs/scheduler/templates/scheduler.yml.erb
+++ b/jobs/scheduler/templates/scheduler.yml.erb
@@ -71,18 +71,18 @@ spring:
   main:
     allow-bean-definition-overriding: true
   ############################################################
-  #    DataSources
+  #    DataSources - #qoutes required to ensure data type safety
   ############################################################
   datasource:
     driverClassName: <%=datasource_driver_class_name%>
-    password: <%=schedulerdb_role['password'] %>
+    password: "<%=schedulerdb_role['password'] %>"
     url: <%=schedulerdb_url %>
-    username: <%=schedulerdb_role['name'] %>
+    username: "<%=schedulerdb_role['name'] %>"
   policy-db-datasource:
     driverClassName: <%=datasource_policy_db_class_name%>
-    password: <%=policydb_role['password'] %>
+    password: "<%=policydb_role['password'] %>"
     url: <%=policydb_url %>
-    username: <%=policydb_role['name'] %>
+    username: "<%=policydb_role['name'] %>"
   ############################################################
   #    Quartz Properties
   ############################################################
@@ -131,9 +131,9 @@ scalingenginejob:
 ############################################################
 scheduler:
   healthserver:
-    password: <%=p('autoscaler.scheduler.health.password') %>
+    password: "<%=p('autoscaler.scheduler.health.password') %>"
     port: <%=p('autoscaler.scheduler.health.port') %>
-    username: <%=p('autoscaler.scheduler.health.username') %>
+    username: "<%=p('autoscaler.scheduler.health.username') %>"
     basicAuthEnabled: <%=p('autoscaler.scheduler.health.basicAuthEnabled') %>
     unprotected_endpoints: <%=p('autoscaler.scheduler.health.unprotected_endpoints') %>
 ############################################################

--- a/spec/fixtures/scheduler.yml
+++ b/spec/fixtures/scheduler.yml
@@ -2,13 +2,13 @@ autoscaler:
   scheduler_db:
     address: 10.11.137.101
     databases:
-      - name: foo
-        password: default
+      - name: "2222e123"
+        password: "default"
         tag: default
     db_scheme: postgres
     port: 5432
     roles:
-      - name: foo
+      - name: 2222e123
         password: default
         tag: default
     tls:

--- a/spec/jobs/scheduler/scheduler_spec.rb
+++ b/spec/jobs/scheduler/scheduler_spec.rb
@@ -11,7 +11,7 @@ describe "scheduler" do
   let(:properties) { YAML.safe_load(fixture("scheduler.yml").read) }
   let(:rendered_template) { YAML.safe_load(template.render(properties)) }
 
-  context "config/scheduler.yml" do
+  context "Health Configuration" do
     it "does set neither username nor password if not configured" do
       properties["autoscaler"]["scheduler"] = {
         "health" => {
@@ -26,8 +26,8 @@ describe "scheduler" do
         {"scheduler" => {
           "healthserver" => {
             "port" => 1234,
-            "username" => nil,
-            "password" => nil,
+            "username" => "",
+            "password" => "",
             "basicAuthEnabled" => false,
             "unprotected_endpoints" => []
           }
@@ -82,6 +82,22 @@ describe "scheduler" do
           }
         }}
       )
+    end
+  end
+
+  context "Datasource Configuration" do
+    it "verify database username and password have string types" do
+      rendered_template = YAML.safe_load(template.render(properties))
+
+      print rendered_template
+      expect(rendered_template["spring"]["datasource"]["username"]).to be_kind_of(String)
+      expect(rendered_template["spring"]["datasource"]["username"]).not_to be_kind_of(Float)
+      expect(rendered_template["spring"]["datasource"]["username"]).not_to eq(2222e123)
+      expect(rendered_template["spring"]["datasource"]["username"]).to eq("2222e123")
+
+      expect(rendered_template["spring"]["datasource"]["password"]).to be_kind_of(String)
+      expect(rendered_template["spring"]["datasource"]["password"]).not_to be_kind_of(Float)
+      expect(rendered_template["spring"]["datasource"]["password"]).to eq("default")
     end
   end
 end

--- a/src/scheduler/src/main/resources/application.yml
+++ b/src/scheduler/src/main/resources/application.yml
@@ -22,14 +22,14 @@ spring:
     ############################################################
     datasource:
         driverClassName: org.postgresql.Driver
-        password: postgres
+        password: "postgres"
         url: jdbc:postgresql://${DB_HOST}/autoscaler
-        username: postgres
+        username: "postgres"
     policy-db-datasource:
         driverClassName: org.postgresql.Driver
-        password: postgres
+        password: "postgres"
         url: jdbc:postgresql://${DB_HOST}/autoscaler
-        username: postgres
+        username: "postgres"
 
     ############################################################
     #    Quartz Properties
@@ -100,10 +100,10 @@ scalingenginejob:
 ############################################################
 scheduler:
     healthserver:
-        password: test-password
+        password: "test-password"
         port: 8081
         unprotectedEndpoints: /health/prometheus,/health/liveness
-        username: test-user
+        username: "test-user"
 ############################################################
 #    Server SSL keys
 ############################################################

--- a/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/conf/DataSourceConfigTest.java
+++ b/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/conf/DataSourceConfigTest.java
@@ -1,0 +1,51 @@
+package org.cloudfoundry.autoscaler.scheduler.conf;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(value = DataSourceProperties.class)
+@SpringBootTest
+public class DataSourceConfigTest {
+
+  @Qualifier("primary")
+  @Autowired
+  private DataSourceProperties properties;
+
+  @Qualifier("policy")
+  @Autowired
+  private DataSourceProperties policyDbProperties;
+
+  @Test
+  void datasourceCredentialsHasStringType() {
+    boolean isUsernameInStringFormat = properties.getUsername() instanceof String;
+    assertFalse(!isUsernameInStringFormat);
+
+    assertInstanceOf(
+        String.class, properties.getUsername(), "datasource db username should be of type string");
+    assertInstanceOf(
+        String.class, properties.getPassword(), "datasource db password should be of type string");
+  }
+
+  @Test
+  void policyDbCredentialsHasStringType() {
+    boolean isUsernameInStringFormat = policyDbProperties.getUsername() instanceof String;
+    assertFalse(!isUsernameInStringFormat);
+
+    assertInstanceOf(
+        String.class,
+        policyDbProperties.getUsername(),
+        "policy db username should be of type string");
+    assertInstanceOf(
+        String.class, policyDbProperties.getPassword(), "db password should be of type string");
+  }
+}


### PR DESCRIPTION
Having YAML configurations, strings starting with numbers e.g. 229259e82505 could infer unwanted data types e.g. Integer, Float, Double, etc. As a result, the scheduler app does not connect to an underlying database and raises an exception.

For instance,  string _229259e82505_ (without quotes) as the username of the datasource is interpreted as "Infinity"(non-existent user in the database)


**FIX**
Treating username and password as String in double quotes (") to ensure the string credentials are passed to the database correclty

**Stacktrace**

```
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'dataSourceScriptDatabaseInitializer' defined in class path resource [org/springframework/boot/autoconfigure/sql/init/DataSourceInitializationConfigurat
ion.class]: Unsatisfied dependency expressed through method 'dataSourceScriptDatabaseInitializer' parameter 0: Error creating bean with name 'dataSource': Failed to connect to datasource:dataSource
		at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:800) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:550) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1332) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1162) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:560) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:520) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:326) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:324) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:313) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1132) ~[spring-context-6.0.8.jar!/:6.0.8]
		at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:907) ~[spring-context-6.0.8.jar!/:6.0.8]
		at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:584) ~[spring-context-6.0.8.jar!/:6.0.8]
		at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.0.6.jar!/:3.0.6]
		at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:732) ~[spring-boot-3.0.6.jar!/:3.0.6]
		at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:434) ~[spring-boot-3.0.6.jar!/:3.0.6]
		at org.springframework.boot.SpringApplication.run(SpringApplication.java:310) ~[spring-boot-3.0.6.jar!/:3.0.6]
		at org.springframework.boot.SpringApplication.run(SpringApplication.java:1304) ~[spring-boot-3.0.6.jar!/:3.0.6]
		at org.springframework.boot.SpringApplication.run(SpringApplication.java:1293) ~[spring-boot-3.0.6.jar!/:3.0.6]
		at org.cloudfoundry.autoscaler.scheduler.SchedulerApplication.main(SchedulerApplication.java:56) ~[classes!/:1.0-SNAPSHOT]
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
		at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
		at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49) ~[scheduler-1.0-SNAPSHOT.war:1.0-SNAPSHOT]
		at org.springframework.boot.loader.Launcher.launch(Launcher.java:95) ~[scheduler-1.0-SNAPSHOT.war:1.0-SNAPSHOT]
		at org.springframework.boot.loader.Launcher.launch(Launcher.java:58) ~[scheduler-1.0-SNAPSHOT.war:1.0-SNAPSHOT]
		at org.springframework.boot.loader.WarLauncher.main(WarLauncher.java:59) ~[scheduler-1.0-SNAPSHOT.war:1.0-SNAPSHOT]
Caused by: org.cloudfoundry.autoscaler.scheduler.util.error.DataSourceConfigurationException: Error creating bean with name 'dataSource': Failed to connect to datasource:dataSource
		at org.cloudfoundry.autoscaler.scheduler.beanPostProcessor.DatasourceBeanPostProcessor.postProcessAfterInitialization(DatasourceBeanPostProcessor.java:33) ~[classes!/:1.0-SNAPSHOT]
		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsAfterInitialization(AbstractAutowireCapableBeanFactory.java:434) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1773) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:598) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:520) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:326) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:324) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:254) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1417) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1337) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:887) ~[spring-beans-6.0.8.jar!/:6.0.8]
		at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:791) ~[spring-beans-6.0.8.jar!/:6.0.8]
		... 29 common frames omitted
Caused by: java.sql.SQLException: Cannot create PoolableConnectionFactory (FATAL: password authentication failed for user "Infinity")
		at org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:653) ~[commons-dbcp2-2.9.0.jar!/:2.9.0]
		at org.apache.commons.dbcp2.BasicDataSource.createDataSource(BasicDataSource.java:531) ~[commons-dbcp2-2.9.0.jar!/:2.9.0]
		at org.apache.commons.dbcp2.BasicDataSource.getConnection(BasicDataSource.java:731) ~[commons-dbcp2-2.9.0.jar!/:2.9.0]
		at org.cloudfoundry.autoscaler.scheduler.beanPostProcessor.DatasourceBeanPostProcessor.postProcessAfterInitialization(DatasourceBeanPostProcessor.java:29) ~[classes!/:1.0-SNAPSHOT]
		... 42 common frames omitted
Caused by: org.postgresql.util.PSQLException: FATAL: password authentication failed for user "Infinity"
		at org.postgresql.core.v3.ConnectionFactoryImpl.doAuthentication(ConnectionFactoryImpl.java:693) ~[postgresql-42.6.0.jar!/:42.6.0]
		at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:203) ~[postgresql-42.6.0.jar!/:42.6.0]
		at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:258) ~[postgresql-42.6.0.jar!/:42.6.0]
		at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54) ~[postgresql-42.6.0.jar!/:42.6.0]
		at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:263) ~[postgresql-42.6.0.jar!/:42.6.0]
		at org.postgresql.Driver.makeConnection(Driver.java:443) ~[postgresql-42.6.0.jar!/:42.6.0]
		at org.postgresql.Driver.connect(Driver.java:297) ~[postgresql-42.6.0.jar!/:42.6.0]
		at org.apache.commons.dbcp2.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:52) ~[commons-dbcp2-2.9.0.jar!/:2.9.0]
		at org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:374) ~[commons-dbcp2-2.9.0.jar!/:2.9.0]
		at org.apache.commons.dbcp2.BasicDataSource.validateConnectionFactory(BasicDataSource.java:106) ~[commons-dbcp2-2.9.0.jar!/:2.9.0]
		at org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:649) ~[commons-dbcp2-2.9.0.jar!/:2.9.0]
		... 45 common frames omitted
```