### PR TITLE
chore(ci): Run unit and integration tests using make

### DIFF
--- a/ci/autoscaler/scripts/run-integration-tests.sh
+++ b/ci/autoscaler/scripts/run-integration-tests.sh
@@ -10,28 +10,6 @@ psql postgres://postgres@127.0.0.1:5432 -c 'CREATE DATABASE autoscaler'
 
 pushd app-autoscaler-release
 
-  POSTGRES_OPTS='--username=postgres --url=jdbc:postgresql://127.0.0.1/autoscaler --driver=org.postgresql.Driver'
-
-  ./src/scheduler/scripts/generate_unit_test_certs.sh
-  ./scripts/generate_test_certs.sh
-
-  pushd src
-    mvn package --no-transfer-progress -Dmaven.test.skip=true -DskipTests
-    echo "liquibase.hub.mode=off" > liquibase.properties
-
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/api/db/api.db.changelog.yml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/api/db/servicebroker.db.changelog.yaml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=scheduler/db/scheduler.changelog-master.yaml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=scheduler/db/quartz.changelog-master.yaml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/metricsserver/db/metricscollector.db.changelog.yml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/eventgenerator/db/dataaggregator.db.changelog.yml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/scalingengine/db/scalingengine.db.changelog.yml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/operator/db/operator.db.changelog.yml update
-  popd
-
-  export DBURL="postgres://postgres@localhost/autoscaler?sslmode=disable"
-
-  make -C src/autoscaler build
-  make -C src/autoscaler integration
+  CI=true make integration
 
 popd

--- a/ci/autoscaler/scripts/run-unit-tests.sh
+++ b/ci/autoscaler/scripts/run-unit-tests.sh
@@ -12,31 +12,6 @@ psql postgres://postgres@127.0.0.1:5432 -c 'CREATE DATABASE autoscaler'
 
 pushd app-autoscaler-release
 
-  POSTGRES_OPTS='--username=postgres --url=jdbc:postgresql://127.0.0.1/autoscaler --driver=org.postgresql.Driver'
+  CI=true make test
 
-  ./src/scheduler/scripts/generate_unit_test_certs.sh
-  ./scripts/generate_test_certs.sh
-
-  pushd src
-    mvn package --no-transfer-progress -Dmaven.test.skip=true -DskipTests
-    echo "liquibase.hub.mode=off" > liquibase.properties
-
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/api/db/api.db.changelog.yml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/api/db/servicebroker.db.changelog.yaml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=scheduler/db/scheduler.changelog-master.yaml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=scheduler/db/quartz.changelog-master.yaml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/metricsserver/db/metricscollector.db.changelog.yml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/eventgenerator/db/dataaggregator.db.changelog.yml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/scalingengine/db/scalingengine.db.changelog.yml update
-    java -cp 'db/target/lib/*' liquibase.integration.commandline.Main $POSTGRES_OPTS --changeLogFile=autoscaler/operator/db/operator.db.changelog.yml update
-
-  popd
-
-  export DBURL="postgres://postgres@localhost/autoscaler?sslmode=disable"
-
-  make -C src/autoscaler build test
-
-  pushd src
-    mvn test --no-transfer-progress
-  popd
 popd


### PR DESCRIPTION
# Issue

Not all tests where run, as the logic in the Concourse scripts was
duplicating the functionality in the `Makefile` but was out-of-date.
In particular, the `go_app` tests were not executed on Concourse.

# Fix

We want our `Makefile` to be the central CI entry-point, thus we just
call `make` to run unit and integration tests.
