### PR TITLE
chore(deps): Increase time for renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "config:best-practices",
     "regexManagers:dockerfileVersions",
     ":label(dependencies)",
-    ":automergeAll"
+    ":automergeAll",
+    "schedule:nonOfficeHours"
   ],
   "transitiveRemediation": true,
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
@@ -133,6 +134,5 @@
     }
   ],
   "lockFileMaintenance": {"enabled": true},
-  "schedule": ["after 1am and before 7am every weekday"],
   "timezone": "Europe/Berlin"
 }


### PR DESCRIPTION
# Issue

Due to the limited time, 6 hours per weekday, renovate PRs were piling up on weekends.

# Solution

The preset [`schedule:nonOfficeHours`](https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours) gives more time, including the whole weekend.