### PR TITLE
chore(deps): Update `cfhttp/v2`

### DIFF
--- a/src/autoscaler/go.mod
+++ b/src/autoscaler/go.mod
@@ -3,7 +3,7 @@ module code.cloudfoundry.org/app-autoscaler/src/autoscaler
 go 1.21.4
 
 require (
-	code.cloudfoundry.org/cfhttp/v2 v2.0.1-0.20230113212937-05beac96f8c7
+	code.cloudfoundry.org/cfhttp/v2 v2.0.1-0.20240327161157-4a95aa40b3cb
 	code.cloudfoundry.org/clock v1.1.0
 	code.cloudfoundry.org/go-log-cache/v2 v2.0.7
 	code.cloudfoundry.org/go-loggregator/v9 v9.2.0

--- a/src/autoscaler/go.sum
+++ b/src/autoscaler/go.sum
@@ -592,8 +592,8 @@ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoIS
 cloud.google.com/go/workflows v1.8.0/go.mod h1:ysGhmEajwZxGn1OhGOGKsTXc5PyxOc0vfKf5Af+to4M=
 cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT3ujaO/WwSA=
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
-code.cloudfoundry.org/cfhttp/v2 v2.0.1-0.20230113212937-05beac96f8c7 h1:GmnxSVBhAABJm8o6QxdScDBkUZH99ejyVll3DeooflA=
-code.cloudfoundry.org/cfhttp/v2 v2.0.1-0.20230113212937-05beac96f8c7/go.mod h1:kVxoVZh/Jx7LD1QAd9t5vmFsfRMEgNCkFvBsueYHAuk=
+code.cloudfoundry.org/cfhttp/v2 v2.0.1-0.20240327161157-4a95aa40b3cb h1:x12KpqaIb9BBLmbkJAViXEz1JNEfTeLyRf0SDrq3ac8=
+code.cloudfoundry.org/cfhttp/v2 v2.0.1-0.20240327161157-4a95aa40b3cb/go.mod h1:yD0n22D4KP4xamgTxbz82KsWzK5kcfUrmJNrrmd4YBg=
 code.cloudfoundry.org/clock v1.1.0 h1:XLzC6W3Ah/Y7ht1rmZ6+QfPdt1iGWEAAtIZXgiaj57c=
 code.cloudfoundry.org/clock v1.1.0/go.mod h1:yA3fxddT9RINQL2XHS7PS+OXxKCGhfrZmlNUCIM6AKo=
 code.cloudfoundry.org/go-diodes v0.0.0-20240325171903-fa19631aa7ba h1:6OnItMdG17kcm2dsBzaNAPMPAmAyQsPXZpIHhvwCctk=


### PR DESCRIPTION
# Issue

The dependency `cfhttp/v2` has not been updated for more than a year.

Renovate has been complaining about the cfhttp repo for some time now:
> Renovate failed to look up the following dependencies:
> `Could not determine new digest for update (go package code.cloudfoundry.org/cfhttp/v2).`
> Files affected: `src/autoscaler/go.mod`

The issue has been reported to [ARP in their Slack channel](https://cloudfoundry.slack.com/archives/C02HNDJB31R/p1713518531547079).

# Fix

Until the underlying gets fixed and Renovate can create an update PR
I've created a manual update using

```
GOPROXY=direct go get -u code.cloudfoundry.org/cfhttp/v2
```
