### PR TITLE
fix(release): use deploy keys for git-resources

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -107,7 +107,7 @@ resources:
   icon: github
   source:
     uri: git@github.com:cloudfoundry/app-autoscaler-release
-    private_key: ((autoscaler-ci-bot-authentication-key-private))
+    private_key: ((autoscaler-deploy-key-private))
     branch: ((branch_name))
     fetch_tags: true
     paths:
@@ -118,7 +118,7 @@ resources:
   icon: github
   source:
     uri: git@github.com:cloudfoundry/app-autoscaler-release
-    private_key: ((autoscaler-ci-bot-authentication-key-private))
+    private_key: ((autoscaler-deploy-key-private))
     branch: ((branch_name))
     fetch_tags: true
 

--- a/ci/autoscaler/tasks/update-sdk/task.yml
+++ b/ci/autoscaler/tasks/update-sdk/task.yml
@@ -17,7 +17,7 @@ params:
   GIT_USER_EMAIL: ApplicationAutoscaler@sap.com
   UPLOADER_KEY: ((autoscaler_blobstore_uploader_key))
   GITHUB_ACCESS_TOKEN: ((autoscaler_access_token))
-  GITHUB_PRIVATE_KEY: ((autoscaler-ci-bot-authentication-key-private))
+  GITHUB_PRIVATE_KEY: ((autoscaler-deploy-key-private))
   type:
   JAVA_DIR: java-release
   GOLANG_DIR: golang-release

--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -26,7 +26,7 @@ resources:
   icon: github
   source:
     uri: git@github.com:cloudfoundry/app-autoscaler-release
-    private_key: ((autoscaler-ci-bot-authentication-key-private))
+    private_key: ((autoscaler-deploy-key-private))
     branch: main
     fetch_tags: true
     paths:


### PR DESCRIPTION
# Problem
The ssh-key of `autoscaler-ci-bot` is not capable of bypassing the branch protection rules. This is due to the fact that this user is no admin on this repo here. 

This breaks the release pipeline when pushing the release https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/release/builds/33#L65fa0435:11:12

# Solution
Make use of a brand new deploy key added to this repo here issued for `ApplicationAutoscaler@sap.com` within the git-resources.