### PR TITLE
feat(envrc): Automatically eval bbl env # Issue

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -15,3 +15,9 @@ else
         layout ruby
     fi
 fi
+
+local bbl_state_dir=../app-autoscaler-env-bbl-state/bbl-state
+if has bbl && [[ -d "$bbl_state_dir" ]]
+then
+    eval "$(bbl print-env --state-dir "$bbl_state_dir")"
+fi


### PR DESCRIPTION
To access our OSS dev environment's BOSH directory one would have to always execute the `bbl print-env` command.

# Fix

Automatically execute it on entering the directory if possible.
