### PR TITLE
fix(operator): Clean up scaling cooldowns

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -21,3 +21,5 @@ if has bbl && [[ -d "$bbl_state_dir" ]]
 then
     eval "$(bbl print-env --state-dir "$bbl_state_dir")"
 fi
+
+export DBURL="postgres://postgres:postgres@localhost/autoscaler"

--- a/src/autoscaler/db/db.go
+++ b/src/autoscaler/db/db.go
@@ -103,6 +103,7 @@ type ScalingEngineDB interface {
 	CountScalingHistories(ctx context.Context, appId string, start int64, end int64, includeAll bool) (int, error)
 	RetrieveScalingHistories(ctx context.Context, appId string, start int64, end int64, orderType OrderType, includeAll bool, page int, resultsPerPAge int) ([]*models.AppScalingHistory, error)
 	PruneScalingHistories(ctx context.Context, before int64) error
+	PruneCooldowns(ctx context.Context, before int64) error
 	UpdateScalingCooldownExpireTime(appId string, expireAt int64) error
 	CanScaleApp(appId string) (bool, int64, error)
 	GetActiveSchedule(appId string) (*models.ActiveSchedule, error)

--- a/src/autoscaler/db/sqldb/scalingengine_sqldb.go
+++ b/src/autoscaler/db/sqldb/scalingengine_sqldb.go
@@ -170,6 +170,15 @@ func (sdb *ScalingEngineSQLDB) PruneScalingHistories(ctx context.Context, before
 	return err
 }
 
+func (sdb *ScalingEngineSQLDB) PruneCooldowns(ctx context.Context, before int64) error {
+	query := sdb.sqldb.Rebind("DELETE FROM scalingcooldown WHERE expireat < ?")
+	_, err := sdb.sqldb.ExecContext(ctx, query, before)
+	if err != nil {
+		sdb.logger.Error("failed-prune-scaling-cooldowns-from-scalingcooldown-table", err, lager.Data{"query": query, "before": before})
+	}
+	return err
+}
+
 func (sdb *ScalingEngineSQLDB) CanScaleApp(appId string) (bool, int64, error) {
 	query := sdb.sqldb.Rebind("SELECT expireat FROM scalingcooldown WHERE appid = ?")
 	rows, err := sdb.sqldb.Query(query, appId)

--- a/src/autoscaler/db/sqldb/sqldb_suite_test.go
+++ b/src/autoscaler/db/sqldb/sqldb_suite_test.go
@@ -220,15 +220,29 @@ func removeScalingHistoryForApp(appId string) {
 	FailOnError("can not clean table scalinghistory", err)
 }
 
+func getNumberOfCooldownEntries() int {
+	var num int
+	query := dbHelper.Rebind("SELECT COUNT(*) FROM scalingcooldown")
+	err := dbHelper.QueryRow(query).Scan(&num)
+	FailOnError("can not count the number of records in table scalingcooldown", err)
+	return num
+}
+
 func removeCooldownForApp(appId string) {
 	query := dbHelper.Rebind("DELETE from scalingcooldown where appId = ?")
 	_, err := dbHelper.Exec(query, appId)
+	FailOnError("can not remove scalingcooldown for app", err)
+}
+
+func cleanUpCooldownTable() {
+	_, err := dbHelper.Exec("DELETE from scalingcooldown")
 	FailOnError("can not clean table scalingcooldown", err)
 }
+
 func removeActiveScheduleForApp(appId string) {
 	query := dbHelper.Rebind("DELETE from activeschedule where appId = ?")
 	_, err := dbHelper.Exec(query, appId)
-	FailOnError("can not clean table scalingcooldown", err)
+	FailOnError("can not remove actives schedules for app", err)
 }
 
 func hasScalingHistory(appId string, timestamp int64) bool {

--- a/src/autoscaler/operator/scalingenginedb_test.go
+++ b/src/autoscaler/operator/scalingenginedb_test.go
@@ -57,5 +57,25 @@ var _ = Describe("ScalingEngineDbPruner", func() {
 				Eventually(buffer).Should(gbytes.Say("test error"))
 			})
 		})
+
+		Context("when pruning records from scalingcooldown table", func() {
+			It("prunes expired cooldowns", func() {
+				Eventually(scalingEngineDB.PruneCooldownsCallCount).Should(Equal(1))
+				_, cutoffTime := scalingEngineDB.PruneCooldownsArgsForCall(0)
+				Expect(cutoffTime).To(Equal(fclock.Now().UnixNano()))
+			})
+		})
+
+		Context("when pruning records from scalingcooldown table fails", func() {
+			BeforeEach(func() {
+				scalingEngineDB.PruneCooldownsReturns(errors.New("test error"))
+			})
+
+			It("should error", func() {
+				Eventually(scalingEngineDB.PruneCooldownsCallCount).Should(Equal(1))
+				Eventually(buffer).Should(gbytes.Say("test error"))
+			})
+		})
+
 	})
 })


### PR DESCRIPTION
# Issue

The table `scalingcooldowns` will gain an entry once an app is scaled.
This entry is never removed, thus a resource leak is created.

The table can get so big, that a simple select starts to take time (as
there is no index on the table).

# Fix

The table is now periodically cleaned by the `operator`.
