### PR TITLE
feat(direnv): Check if `devbox` is installed before invoking it

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,17 @@
-# Automatically sets up your devbox environment whenever you cd into this
-# directory via our direnv integration:
+strict_env
 
-eval "$(devbox generate direnv --print-envrc)"
-
-# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
-# for more details
+# Prefers devbox over nix, as nix is a prerequisite for devbox
+if has devbox
+then
+    unstrict_env # seems to be required for devbox :(
+    eval "$(devbox generate direnv --print-envrc)"
+    # check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+    # for more details
+else
+    if has nix
+    then
+        unset GOPATH # Required for editors to discover the go-tools in the flake.
+        use flake
+        layout ruby
+    fi
+fi

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,27 @@
 {
   "nodes": {
+    "local-flake": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-ZmNHp5kO8fEuq3BWOnLr6FDZRLxY8v6QkqtpDQiFG2Y=",
+        "path": "./local-flake",
+        "type": "path"
+      },
+      "original": {
+        "path": "./local-flake",
+        "type": "path"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699099776,
-        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
+        "lastModified": 1710272261,
+        "narHash": "sha256-g0bDwXFmTE7uGDOs9HcJsfLFhH7fOsASbAuOzDC+fhQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
+        "rev": "0ad13a6833440b8e238947e47bea7f11071dc2b2",
         "type": "github"
       },
       "original": {
@@ -32,9 +47,26 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1699099776,
+        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "local-flake": "local-flake",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-bosh-cli-v7-3-1": "nixpkgs-bosh-cli-v7-3-1"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,10 @@
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
     nixpkgs-bosh-cli-v7-3-1.url = github:NixOS/nixpkgs/1179c6c3705509ba25bd35196fca507d2a227bd0;
+    local-flake.url = "path:./local-flake";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-bosh-cli-v7-3-1 }:
+  outputs = { self, nixpkgs, nixpkgs-bosh-cli-v7-3-1, local-flake }:
     let
       supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
 
@@ -17,36 +18,6 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
       nixpkgsFor-bosh-cli-v7-3-1 = forAllSystems (system: import nixpkgs-bosh-cli-v7-3-1 { inherit system; });
     in {
-      packages = forAllSystems (system: {
-        app-autoscaler-cli-plugin = nixpkgsFor.${system}.buildGoModule rec {
-          pname = "app-autoscaler-cli-plugin";
-          gitCommit = "f46dc1ea62c4c7bd426c82f4e2a525b3a3c42300";
-          version = "${gitCommit}";
-          src = nixpkgsFor.${system}.fetchgit {
-            url = "https://github.com/cloudfoundry/app-autoscaler-cli-plugin";
-            rev = "${gitCommit}";
-            hash = "sha256-j8IAUhjYjEFvtRbA6o2vA7P2uUmKVYsd9uJmN0WtVCM=";
-            fetchSubmodules = true;
-          };
-          doCheck = false;
-          vendorHash = "sha256-NzEStcOv8ZQsHOA8abLABKy+ZE3/SiYbRD/ZVxo0CEk=";
-        };
-
-        # this bosh-bootloader custom build can be removed once https://github.com/cloudfoundry/bosh-bootloader/issues/596 is implemented.
-        bosh-bootloader = nixpkgsFor.${system}.buildGoModule rec {
-          pname = "bosh-bootloader";
-          version = "9.0.17";
-          src = nixpkgsFor.${system}.fetchgit {
-            url = "https://github.com/cloudfoundry/bosh-bootloader";
-            rev = "v${version}";
-            fetchSubmodules = true;
-            hash = "sha256-P4rS7Nv/09+9dD198z4NOXnldSE5fx3phEK24Acatps=";
-          };
-          doCheck = false;
-          vendorHash = null;
-        };
-      });
-
       openapi-specifications = {
         app-autoscaler-api =
           let
@@ -65,8 +36,8 @@
             buildInputs = with pkgs; [
               act
               actionlint
-              self.packages.${system}.app-autoscaler-cli-plugin
-              self.packages.${system}.bosh-bootloader
+              local-flake.packages.${system}.app-autoscaler-cli-plugin
+              local-flake.packages.${system}.bosh-bootloader
               # to make `bosh create-release` work in a Nix shell on macOS, use an older bosh-cli version that reuses
               # a bosh-utils version under the hood that doesn't use the tar option `--no-mac-metadata`.
               # unfortunately, Nix provides gnutar by default, which doesn't have the `--no-mac-metadata` option.
@@ -121,7 +92,7 @@
             shellHook = ''
               # install required CF CLI plugins
               cf install-plugin -f \
-                '${self.packages.${system}.app-autoscaler-cli-plugin}/bin/app-autoscaler-cli-plugin'
+                '${local-flake.packages.${system}.app-autoscaler-cli-plugin}/bin/app-autoscaler-cli-plugin'
 
               aes_terminal_font_yellow='\e[38;2;255;255;0m'
               aes_terminal_font_blink='\e[5m'


### PR DESCRIPTION
# Issue

If you don't have `devbox` installed the `.envrc` would error out.

# Fix

First check for `devbox` and then `nix`, restoring plain Nix usage as
well.

# Issue

The package definitions for `app-autoscaler-cli-plugin` and
`bosh-bootloader` were duplicated in the root and `local-flake` flakes.

# Fix

Reuse `local-flake` package definitions in main flake
