### PR TITLE
fix(acceptance): use CF API to check if broker exists instead of `grep`ping from `cf`-cli

### DIFF
--- a/ci/autoscaler/scripts/register-broker.sh
+++ b/ci/autoscaler/scripts/register-broker.sh
@@ -14,7 +14,7 @@ cf_admin_password="$(credhub get -n /bosh-autoscaler/cf/cf_admin_password -q)"
 cf auth admin "${cf_admin_password}"
 
 set +e
-existing_service_broker="$(cf service-brokers | grep "${service_broker_name}.${system_domain}" |  cut -d' ' -f1)"
+existing_service_broker="$(cf curl v3/service_brokers | jq -r --arg service_broker_name "${deployment_name}" -r '.resources[] | select(.name == $service_broker_name) | .name')"
 set -e
 
 if [[ -n "$existing_service_broker" ]]; then


### PR DESCRIPTION
# Problem
When having multiple CI-pipelines in Concourse, during the acceptance tests, the `register-broker`-job tries to clean up more service brokers than it should be. This leads to the fact, that a service broker get's deleted which shouldn't be but the actual to be deleted one stays untouched.

Example: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/acceptance/builds/1310#L664ad3ee:19:58

This is the error-prone code line: 
https://github.com/cloudfoundry/app-autoscaler-release/blob/b9a590adb116bc70405731033a896c66d880c477/ci/autoscaler/scripts/register-broker.sh#L17


Example why `grep`ping is not a good because it returns more than one service-broker: 
```
❯ cf service-brokers | grep acceptance-lcservicebroker.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org
acceptance-lc            https://acceptance-lcservicebroker.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org
2913-acceptance-lc       https://2913-acceptance-lcservicebroker.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org
```

# Solution
Call CF API with exact service-broker name to check if it exists.