### PR TITLE
Add netcat to dockerfile to use bosh scp

### DIFF
--- a/ci/dockerfiles/autoscaler-tools/Dockerfile
+++ b/ci/dockerfiles/autoscaler-tools/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
             cf8-cli \
             gnupg \
             gnupg2 \
+            netcat \
             gh  \
             make \
             mysql-client && \


### PR DESCRIPTION
bosh scp needs the `nc` binary in order to run. This is provided in the netcat package