### PR TITLE
fix(ci): make `acceptance-log-cache-syslog` run with a `metricsforwarder` sending metrics to the `loggr-syslog-agent`

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -19,7 +19,6 @@ anchors:
       operations/enable-nats-tls.yml
       operations/add-extra-plan.yml
       operations/set-release-version.yml
-      operations/enable-metricsforwarder-via-syslog-agent.yml
       operations/enable-scheduler-logging.yml
 
   app-autoscaler-ops-files-log-cache-syslog-cf: &app-autoscaler-ops-files-log-cache-syslog-cf


### PR DESCRIPTION
# Problem
Accidentally, the `acceptance-log-cache-syslog`-test was configured to have a `metricsforwarder` sending metrics directly to the Log Cache syslog server: https://github.com/cloudfoundry/app-autoscaler-release/pull/2913/files#diff-10ff83017bf5f3630e6c372c3aa8dc981a23f71cdc48c725cd17509d8d757a03R40

This should not be the case, `acceptance-log-cache-syslog` should run with a `metricsforwarder` sending metrics to `loggr-syslog-agent` (as it was before), see also #2685.

# Solution 
Don't apply `enable-metricsforwarder-via-syslog-agent.yml` during runs of `acceptance-log-cache-syslog`.