### PR TITLE
chore(ci): Configure `ruby/setup-ruby` for `ubuntu24`

### DIFF
--- a/.github/workflows/bosh-templates.yaml
+++ b/.github/workflows/bosh-templates.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         env:
           # Needed for self-hosted runner
-          ImageOS: "ubuntu22"
+          ImageOS: "ubuntu24"
         with:
           # runs 'bundle install' and caches installed gems automatically
           bundler-cache: true

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -39,7 +39,7 @@ jobs:
           bundler-cache: true
         env:
           # Needed for self-hosted runner
-          ImageOS: ubuntu22
+          ImageOS: ubuntu24
 
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1


### PR DESCRIPTION
# Issue
Since [PR #2905] our GitHub Actions workflows using `ruby/setup-ruby`
started failing with

```
Error: The current runner (ubuntu-24.04-x64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).

```

This is due to the mismatch of the Ubuntu version configured and
actually used.

# Fix

Configure `ImageOS: "ubuntu24"`.

[PR #2905]: https://github.com/cloudfoundry/app-autoscaler-release/pull/2905
