### PR TITLE
chore(template): Remove unused `metric_scraper_ca`

### DIFF
--- a/templates/app-autoscaler.yml
+++ b/templates/app-autoscaler.yml
@@ -779,14 +779,6 @@ variables:
     - client_auth
     key_length: 4096
     duration: 180
-- name: metric_scraper_ca
-  type: certificate
-  update_mode: converge
-  options:
-    common_name: metricScraperCA
-    is_ca: true
-    key_length: 4096
-    duration: 180
 
   # metricsforwarder loggregator certificates
 - name: metricsforwarder_autoscaler_metricsforwarder_loggregator_tls


### PR DESCRIPTION
which was only used to sign the certificate `loggregator_agent_metrics_tls` which was removed by https://github.com/cloudfoundry/app-autoscaler-release/commit/3012a3e3a3958ab33facff60012300eddbc1296f#diff-276a5bf9491a6514a7792457803f74994a60f5cdc811948a3e6d555d4b43ffae