### PR TITLE
fix(acceptance): fix naming of plan update tests names

### DIFF
--- a/src/acceptance/bin/test_default
+++ b/src/acceptance/bin/test_default
@@ -2,6 +2,7 @@
 
 # Tests that are skipped by default and why:
 # mtls - this requires changes to gorouter/haproxy to allow mtls operations
+# updating service plans - this requires a deployment with two service plans, at least one of which is updatable
 
 $(dirname $0)/test \
   -v \
@@ -9,5 +10,6 @@ $(dirname $0)/test \
   --keep-going \
   --race \
   --skip "mtls" \
+  --skip "updating service plans" \
   "$@" \
   . broker app api

--- a/src/acceptance/broker/broker_test.go
+++ b/src/acceptance/broker/broker_test.go
@@ -243,6 +243,6 @@ func (p ServicePlans) getSourceAndTargetForPlanUpdate() (source, target ServiceP
 		return ServicePlan{}, ServicePlan{}, fmt.Errorf("no updatable plan found")
 	}
 	source = p[updatablePlanIndex]
-	target = p[(updatablePlanIndex+1)%p.length()]
+	target = p[(updatablePlanIndex+1)%p.length()] // simply update to any other plan
 	return source, target, nil
 }

--- a/src/acceptance/broker/broker_test.go
+++ b/src/acceptance/broker/broker_test.go
@@ -164,7 +164,7 @@ var _ = Describe("AutoScaler Service Broker", func() {
 		})
 	})
 
-	It("should update service instance from autoscaler-free-plan to acceptance-standard", func() {
+	It("should update a service instance from the first plan to the second plan", func() {
 		plans := getPlans()
 		if plans.length() < 2 {
 			Skip(fmt.Sprintf("2 plans needed, only one plan available plans:%+v", plans))
@@ -177,18 +177,14 @@ var _ = Describe("AutoScaler Service Broker", func() {
 		service.delete()
 	})
 
-	It("should fail to update service instance from acceptance-standard to first", func() {
+	It("should fail to update a service instance from the second plan to the first plan", func() {
 		plans := getPlans()
 		if plans.length() < 2 {
 			Skip(fmt.Sprintf("2 plans needed, only one plan available plans:%+v", plans))
 			return
 		}
-		if !plans.contains("acceptance-standard") {
-			Skip(fmt.Sprintf("Acceptance test standard plan required plans:%+v", plans))
-			return
-		}
 
-		service := createService("acceptance-standard")
+		service := createService(plans[1])
 		updateService := service.updatePlanRaw(plans[0])
 		Expect(updateService).To(Exit(1), "failed updating service")
 
@@ -210,14 +206,6 @@ func isCFVersion7() bool {
 type plans []string
 
 func (p plans) length() int { return len(p) }
-func (p plans) contains(planName string) bool {
-	for _, plan := range p {
-		if plan == planName {
-			return true
-		}
-	}
-	return false
-}
 
 func getPlans() plans {
 	values := url2.Values{

--- a/src/acceptance/broker/broker_test.go
+++ b/src/acceptance/broker/broker_test.go
@@ -172,9 +172,7 @@ var _ = Describe("AutoScaler Service Broker", func() {
 		It("should update a service instance from one plan to another plan", func() {
 			servicePlans := GetServicePlans(cfg)
 			source, target, err := servicePlans.getSourceAndTargetForPlanUpdate()
-			if err != nil {
-				Skip(err.Error())
-			}
+			Expect(err).NotTo(HaveOccurred(), "failed getting source and target service plans")
 			instance = createService(source.Name)
 			instance.updatePlan(target.Name)
 		})


### PR DESCRIPTION
# Issue

Previously we backed some assumptions into our plan update tests:
Their must be at least two plans, the first being updatable, and another with a specific name that should not be updatable.

This made the tests very dependent on the configuration chosen by the platform operator.

# Fix

We now dynamically choose the first updatable plan and update to second.
If there are no two plans or none is updatable, we skip the test

# Note

The test testing that you cannot update from the first plan has been removed, as this is already guaranteed by the Cloud Controller, so the test was just excercising Cloud Controller code.