### PR TITLE
Reducing the `prConcurrentLimit` to `2`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "platformAutomerge": true,
   "automergeStrategy": "squash",
+  "prConcurrentLimit": 2,
   "packageRules": [
     {
       "description": "Opt-out minimum Go version updates: https://github.com/renovatebot/renovate/issues/16715",


### PR DESCRIPTION
As runners are scarce in the `cloudfoundry` org,
we want to limit the number of concurrent PRs.

Every renovate PR gets rebased after every commit to main for
[good reasons](https://docs.renovatebot.com/configuration-options/#rebasewhen).

This means if there are the default `10` PRs open concurrently,
merging one PR currently triggers at least 9 * 31 = 279 workflows.

I chose the value of `2` so that if one PR fails to validate
consistently there's a second slot for other PRs. If two PRs
fail to validate consistently, probably a deeper look is necessary
anyways.
