### PR TITLE
fix(ci): Provide `GH_TOKEN` to go-get-u workflow

### DIFF
--- a/.github/workflows/update-all-golang-dependencies.yaml
+++ b/.github/workflows/update-all-golang-dependencies.yaml
@@ -21,6 +21,8 @@ jobs:
           token: ${{ secrets.APP_AUTOSCALER_CI_TOKEN }} # With push token that can trigger new PR jobs
       - name: make go-get-u and make package-specs
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.APP_AUTOSCALER_CI_TOKEN }}
         run: |
           #! /usr/bin/env bash
           set -eu -o pipefail


### PR DESCRIPTION
as it is needed by the `gh` CLI.
