### PR TITLE
fix(metrics-architecture): remove configuration referencing the dead table `appinstancemetrics`

### DIFF
--- a/jobs/operator/spec
+++ b/jobs/operator/spec
@@ -90,32 +90,6 @@ properties:
     default: disable
     description: "sslmode to connect to postgres server"
 
-
-  autoscaler.instancemetrics_db.address:
-    description: "IP address on which the instancemetricsdb server will listen"
-    default: "autoscalerpostgres.service.cf.internal"
-  autoscaler.instancemetrics_db.databases:
-    description: "The list of databases used in instancemetricsdb database including name"
-  autoscaler.instancemetrics_db.db_scheme:
-    description: "Database scheme to be used to access instancemetricsdb"
-    default: postgres
-  autoscaler.instancemetrics_db.port:
-    description: "Port on which the instancemetricsdb server will listen"
-  autoscaler.instancemetrics_db.roles:
-    description: "The list of database roles used in instancemetricsdb database including name/password"
-  autoscaler.instancemetrics_db.tls.ca:
-    default: ''
-    description: 'PEM-encoded ca certificate for TLS database server'
-  autoscaler.instancemetrics_db.tls.certificate:
-    default: ''
-    description: 'PEM-encoded certificate for TLS database client'
-  autoscaler.instancemetrics_db.tls.private_key:
-    default: ''
-    description: 'PEM-encoded key for tls database client'
-  autoscaler.instancemetrics_db.sslmode:
-    default: disable
-    description: "sslmode to connect to postgres server"
-
   autoscaler.appmetrics_db.address:
     description: "IP address on which the appmetricsdb server will listen"
     default: "autoscalerpostgres.service.cf.internal"
@@ -181,12 +155,6 @@ properties:
   autoscaler.appmetrics_db_connection_config.connection_max_lifetime:
     default: 60s
 
-  autoscaler.instancemetrics_db_connection_config.max_open_connections:
-    default: 10
-  autoscaler.instancemetrics_db_connection_config.max_idle_connections:
-    default: 1
-  autoscaler.instancemetrics_db_connection_config.connection_max_lifetime:
-    default: 60s
 
   autoscaler.scalingengine_db_connection_config.max_open_connections:
     default: 10

--- a/operations/connect_to_postgres_with_certs.yml
+++ b/operations/connect_to_postgres_with_certs.yml
@@ -44,12 +44,6 @@
   value: ((postgres_client.private_key))
 
 - type: replace
-  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/instancemetrics_db/tls/certificate
-  value: ((postgres_client.certificate))
-- type: replace
-  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/instancemetrics_db/tls/private_key
-  value: ((postgres_client.private_key))
-- type: replace
   path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/appmetrics_db/tls/certificate
   value: ((postgres_client.certificate))
 - type: replace

--- a/operations/disable-postgres-tls-config.yml
+++ b/operations/disable-postgres-tls-config.yml
@@ -46,10 +46,6 @@
   value: disable
 
 - type: replace
-  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/instancemetrics_db/sslmode
-  value: disable
-
-- type: replace
   path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/lock_db/sslmode
   value: disable
 

--- a/templates/app-autoscaler.yml
+++ b/templates/app-autoscaler.yml
@@ -366,7 +366,6 @@ instance_groups:
     release: app-autoscaler
     properties:
       autoscaler:
-        instancemetrics_db: *database
         appmetrics_db: *database
         appmetrics_db_connection_config: *databaseConnectionConfig
         scalingengine_db: *database


### PR DESCRIPTION
# Problem
The table `appinstancemetrics` got deleted with #2983, which makes references like `instancemetrics_db` stale.

# Solution 
Cleanup leftovers of `instancemetrics_db`