### PR TITLE
chore(linter-findings): ignore `gosec` findings in test-code

### DIFF
--- a/src/autoscaler/api/cmd/api/api_test.go
+++ b/src/autoscaler/api/cmd/api/api_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Api", func() {
 				badfile, err := os.CreateTemp("", "bad-ap-config")
 				Expect(err).NotTo(HaveOccurred())
 				runner.configPath = badfile.Name()
+				// #nosec G306
 				err = os.WriteFile(runner.configPath, []byte("bogus"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 				runner.Start()

--- a/src/autoscaler/eventgenerator/cmd/eventgenerator/eventgenerator_test.go
+++ b/src/autoscaler/eventgenerator/cmd/eventgenerator/eventgenerator_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Eventgenerator", func() {
 			badfile, err := os.CreateTemp("", "bad-mc-config")
 			Expect(err).NotTo(HaveOccurred())
 			runner.configPath = badfile.Name()
+			// #nosec G306
 			err = os.WriteFile(runner.configPath, []byte("bogus"), os.ModePerm)
 			Expect(err).NotTo(HaveOccurred())
 			runner.Start()

--- a/src/autoscaler/metricsforwarder/cmd/metricsforwarder/metricsforwarder_test.go
+++ b/src/autoscaler/metricsforwarder/cmd/metricsforwarder/metricsforwarder_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Metricsforwarder", func() {
 				badfile, err := os.CreateTemp("", "bad-mf-config")
 				Expect(err).NotTo(HaveOccurred())
 				runner.configPath = badfile.Name()
+				// #nosec G306
 				err = os.WriteFile(runner.configPath, []byte("bogus"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 				runner.Start()

--- a/src/autoscaler/metricsgateway/cmd/metricsgateway/metricsgateway_test.go
+++ b/src/autoscaler/metricsgateway/cmd/metricsgateway/metricsgateway_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Metricsgateway", func() {
 				badfile, err := os.CreateTemp("", "bad-mc-config")
 				Expect(err).NotTo(HaveOccurred())
 				runner.configPath = badfile.Name()
+				// #nosec G306
 				err = os.WriteFile(runner.configPath, []byte("bogus"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/src/autoscaler/metricsserver/cmd/metricsserver/metricsserver_test.go
+++ b/src/autoscaler/metricsserver/cmd/metricsserver/metricsserver_test.go
@@ -47,6 +47,7 @@ var _ = Describe("MetricsServer", func() {
 				badfile, err := os.CreateTemp("", "bad-ms-config")
 				Expect(err).NotTo(HaveOccurred())
 				runner.configPath = badfile.Name()
+				// #nosec G306
 				err = os.WriteFile(runner.configPath, []byte("bogus"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 				runner.Start()

--- a/src/autoscaler/operator/cmd/operator/operator_test.go
+++ b/src/autoscaler/operator/cmd/operator/operator_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Operator", Serial, func() {
 				badfile, err := os.CreateTemp("", "bad-pr-config")
 				Expect(err).NotTo(HaveOccurred())
 				runner.configPath = badfile.Name()
+				// #nosec G306
 				err = os.WriteFile(runner.configPath, []byte("bogus"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 				runner.Start()

--- a/src/autoscaler/scalingengine/cmd/scalingengine/scalingengine_test.go
+++ b/src/autoscaler/scalingengine/cmd/scalingengine/scalingengine_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Main", func() {
 				badfile, err := os.CreateTemp("", "bad-engine-config")
 				Expect(err).NotTo(HaveOccurred())
 				runner.configPath = badfile.Name()
+				// #nosec G306
 				err = os.WriteFile(runner.configPath, []byte("bogus"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 			})


### PR DESCRIPTION
# Problem
We have some `gosec` findings in our test-code https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/9478498599

# Solution
Ignore these findings since it's just test-code.