### PR TITLE
fix(acceptance-tests): compile test suites and ginkgo cli for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,7 @@ build/autoscaler-test.tgz:
 acceptance-release: clean-acceptance go-mod-tidy go-mod-vendor build-test-app
 	@echo " - building acceptance test release '${VERSION}' to dir: '${DEST}' "
 	@mkdir -p ${DEST}
+	${AUTOSCALER_DIR}/scripts/compile-acceptance-tests.sh
 	@tar --create --auto-compress --directory="src" --file="${ACCEPTANCE_TESTS_FILE}" 'acceptance'
 
 .PHONY: generate-fakes autoscaler.generate-fakes test-app.generate-fakes

--- a/scripts/compile-acceptance-tests.sh
+++ b/scripts/compile-acceptance-tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SUITES=("api" "app" "broker" "post_upgrade" "pre_upgrade" "run_performance" "setup_performance")
+readonly OPERATING_SYSTEMS=("linux" "darwin")
+readonly ARCHITECTURES=("amd64" "arm64") # [amd64: intel 64 bit chips]  [arm64: apple silicon chips]
+
+compile_suites() {
+  for suite in "${SUITES[@]}"; do
+      for os in "${OPERATING_SYSTEMS[@]}"; do
+        for arch in "${ARCHITECTURES[@]}"; do
+          GOOS="${os}" GOARCH="${arch}" ginkgo build "src/acceptance/${suite}"
+
+          # adjust binary name to include os and architecture information
+          mv "src/acceptance/${suite}/${suite}.test" "src/acceptance/${suite}/${suite}_${os}_${arch}.test"
+        done
+      done
+  done
+}
+
+compile_ginkgo() {
+  pushd ./src/acceptance > /dev/null
+    for os in "${OPERATING_SYSTEMS[@]}"; do
+      for arch in "${ARCHITECTURES[@]}"; do
+        binary_name="ginkgo_v2_${os}_${arch}"
+        GOOS="${os}" GOARCH="${arch}" go build -o "ginkgo_v2_${os}_${arch}" github.com/onsi/ginkgo/v2/ginkgo
+        chmod +x "${binary_name}"
+      done
+    done
+  popd > /dev/null
+}
+
+main() {
+  compile_suites
+  compile_ginkgo
+}
+
+main

--- a/src/acceptance/bin/test
+++ b/src/acceptance/bin/test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 bin_dir=$(dirname "${BASH_SOURCE[0]}")
 pushd "${bin_dir}/.." > /dev/null
@@ -11,16 +11,26 @@ pushd "${bin_dir}/.." > /dev/null
     exit 1;\
   }
 
-  minor_version=$(go version | cut -d ' ' -f 3 | sed -E 's/go[0-9]+\.([0-9]+).*/\1/')
+  # retrieve current go version not in the context of the acceptance module
+  # this ensures that no additional go toolchain downloads happen because the module requires another version
+  pushd "$(mktemp -d)" > /dev/null
+    minor_version="$(go version | cut -d ' ' -f 3 | sed -E 's/go[0-9]+\.([0-9]+).*/\1/')"
+  popd
+
   [ "${minor_version}" -lt "${MIN_GO_VERSION}" ] && { \
     echo "ERROR: golang version 1.${MIN_GO_VERSION} or above needs to be installed to use the acceptance tests" 1>&2;\
     exit 1;\
   }
-  echo "# Acceptance tests"
-  echo " - building ginkgo"
-  go build -o ginkgo_v2 github.com/onsi/ginkgo/v2/ginkgo
+
+  # build ginkgo binary if no one specified path to it
+  if [[ -z "$GINKGO_BINARY" ]]; then
+    echo "env var GINKGO_BINARY not specified, building ginkgo"
+    go build -o ginkgo_v2 github.com/onsi/ginkgo/v2/ginkgo
+    GINKGO_BINARY="./ginkgo_v2"
+  fi
 
   # shellcheck disable=SC2068
-  echo " - running ginkgo v2 with: '${*}'"
-  ./ginkgo_v2 "$@"
+  echo "running ${GINKGO_BINARY} with: '${*}'"
+
+  "${GINKGO_BINARY}" "$@"
 popd > /dev/null

--- a/src/acceptance/bin/test
+++ b/src/acceptance/bin/test
@@ -11,8 +11,7 @@ pushd "${bin_dir}/.." > /dev/null
     exit 1;\
   }
 
-  # retrieve current go version not in the context of the acceptance module
-  # this ensures that no additional go toolchain downloads happen because the module requires another version
+  # retrieve go version outside of the context of any module to ensure that no toolchain download happens
   pushd "$(mktemp -d)" > /dev/null
     minor_version="$(go version | cut -d ' ' -f 3 | sed -E 's/go[0-9]+\.([0-9]+).*/\1/')"
   popd

--- a/src/acceptance/bin/test
+++ b/src/acceptance/bin/test
@@ -21,7 +21,7 @@ pushd "${bin_dir}/.." > /dev/null
     exit 1;\
   }
 
-  # build ginkgo binary if binary path wasn't provided
+  # compile ginkgo cli if binary path wasn't provided
   if [[ -z "$GINKGO_BINARY" ]]; then
     echo "env var GINKGO_BINARY not specified, building ginkgo"
     go build -o ginkgo_v2 github.com/onsi/ginkgo/v2/ginkgo

--- a/src/acceptance/bin/test
+++ b/src/acceptance/bin/test
@@ -21,7 +21,7 @@ pushd "${bin_dir}/.." > /dev/null
     exit 1;\
   }
 
-  # build ginkgo binary if no one specified path to it
+  # build ginkgo binary if binary path wasn't provided
   if [[ -z "$GINKGO_BINARY" ]]; then
     echo "env var GINKGO_BINARY not specified, building ginkgo"
     go build -o ginkgo_v2 github.com/onsi/ginkgo/v2/ginkgo


### PR DESCRIPTION
# Problem
Go tries to download a specific toolchain version whenever the required version is not available on the system. The following PR introduced the exact Go toolchain version pinning #2757.

Requiring an exact Go toolchain version can make the acceptance tests execution fail in an environment that has no connectivity to the public internet. Here is a sample failure from an execution in China which tries to download a required toolchain version:
```
download go1.21.4: golang.org/toolchain@v0.0.1-go1.21.4.linux-amd64: Get "https://proxy.golang.org/golang.org/toolchain/@v/v0.0.1-go1.21.4.linux-amd64.zip": dial tcp 172.217.163.49:443: i/o timeout
```



# Solution
Compile test suites and ginkgo CLI for 
* `linux` (`amd64`, `arm64`) 
* `darwin` (`amd64`, `arm64`)

Acceptance test executions with no public internet access can make use of these binaries.

