### PR TITLE
fix(deps): `google-cloud-cli` download in `app-autoscaler-release-tools`

### DIFF
--- a/ci/dockerfiles/autoscaler-tools/Dockerfile
+++ b/ci/dockerfiles/autoscaler-tools/Dockerfile
@@ -122,11 +122,11 @@ RUN sed -i 's/peer/trust/' ${PGCONFIG}/pg_hba.conf \
   	&& sed -i 's/md5/trust/' ${PGCONFIG}/pg_hba.conf
 
 # Install gcloud
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-  apt-get update -y &&\
-  apt-get install google-cloud-sdk -y &&\
-  apt-get clean &&\
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+  apt-get update -y && \
+  apt-get install google-cloud-cli -y && \
+  apt-get clean && \
   gcloud version
 
 # renovate: datasource=github-releases depName=ginkgo lookupName=onsi/ginkgo


### PR DESCRIPTION
Apparently, the package name was changed from `google-cloud-sdk` to
`google-cloud-cli`, see also
https://cloud.google.com/sdk/docs/install#deb
and on that page
> NOTE: For releases prior to 371.0.0, the package name is google-cloud-sdk