### PR TITLE
fix(readme): drop HTML-tags to fix rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ through
 
 ### Make Targets
 
-| Category          | Description                                                                            | Target                                                                   |
-|-------------------|----------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| mock              | generate mocks                                                                         | `make generate-fakes`                                                    |
-| unit-tests        | run against PostgreSQL                                                                 | `make test`                                                              |
-| unit-tests        | run against specific PostgreSQL version                                                | `make clean && make test POSTGRES_TAG=x.y`                   |
-| unit-tests        | run against MySQL                                                                      | `make test db_type=mysql`                                                |
-| unit-tests        | run against specific MySQL version                                                     | `make clean && make test db_type=mysql MYSQL_TAG=x.y`        |
-| integration-tests | run against PostgreSQL                                                                 | `make integration`                                                       |
-| integration-tests | run against specific PostgreSQL version                                                | `make clean && make integration POSTGRES_TAG=x.y`            |
-| integration-tests | run against MySQL                                                                      | `make integration db_type=mysql`                                         |
-| integration-tests | run against specific MySQL version                                                     | `make clean && make integration db_type=mysql MYSQL_TAG=x.y` |
-| acceptance-tests  | run acceptance-tests, see [AutoScaler UAT guide](src/acceptance/README.md) for details | `make acceptance-tests`                                                  |
-| lint              | check code style                                                                       | `make lint`                                                              |
-| lint              | check code style and apply auto-fixes                                                  | `OPTS=--fix RUBOCOP_OPTS=-A make lint`                                   |
-| build             | compile project                                                                        | `make build`                                                             |
-| deploy            | deploy Application Autoscaler and register the service broker in CF                    | `make deploy-autoscaler`                                                 |
-| cleanup           | remove build artifacts                                                                 | `make clean`                                                             |
+| Target                                                                   | Description                                                                            |
+|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| `make generate-fakes`                                                    | generate mocks                                                                         |
+| `make test`                                                              | run unit-tests against PostgreSQL                                                      |
+| `make clean && make test POSTGRES_TAG=x.y`                   | run unit-tests against specific PostgreSQL version                                     |
+| `make test db_type=mysql`                                                | run unit-tests against MySQL                                                           |
+| `make clean && make test db_type=mysql MYSQL_TAG=x.y`        | run unit-tests against specific MySQL version                                          |
+| `make integration`                                                       | run integration-tests against PostgreSQL                                               |
+| `make clean && make integration POSTGRES_TAG=x.y`            | run integration-tests against specific PostgreSQL version                              |
+| `make integration db_type=mysql`                                         | run integration-tests against MySQL                                                    |
+| `make clean && make integration db_type=mysql MYSQL_TAG=x.y` | run integration-tests against specific MySQL version                                   |
+| `make acceptance-tests`                                                  | run acceptance-tests, see [AutoScaler UAT guide](src/acceptance/README.md) for details |
+| `make lint`                                                              | check code style                                                                       |
+| `OPTS=--fix RUBOCOP_OPTS=-A make lint`                                   | check code style and apply auto-fixes                                                  |
+| `make build`                                                             | compile project                                                                        |
+| `make deploy-autoscaler`                                                 | deploy Application Autoscaler and register the service broker in CF                    |
+| `make clean`                                                             | remove build artifacts                                                                 |
 
 ## Use Application Autoscaler Service
 

--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ through
 
 ### Make Targets
 
-| Category          | Description                                                                            | Target                                                                                                                                                    |
-|-------------------|----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| mock              | generate mocks                                                                         | `make generate-fakes`                                                                                                                                     |
-| unit-tests        | run against PostgreSQL                                                                 | `make test`                                                                                                                                               |
-| unit-tests        | run against specific PostgreSQL version                                                | <pre><code>make clean #Only if you're changing versions to refresh the running docker image<br/>make test POSTGRES_TAG=x.y</code></pre>                   |
-| unit-tests        | run against MySQL                                                                      | `make test db_type=mysql`                                                                                                                                 |
-| unit-tests        | run against specific MySQL version                                                     | <pre><code>make clean #Only if you're changing versions to refresh the running docker image<br/>make test db_type=mysql MYSQL_TAG=x.y</code></pre>        |
-| integration-tests | run against PostgreSQL                                                                 | `make integration`                                                                                                                                        |
-| integration-tests | run against specific PostgreSQL version                                                | <pre><code>make clean #Only if you're changing versions to refresh the running docker image<br/>make integration POSTGRES_TAG=x.y</code></pre>            |
-| integration-tests | run against MySQL                                                                      | `make integration db_type=mysql`                                                                                                                          |
-| integration-tests | run against specific MySQL version                                                     | <pre><code>make clean #Only if you're changing versions to refresh the running docker image<br/>make integration db_type=mysql MYSQL_TAG=x.y</code></pre> |
-| acceptance-tests  | run acceptance-tests, see [AutoScaler UAT guide](src/acceptance/README.md) for details | `make acceptance-tests`                                                                                                                                   |
-| lint              | check code style                                                                       | `make lint`                                                                                                                                               |
-| lint              | check code style and apply auto-fixes                                                  | `OPTS=--fix RUBOCOP_OPTS=-A make lint`                                                                                                                    |
-| build             | compile project                                                                        | `make build`                                                                                                                                              |
-| deploy            | deploy Application Autoscaler and register the service broker in CF                    | `make deploy-autoscaler`                                                                                                                                  |
-| cleanup           | remove build artifacts                                                                 | `make clean`                                                                                                                                              |
+| Category          | Description                                                                            | Target                                                                   |
+|-------------------|----------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| mock              | generate mocks                                                                         | `make generate-fakes`                                                    |
+| unit-tests        | run against PostgreSQL                                                                 | `make test`                                                              |
+| unit-tests        | run against specific PostgreSQL version                                                | `make clean && make test POSTGRES_TAG=x.y`                   |
+| unit-tests        | run against MySQL                                                                      | `make test db_type=mysql`                                                |
+| unit-tests        | run against specific MySQL version                                                     | `make clean && make test db_type=mysql MYSQL_TAG=x.y`        |
+| integration-tests | run against PostgreSQL                                                                 | `make integration`                                                       |
+| integration-tests | run against specific PostgreSQL version                                                | `make clean && make integration POSTGRES_TAG=x.y`            |
+| integration-tests | run against MySQL                                                                      | `make integration db_type=mysql`                                         |
+| integration-tests | run against specific MySQL version                                                     | `make clean && make integration db_type=mysql MYSQL_TAG=x.y` |
+| acceptance-tests  | run acceptance-tests, see [AutoScaler UAT guide](src/acceptance/README.md) for details | `make acceptance-tests`                                                  |
+| lint              | check code style                                                                       | `make lint`                                                              |
+| lint              | check code style and apply auto-fixes                                                  | `OPTS=--fix RUBOCOP_OPTS=-A make lint`                                   |
+| build             | compile project                                                                        | `make build`                                                             |
+| deploy            | deploy Application Autoscaler and register the service broker in CF                    | `make deploy-autoscaler`                                                 |
+| cleanup           | remove build artifacts                                                                 | `make clean`                                                             |
 
 ## Use Application Autoscaler Service
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The Application Autoscaler provides the capability to adjust the computation res
 through
 
 * dynamic scaling based on application performance metrics
+* dynamic scaling based on custom metrics
 * scheduled scaling based on time
 
 ## Local Development


### PR DESCRIPTION
# Problem
Seems like GitHub doesn't render the `<br/>`-tags properly. That's why the new line is messed up:
<img width="595" alt="Screenshot 2024-06-18 at 15 49 46" src="https://github.com/cloudfoundry/app-autoscaler-release/assets/112163019/49e7ab3f-20a8-4aae-9c41-b711a6cf2107">

# Solution 
Inline the commands and get rid of custom HTML-tags.

# Unrelated changes
Removed the Category column which didn't add any value but simply ate up screen-width