### PR TITLE
Improve test-app deployment script

### DIFF
--- a/src/acceptance/assets/app/go_app/deploy.sh
+++ b/src/acceptance/assets/app/go_app/deploy.sh
@@ -30,12 +30,12 @@ function deploy(){
   org="test"
   space="test_$(whoami)"
 
-  use_existing_organization="$(getConfItem use_existing_organization)"
+  use_existing_organization="$(getConfItem use_existing_organization || echo false)"
   if ${use_existing_organization}; then
     org="$(getConfItem existing_organization)"
   fi
 
-  use_existing_space="$(getConfItem use_existing_space)"
+  use_existing_space="$(getConfItem use_existing_space || echo false)"
   if ${use_existing_space}; then
     space="$(getConfItem existing_space)"
   fi


### PR DESCRIPTION
# Problem 
It can happen that `use_existing_space` or `use_existing_org` is not set which causes the script to fail.

# Solution
Let's default to `false` if any of `use_existing_space` or `use_existing_org` is not set propertly.