### PR TITLE
Adds netcat to CI Image

### DIFF
--- a/ci/dockerfiles/autoscaler-tools/Dockerfile
+++ b/ci/dockerfiles/autoscaler-tools/Dockerfile
@@ -38,7 +38,8 @@ RUN apt-get update && \
             gnupg2 \
             gh  \
             make \
-            mysql-client && \
+            mysql-client \
+            netcat && \
     apt-get clean
 
 RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add -


### PR DESCRIPTION
To be able to run bosh scp commands for #2967 track we need the nc tooling available on the dockerfile.