### PR TITLE
Print errors occured while sending metrics by default

### DIFF
--- a/src/autoscaler/helpers/loggregator_logger.go
+++ b/src/autoscaler/helpers/loggregator_logger.go
@@ -16,7 +16,7 @@ func NewLoggregatorGRPCLogger(logger lager.Logger) *LoggregatorGRPCLogger {
 	}
 }
 func (l *LoggregatorGRPCLogger) Printf(message string, data ...interface{}) {
-	l.logger.Debug(fmt.Sprint(message, data), lager.Data{"data": data})
+	l.logger.Info(fmt.Sprint(message, data), lager.Data{"data": data})
 }
 func (l *LoggregatorGRPCLogger) Panicf(message string, data ...interface{}) {
 	l.logger.Fatal(fmt.Sprintf(message, data...), nil, lager.Data{"data": data})


### PR DESCRIPTION
# Problem
By default, a regular `metricsforwarder` deployment has the log level configured as `info`: https://github.com/cloudfoundry/app-autoscaler-release/blob/a993d5635879c6d32e0bc8a940d58a27881b5392/jobs/metricsforwarder/spec#L33-L35

The client which sends metrics uses a custom logger implementation: https://github.com/cloudfoundry/app-autoscaler-release/blob/fda280de2d3173d7a6898f8cc86d6d4a1192aef6/src/autoscaler/metricsforwarder/forwarder/metric_forwarder.go#L37. The custom logger implementation logs messages with level `debug` when `Printf` is called: https://github.com/cloudfoundry/app-autoscaler-release/blob/fda280de2d3173d7a6898f8cc86d6d4a1192aef6/src/autoscaler/helpers/loggregator_logger.go#L19

Interface method `Printf` is called by the client when erros occured while sending logs: https://github.com/cloudfoundry/go-loggregator/blob/a52b61896b6f971d5c47f1008a1eaa279223c7c5/ingress_client.go#L537

To sum it up, the problem with all this is that a regular `metricsforwarder` deployment doesn't print errors that occurred while sending metrics because the logs are logged with level `debug` but only `info` messages are shown.

# Solution
This PR changes the custom logger implementation to print logs as `info` which causes a regular `metricsforwarder` deployment to show the logs occured while sending metrics.