### PR TITLE
Fix CF CLI plugin installation on linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
 
             shellHook = ''
               # install required CF CLI plugins
-              cf install-plugin "$(whereis -q app-autoscaler-cli-plugin)" -f
+              cf install-plugin "$(which app-autoscaler-cli-plugin)" -f
 
               aes_terminal_font_yellow='\e[38;2;255;255;0m'
               aes_terminal_font_blink='\e[5m'


### PR DESCRIPTION
# Problem
`whereis -q` is not available on linux

# Solution
Use `which` instead, this works on linux and macOS.