### PR TITLE
Revert "chore(deps): update ubuntu docker tag to v24"

### DIFF
--- a/ci/dockerfiles/autoscaler-tools/Dockerfile
+++ b/ci/dockerfiles/autoscaler-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble@sha256:562456a05a0dbd62a671c1854868862a4687bf979a96d48ae8e766642cd911e8
+FROM ubuntu:jammy
 MAINTAINER autoscaler-team
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"


### PR DESCRIPTION
# Issue

Due to the mismatch of the GitHub-hosted runner running Ubuntu 22.04 and the version of the base image for our tools image,
GitHub Actions workflows using `ruby/setup-ruby`
started failing with

```
Error: The current runner (ubuntu-24.04-x64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).

```

# Fix
Reverts cloudfoundry/app-autoscaler-release#2905

The update should wait until a [runner image](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) based on Ubuntu 24.04 becomes available.