### PR TITLE
fix(codeql): disable renovate golang updates

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -6,7 +6,7 @@ concourse 7.11.0
 direnv 2.33.0
 gcloud 456.0.0
 ginkgo 2.13.2
-golang 1.21.5
+golang 1.20.7
 golangci-lint 1.55.2
 java temurin-17.0.9+9
 make 4.4

--- a/ci/dockerfiles/autoscaler-tools/Dockerfile
+++ b/ci/dockerfiles/autoscaler-tools/Dockerfile
@@ -45,7 +45,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg m
 
 # install golang
 # renovate: datasource=golang-version depName=golang
-ARG GO_VERSION=1.21.5
+ARG GO_VERSION=1.21.4
 ENV GOPATH $HOME/go
 ENV PATH $HOME/go/bin:/usr/local/go/bin:$PATH
 RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -P /tmp &&\

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
     {
       "description": "Disable asdf Go version updates, as they are taken care by our bosh-package-golang-release-based automation",
       "matchManagers": ["asdf"],
-      "matchDepTypes": ["golang"],
+      "matchDepNames": ["golang"],
       "enabled": false
     },
     {


### PR DESCRIPTION
- Revert "chore(deps): update dependency golang to v1.21.5 (#2421)"
- fixup! Fix CodeQL scanning (#2215)
