### PR TITLE
Document that `-1` is our "not applicable" value

### DIFF
--- a/api/scaling-history-api.openapi.yaml
+++ b/api/scaling-history-api.openapi.yaml
@@ -165,14 +165,14 @@ components:
         old_instances:
           type: integer
           format: int64
-          minimum: 0
-          description: The number of instances before the scaling.
+          minimum: -1
+          description: The number of instances before the scaling. -1 means that the value is not applicable.
           example: 1
         new_instances:
           type: integer
           format: int64
-          minimum: 0
-          description: The number of instances after the scaling.
+          minimum: -1
+          description: The number of instances after the scaling. -1 means that the value is not applicable.
           example: 2
         reason:
           type: string

--- a/src/autoscaler/integration/integration_golangapi_scalingengine_test.go
+++ b/src/autoscaler/integration/integration_golangapi_scalingengine_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Integration_GolangApi_ScalingEngine", func() {
 
 		Context("Get scaling histories", func() {
 			BeforeEach(func() {
-				history1 := createScalingHistory(appId, 666666)
+				history1 := createScalingHistoryError(appId, 666666)
 				insertScalingHistory(&history1)
 
 				history2 := createScalingHistory(appId, 222222)
@@ -158,12 +158,12 @@ var _ = Describe("Integration_GolangApi_ScalingEngine", func() {
 							AppId:        appId,
 							Timestamp:    666666,
 							ScalingType:  models.ScalingTypeDynamic,
-							Status:       models.ScalingStatusSucceeded,
-							OldInstances: 2,
-							NewInstances: 4,
+							Status:       models.ScalingStatusFailed,
+							OldInstances: -1,
+							NewInstances: -1,
 							Reason:       "a reason",
 							Message:      "a message",
-							Error:        "",
+							Error:        "an error",
 						},
 						{
 							AppId:        appId,
@@ -261,12 +261,12 @@ var _ = Describe("Integration_GolangApi_ScalingEngine", func() {
 							AppId:        appId,
 							Timestamp:    666666,
 							ScalingType:  models.ScalingTypeDynamic,
-							Status:       models.ScalingStatusSucceeded,
-							OldInstances: 2,
-							NewInstances: 4,
+							Status:       models.ScalingStatusFailed,
+							OldInstances: -1,
+							NewInstances: -1,
 							Reason:       "a reason",
 							Message:      "a message",
-							Error:        "",
+							Error:        "an error",
 						},
 						{
 							AppId:        appId,

--- a/src/autoscaler/integration/integration_suite_test.go
+++ b/src/autoscaler/integration/integration_suite_test.go
@@ -620,6 +620,20 @@ func createScalingHistory(appId string, timestamp int64) models.AppScalingHistor
 	}
 }
 
+func createScalingHistoryError(appId string, timestamp int64) models.AppScalingHistory {
+	return models.AppScalingHistory{
+		AppId:        appId,
+		OldInstances: -1,
+		NewInstances: -1,
+		Reason:       "a reason",
+		Message:      "a message",
+		ScalingType:  models.ScalingTypeDynamic,
+		Status:       models.ScalingStatusFailed,
+		Error:        "an error",
+		Timestamp:    timestamp,
+	}
+}
+
 func getScalingHistoryCount(appId string, oldInstanceCount int, newInstanceCount int) int {
 	var count int
 	query := dbHelper.Rebind("SELECT COUNT(*) FROM scalinghistory WHERE appid=? AND oldinstances=? AND newinstances=?")


### PR DESCRIPTION
to not break backwards compatibility.

If designing this API from scratch we would probably just omit this
value.
