### PR TITLE
Add PostgreSQL version 16 to test matrix

### DIFF
--- a/.github/workflows/postgres.yaml
+++ b/.github/workflows/postgres.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        postgres: [12, 15]
+        postgres: [12, 15, 16]
         suite: [test, integration]
     env:
       DB_DATABASE: autoscaler


### PR DESCRIPTION
AWS only offers TLS 1.3 in AWS RDS PostgreSQL 16, so we should test PostgreSQL version 16, in case someone wants to run app-autoscaler-release on it.