### PR TITLE
Replace DBCP2 database connection pool implementation with HikariCP

### DIFF
--- a/src/scheduler/pom.xml
+++ b/src/scheduler/pom.xml
@@ -86,11 +86,6 @@
             <version>8.2.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-            <version>2.10.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
         </dependency>

--- a/src/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/DataSourceConfig.java
+++ b/src/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/conf/DataSourceConfig.java
@@ -1,8 +1,8 @@
 package org.cloudfoundry.autoscaler.scheduler.conf;
 
+import com.zaxxer.hikari.HikariDataSource;
 import java.util.Properties;
 import javax.sql.DataSource;
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.cloudfoundry.autoscaler.scheduler.beanPostProcessor.DatasourceBeanPostProcessor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -24,7 +24,7 @@ public class DataSourceConfig {
   @Qualifier("primary")
   @ConfigurationProperties(prefix = "spring.datasource")
   public DataSource dataSource(@Qualifier("primary") DataSourceProperties properties) {
-    return properties.initializeDataSourceBuilder().type(BasicDataSource.class).build();
+    return properties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
   }
 
   @Bean
@@ -45,7 +45,7 @@ public class DataSourceConfig {
   @Qualifier("policy")
   @ConfigurationProperties("spring.policy-db-datasource")
   public DataSource policyDbDataSource(@Qualifier("policy") DataSourceProperties properties) {
-    return properties.initializeDataSourceBuilder().type(BasicDataSource.class).build();
+    return properties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
   }
 
   @Bean

--- a/src/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/health/DbStatusCollector.java
+++ b/src/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/health/DbStatusCollector.java
@@ -1,11 +1,11 @@
 package org.cloudfoundry.autoscaler.scheduler.health;
 
+import com.zaxxer.hikari.HikariDataSource;
 import io.prometheus.client.Collector;
 import io.prometheus.client.GaugeMetricFamily;
 import java.util.ArrayList;
 import java.util.List;
 import javax.sql.DataSource;
-import org.apache.commons.dbcp2.BasicDataSource;
 
 public class DbStatusCollector extends Collector {
 
@@ -24,53 +24,42 @@ public class DbStatusCollector extends Collector {
 
   private DataSource policyDbDataSource;
 
-  private List<MetricFamilySamples> collectForDataSource(BasicDataSource dataSource, String name) {
-    List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+  private List<MetricFamilySamples> collectForDataSource(HikariDataSource dataSource, String name) {
+    List<MetricFamilySamples> mfs = new ArrayList<>();
     mfs.add(
         new GaugeMetricFamily(
-            namespace + "_" + subSystem + name + "_initial_size",
-            "The initial number of connections that are created when the pool is started",
-            dataSource.getInitialSize()));
-    mfs.add(
-        new GaugeMetricFamily(
-            namespace + "_" + subSystem + name + "_max_active",
+            namespace + "_" + subSystem + name + "_max_size",
             "The maximum number of active connections that can be allocated from this pool at the"
                 + " same time, or negative for no limit",
-            dataSource.getMaxTotal()));
-    mfs.add(
-        new GaugeMetricFamily(
-            namespace + "_" + subSystem + name + "_max_idle",
-            "The maximum number of connections that can remain idle in the pool, without extra ones"
-                + " being released, or negative for no limit.",
-            dataSource.getMaxIdle()));
+            dataSource.getMaximumPoolSize()));
     mfs.add(
         new GaugeMetricFamily(
             namespace + "_" + subSystem + name + "_min_idle",
             "The minimum number of active connections that can remain idle in the pool, without"
                 + " extra ones being created, or 0 to create none.",
-            dataSource.getMinIdle()));
+            dataSource.getMinimumIdle()));
     mfs.add(
         new GaugeMetricFamily(
             namespace + "_" + subSystem + name + "_active_connections_number",
             "The current number of active connections that have been allocated from this data"
                 + " source",
-            dataSource.getNumActive()));
+            dataSource.getHikariPoolMXBean().getActiveConnections()));
     mfs.add(
         new GaugeMetricFamily(
             namespace + "_" + subSystem + name + "_idle_connections_number",
             "The current number of idle connections that are waiting to be allocated from this data"
                 + " source",
-            dataSource.getNumIdle()));
+            dataSource.getHikariPoolMXBean().getIdleConnections()));
     return mfs;
   }
 
   @Override
   public List<MetricFamilySamples> collect() {
     List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
-    BasicDataSource basicDataSource = (BasicDataSource) this.dataSource;
+    HikariDataSource basicDataSource = (HikariDataSource) this.dataSource;
     mfs.addAll(collectForDataSource(basicDataSource, "_data_source"));
 
-    BasicDataSource policyBasicDataSource = (BasicDataSource) this.policyDbDataSource;
+    HikariDataSource policyBasicDataSource = (HikariDataSource) this.policyDbDataSource;
     mfs.addAll(collectForDataSource(policyBasicDataSource, "_policy_db_data_source"));
     return mfs;
   }

--- a/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/SchedulerApplicationTest.java
+++ b/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/SchedulerApplicationTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.autoscaler.scheduler;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,13 +14,12 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class SchedulerApplicationTest {
-  @Autowired private BasicDataSource dataSource;
+  @Autowired private HikariDataSource dataSource;
 
   @Test
   public void testTomcatConnectionPoolNameCorrect() {
     assertThat(
-        dataSource.getClass().getName(),
-        equalToIgnoringCase("org.apache.commons.dbcp2.BasicDataSource"));
+        dataSource.getClass().getName(), equalToIgnoringCase("com.zaxxer.hikari.HikariDataSource"));
   }
 
   @Test


### PR DESCRIPTION
HikariCP is the default Spring Boot database connection pool
implementation and the current implementation of choice.
