### PR TITLE
feat(ci): update all golang dependencies weekly

### DIFF
--- a/.github/workflows/update-all-golang-dependencies.yaml
+++ b/.github/workflows/update-all-golang-dependencies.yaml
@@ -1,0 +1,47 @@
+# This is a stop-gap solution until https://github.com/renovatebot/renovate/issues/9578 is implemented.
+name: "update all golang dependencies"
+on:
+  schedule:  # Monday morning: https://crontab.guru/#0_6_*_*_1
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+jobs:
+  make-go-get-u:
+    name: "go get -u"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cloudfoundry/app-autoscaler-release-tools:main
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+          token: ${{ secrets.APP_AUTOSCALER_CI_TOKEN }} # With push token that can trigger new PR jobs
+      - name: make go-get-u and make package-specs
+        shell: bash
+        run: |
+          #! /usr/bin/env bash
+          set -eu -o pipefail
+
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          git config user.name "app-autoscaler-ci-bot"
+          git config user.email "ApplicationAutoscaler@sap.com"
+
+          git switch --create scheduled-dependency-update-with-go-get-u
+
+          make go-get-u package-specs
+
+          declare -i -r num_changed_files="$(git status --porcelain | wc --lines)"
+          if ((num_changed_files > 0))
+          then
+            echo 'Changes to some files were necessary!'
+            git add .
+            git commit --message="chore(deps): automated dependency update with go get -u" --message="Please check that no unwanted changes have been introduced." --no-verify
+            git push --set-upstream origin scheduled-dependency-update-with-go-get-u
+            gh pr create --base main --fill --label dependencies
+          else
+            echo 'No files changed!'
+          fi
+          echo '🏁'

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ go-changelog-dir := ./src/changelog
 go-changeloglockcleander-dir := ./src/changeloglockcleaner
 go-test-app-dir := ./src/acceptance/assets/app/go_app
 
-go_modules := $(shell find . -maxdepth 3 -name "*.mod" -exec dirname {} \; | sed 's|\./src/||' | sort)
+go_modules := $(shell find . -maxdepth 6 -name "*.mod" -exec dirname {} \; | sed 's|\./src/||' | sort)
 all_modules := $(go_modules) db scheduler
 
 MVN_OPTS = "-Dmaven.test.skip=true"
@@ -436,3 +436,12 @@ validate-openapi-specs: $(wildcard ./api/*.openapi.yaml)
 	for file in $^ ; do \
 		swagger-cli validate "$${file}" ; \
 	done
+
+.PHONY: go-get-u
+go-get-u: $(addsuffix .go-get-u,$(go_modules))
+
+.PHONY: %.go-get-u
+%.go-get-u: % generate-fakes
+	@echo " - go get -u" $<
+	cd src/$< && \
+	go get -u ./...


### PR DESCRIPTION
As indirect dependencies are not updated unless necessary by renovate (c.f. the [feature request to add lockfile updates for Go to renovate](https://github.com/renovatebot/renovate/issues/9578)) this PR adds a worflow scheduled monday mornings to create a PR updating *all* dependencies.