### PR TITLE
fix(devbox): Downgrade `bosh-cli` so that `make deploy-autoscaler` works on macOS

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 act 0.2.62
 actionlint 1.6.27
-bosh 7.5.6
+bosh 7.3.1
 cf 8.7.10
 concourse 7.10.0
 direnv 2.34.0

--- a/devbox.json
+++ b/devbox.json
@@ -39,11 +39,6 @@
     "init_hook": [
       "cf install-plugin -f $(which app-autoscaler-cli-plugin)",
       "cf install-plugin -f $(which log-cache-cli)"
-    ],
-    "scripts": {
-      "test": [
-        "echo \"Error: no test specified\" && exit 1"
-      ]
-    }
+    ]
   }
 }

--- a/devbox.json
+++ b/devbox.json
@@ -18,7 +18,7 @@
     "gnumake@4.4",
     "maven@3.8.6",
     "pre-commit@latest",
-    "bosh-cli@7.5.6",
+    "bosh-cli@7.3.1",
     "golangci-lint@1.57.2",
     "yq-go@4.43.1",
     "which@latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -69,51 +69,51 @@
         }
       }
     },
-    "bosh-cli@7.5.6": {
-      "last_modified": "2024-04-19T17:36:04-04:00",
-      "resolved": "github:NixOS/nixpkgs/92d295f588631b0db2da509f381b4fb1e74173c5#bosh-cli",
+    "bosh-cli@7.3.1": {
+      "last_modified": "2023-08-22T06:04:29Z",
+      "resolved": "github:NixOS/nixpkgs/9d757ec498666cc1dcc6f2be26db4fd3e1e9ab37#bosh-cli",
       "source": "devbox-search",
-      "version": "7.5.6",
+      "version": "7.3.1",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/p2sm9lj0jlikhh69xi55larmyqh61ryw-bosh-cli-7.5.6",
+              "path": "/nix/store/qknp5ly60n24vnschjsqj7xddnbw2law-bosh-cli-7.3.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/p2sm9lj0jlikhh69xi55larmyqh61ryw-bosh-cli-7.5.6"
+          "store_path": "/nix/store/qknp5ly60n24vnschjsqj7xddnbw2law-bosh-cli-7.3.1"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/w3sby9zipmphdgsjd2xbaqna9qsb3db1-bosh-cli-7.5.6",
+              "path": "/nix/store/64nwkd5lk1370a0n5jw6xz35gbc97zws-bosh-cli-7.3.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/w3sby9zipmphdgsjd2xbaqna9qsb3db1-bosh-cli-7.5.6"
+          "store_path": "/nix/store/64nwkd5lk1370a0n5jw6xz35gbc97zws-bosh-cli-7.3.1"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/i7csc1lqbrw76hhibxyi799blf1mi6fm-bosh-cli-7.5.6",
+              "path": "/nix/store/1zk21pgb266m9c6gd8sxxd8kj34idyfl-bosh-cli-7.3.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/i7csc1lqbrw76hhibxyi799blf1mi6fm-bosh-cli-7.5.6"
+          "store_path": "/nix/store/1zk21pgb266m9c6gd8sxxd8kj34idyfl-bosh-cli-7.3.1"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/dila416vvd6zjr1rb54ygl39b84x4mc4-bosh-cli-7.5.6",
+              "path": "/nix/store/y8hglq4jc9hnr1aaisbrij2f9ldf25kq-bosh-cli-7.3.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/dila416vvd6zjr1rb54ygl39b84x4mc4-bosh-cli-7.5.6"
+          "store_path": "/nix/store/y8hglq4jc9hnr1aaisbrij2f9ldf25kq-bosh-cli-7.3.1"
         }
       }
     },

--- a/renovate.json
+++ b/renovate.json
@@ -85,18 +85,6 @@
         "\\.tool-versions$"
       ],
       "matchStrings": [
-        "(^|\\n)bosh (?<currentValue>.+?)\\n"
-      ],
-      "depNameTemplate": "cloudfoundry/bosh-cli",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>\\S+)"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "\\.tool-versions$"
-      ],
-      "matchStrings": [
         "(^|\\n)cf (?<currentValue>.+?)\\n"
       ],
       "depNameTemplate": "cloudfoundry/cli",


### PR DESCRIPTION
This PR brings https://github.com/cloudfoundry/app-autoscaler-release/pull/2619 also to the devbox environment.