### PR TITLE
Bump to exact Go versions during `update-golang`

### DIFF
--- a/ci/autoscaler/tasks/update-sdk/update_golang_package.sh
+++ b/ci/autoscaler/tasks/update-sdk/update_golang_package.sh
@@ -2,26 +2,25 @@
 [ -n "${DEBUG}" ] && set -x
 set -euo pipefail
 
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+script_dir="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 source "${script_dir}/vars.source.sh"
 source "${script_dir}/vendor_package.sh"
 
 golang_dir=${GOLANG_DIR:-"${autoscaler_dir}/../golang-release"}
-export golang_dir="$(realpath -e "${golang_dir}")"
+golang_dir="$(realpath -e "${golang_dir}")"
+export golang_dir
 
-SED="sed"
-which gsed >/dev/null && SED=gsed
+golang_version=$(cat "${golang_dir}/packages/golang-1-linux/version")
 
-# shellcheck disable=SC2154
-golang_version=$( cat "${golang_dir}/packages/golang-1-linux/version")
-stripped_go_version=$(echo "${golang_version}" | cut -d . -f -2)
+step "updating go.work file with golang version ${golang_version}"
+go work edit -go "${golang_version}" "${autoscaler_dir}/go.work"
 
-step "updating mod files with ${stripped_go_version}"
-# shellcheck disable=SC2154
-find "${autoscaler_dir}" -name go.mod -type f -exec ${SED} -i "s/^[[:space:]]*go 1.*/go ${stripped_go_version}/g" "{}" \;
+step "updating go.mod files with golang version ${golang_version}"
+find "${autoscaler_dir}" -name go.mod -type f -exec go mod edit -go "${golang_version}" "{}" \;
 
-step "updating .tool-version with ${golang_version}"
-"${SED}" -i "s/golang 1.*/golang ${golang_version}/g" "${autoscaler_dir}/.tool-versions"
+step "updating .tool-versions file with golang version ${golang_version}"
+sed -i "s/golang 1.*/golang ${golang_version}/g" "${autoscaler_dir}/.tool-versions"
 
-echo -n "${golang_version}" > ${autoscaler_dir}/version
-vendor-package "$golang_dir" golang-1-linux "${golang_version}"
+echo -n "${golang_version}" > "${autoscaler_dir}/version"
+vendor-package "${golang_dir}" golang-1-linux "${golang_version}"
+

--- a/ci/terragrunt/app-autoscaler/concourse/pipelines/api-tester/src/go.mod
+++ b/ci/terragrunt/app-autoscaler/concourse/pipelines/api-tester/src/go.mod
@@ -1,3 +1,3 @@
 module apitester
 
-go 1.21
+go 1.21.3

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.21.3
 
 use (
 	./src/acceptance

--- a/src/acceptance/assets/app/go_app/go.mod
+++ b/src/acceptance/assets/app/go_app/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/app-autoscaler-release/src/acceptance/assets/app/go_app
 
-go 1.21
+go 1.21.3
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/src/acceptance/go.mod
+++ b/src/acceptance/go.mod
@@ -1,6 +1,6 @@
 module acceptance
 
-go 1.21
+go 1.21.3
 
 require (
 	github.com/cloudfoundry/cf-test-helpers/v2 v2.9.0

--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -37,7 +37,9 @@ openapi-generated-clients-and-servers-files = $(wildcard ${openapi-generated-cli
 generate-openapi-generated-clients-and-servers: ${openapi-generated-clients-and-servers-dir} ${openapi-generated-clients-and-servers-files}
 ${openapi-generated-clients-and-servers-dir} ${openapi-generated-clients-and-servers-files} &: $(wildcard ./helpers/apis/generate.go) ${openapi-specs-list} ./go.mod ./go.sum
 	@echo "# Generating OpenAPI clients and servers"
-	go generate ./helpers/apis/generate.go
+	# $(wildcard ./helpers/apis/generate.go) causes the target to always being executed, no matter if file exists or not.
+	# so let's don't fail if file can't be found, e.g. the eventgenerator bosh package does not contain it.
+	go generate ./helpers/apis/generate.go || true
 
 # The presence of the subsequent directory indicates whether the fakes still need to be generated
 # or not.

--- a/src/autoscaler/go.mod
+++ b/src/autoscaler/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/app-autoscaler/src/autoscaler
 
-go 1.21
+go 1.21.3
 
 require (
 	code.cloudfoundry.org/cfhttp/v2 v2.0.1-0.20230113212937-05beac96f8c7

--- a/src/changelog/go.mod
+++ b/src/changelog/go.mod
@@ -1,6 +1,6 @@
 module changelog
 
-go 1.21
+go 1.21.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/src/changeloglockcleaner/go.mod
+++ b/src/changeloglockcleaner/go.mod
@@ -1,6 +1,6 @@
 module changeloglockcleaner
 
-go 1.21
+go 1.21.3
 
 require (
 	github.com/go-sql-driver/mysql v1.8.0


### PR DESCRIPTION
# Problem
As of Go `1.21`, versions specified in `go.mod` files are treated not as a guideline but as a strict rule. Also, `go 1.21` is automatically being mapped to `1.21.0`.

The following example basically says that Go `1.21.0` is required 
https://github.com/cloudfoundry/app-autoscaler-release/blob/13755c96c1458f27c88c3ca3762c6d8d07663900/src/autoscaler/go.mod#L3

Which causes problems because the "`1.21` -> `1.21.0` mapping" doesn't work for `go.work` files
https://github.com/cloudfoundry/app-autoscaler-release/blob/13755c96c1458f27c88c3ca3762c6d8d07663900/go.work#L1

[Example of a failing CI build](https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/8258040332/job/22589620245#step:5:302):
```bash
go.work file requires go >= 1.21.0, but go.work lists go 1.21.
```

# Solution
* bump to exact Go versions and include `go.work` during the [bumping process](https://github.com/cloudfoundry/app-autoscaler-release/blob/7245afabc35a2ca592946adf4b51f59270831c8c/ci/autoscaler/pipeline.yml#L564-L577).

# Somewhat related changes
* bumped all `go.mod`- and `go.work` files to the currently used version `1.21.3`
* made `Create Bosh Release` pipeline future proof for Go `>=1.22.0`, see https://github.com/cloudfoundry/app-autoscaler-release/pull/2757#discussion_r1523320751
