### PR TITLE
fix(ci): fix `fly` param value assignment so that `make delete-pipeline` works

### DIFF
--- a/ci/scripts/delete-pipeline.sh
+++ b/ci/scripts/delete-pipeline.sh
@@ -7,7 +7,7 @@ set -eu -o pipefail
 target="app-autoscaler-release"
 
 function delete-pipeline(){
-  payload=$(fly --target= "$target" pipelines --json)
+  payload=$(fly --target="$target" pipelines --json)
 
   pipelines=$(echo "$payload" | jq ".[] |.name" -r | sort)
   # ignore shellcheck warning


### PR DESCRIPTION
# Problem
The additional space between param and value assignment breaks `make delete-pipeline`

```console
❯ make delete-pipeline                   
+ target=app-autoscaler-release
+ check-login
+ fly -t app-autoscaler-release status
logged in successfully
+ delete-pipeline ''
++ fly  👹--target= app-autoscaler-release pipelines👹  --json 
error: Unknown command `app-autoscaler-release'. Please specify one command of: abort-build, active-users, archive-pipeline, builds, check-resource, check-resource-type, checklist, clear-resource-cache, clear-task-cache, clear-versions, completion, containers, curl, delete-target, destroy-pipeline, destroy-team, disable-resource-version, edit-target, enable-resource-version, execute, expose-pipeline, format-pipeline, get-pipeline, get-team, help, hide-pipeline, hijack, jobs, land-worker, login, logout, order-instanced-pipelines, order-pipelines, pause-job, pause-pipeline, paused-jobs, paused-pipelines, pin-resource, pipelines, prune-worker, rename-pipeline, rename-team, rerun-build, resource-versions, resources, schedule-job, set-pipeline, set-team, status, sync, targets, teams, trigger-job, unpause-job, unpause-pipeline, unpin-resource, userinfo, validate-pipeline, volumes, watch or workers
+ payload=
make: *** [Makefile:13: delete-pipeline] Error 1
```

# Solution
Deleting the faulty extra space so that`make delete-pipeline` works.