### PR TITLE
chor(deps) Automate Java Package Version Update

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -166,8 +166,10 @@ resources:
   check_every: 5m
   source:
     uri: https://github.com/SAP/SapMachine.git
-    branch: sapmachine
-    version_depth: 20
+    branch: sapmachine21 # use JDK 21 as the LTS version
+    fetch_tags: true
+    tag_regex: 'sapmachine-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'
+    version_depth: 50
 
 - name: gcp-jammy-stemcell
   type: bosh-io-stemcell

--- a/ci/autoscaler/tasks/update-sdk/download_java.sh
+++ b/ci/autoscaler/tasks/update-sdk/download_java.sh
@@ -6,19 +6,24 @@
 
 set -euo pipefail
 
-JAVA_VERSION=${1:-"21.0.3"} # default java version
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source "${script_dir}/vars.source.sh"
+
+JAVA_VERSION=${1:-"21.0.3"}
 
 # Step 1 --> Download java from https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.3/sapmachine-jdk-21.0.3_linux-x64_bin.tar.gz
 SAP_MACHINE_BASE_URL="https://github.com/SAP/SapMachine"
 binary_name="sapmachine-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz"
 
 printf "\n"
-
 jdk_download_url="${SAP_MACHINE_BASE_URL}/releases/download/sapmachine-${JAVA_VERSION}/${binary_name}"
 
-echo "Fetching SAP Machine JDK from ${JAVA_VERSION} ${jdk_download_url}"
-mkdir -p src/binaries/jdk && pushd src/binaries/jdk > /dev/null
+echo "Fetching SAP Machine JDK  ${JAVA_VERSION} from ${jdk_download_url}"
+# shellcheck disable=SC2154
+pushd "${autoscaler_dir}"
+  mkdir -p src/binaries/jdk && pushd src/binaries/jdk > /dev/null
   curl -JLO "${jdk_download_url}"
+  popd > /dev/null
 popd > /dev/null
 
 # Step 2 --> Build java

--- a/ci/autoscaler/tasks/update-sdk/update_java_package.sh
+++ b/ci/autoscaler/tasks/update-sdk/update_java_package.sh
@@ -2,7 +2,6 @@
 
 # This script is used to update the java version used in the bosh packaging
 # It downloads the given SAP Machine java distribution and updates the bosh packaging with the new version.
-# usage: ./update_java_package 21.0.3
 
 [ -n "${DEBUG}" ] && set -x
 set -euo pipefail
@@ -10,13 +9,33 @@ set -euo pipefail
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${script_dir}/vars.source.sh"
 
-JAVA_VERSION=${1:-"21.0.3"} # default java version
+java_dir=${JAVA_DIR:-"${autoscaler_dir}/../SapMachine"}
+java_dir=$(realpath --canonicalize-existing "${java_dir}")
+
+pushd "${java_dir}"
+  java_major_version=$(grep "DEFAULT_JDK_SOURCE_TARGET_VERSION" make/conf/version-numbers.conf | cut -d= -f2)
+  java_version_interim=$(grep "DEFAULT_VERSION_INTERIM" make/conf/version-numbers.conf | cut -d= -f2)
+  java_version_update=$(grep "DEFAULT_VERSION_UPDATE" make/conf/version-numbers.conf | cut -d= -f2)
+  java_version_prerelease=$(grep "DEFAULT_PROMOTED_VERSION_PRE" make/conf/version-numbers.conf | cut -d= -f2)
+popd
+
+sapmachine_java_version="${java_major_version}.${java_version_interim}.${java_version_update}"
+echo "Desired Java Version: ${sapmachine_java_version}"
+
+# consider only lts releases
+if [ "${java_version_prerelease}" != "" ]; then
+     echo "java version ${sapmachine_java_version} is not a LTS release. skipping update"
+     exit 0
+fi
+
+JAVA_VERSION=${sapmachine_java_version:-"21.0.3"}
 desired_major_version=${JAVA_VERSION%%.*}
 
 # identify current version
-current_major_version=$(find ./packages -type d -name "openjdk-*" -exec bash -c '
+# shellcheck disable=SC2154
+current_major_version=$(find "${autoscaler_dir}/packages" -type d -name "openjdk-*" -exec bash -c '
                           directory_name="$1"
-                          version_number=${directory_name#*-}
+                          version_number=${directory_name##*-}
                           echo "${version_number}"
                           ' bash {} \;)
 # shellcheck disable=SC2154
@@ -24,25 +43,38 @@ current_java_version=$(cat "${autoscaler_dir}/packages/openjdk-${current_major_v
 echo "Checking current Java Versions"
 echo " - Full version: ${current_java_version}"
 
+if [ "${JAVA_VERSION}" == "${current_java_version}" ]; then
+  echo "Already on java version ${JAVA_VERSION}. No need to update the java version"
+  exit 0
+fi
+
 # Step 1 --> Download java...
 source "${script_dir}/download_java.sh" "${JAVA_VERSION}"
-
-binary_name="sapmachine-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz"
+printf "\n"
 
 # Step 2 --> upload blob to blobstore
-echo "- Adding and uploading blobs to release blobstore "
-bosh add-blob "${autoscaler_dir}/src/binaries/jdk/${binary_name}" "${binary_name}"
-create_bosh_config
-bosh upload-blobs
+binary_name="sapmachine-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz"
+pushd "${autoscaler_dir}" > /dev/null
+  echo "- Adding and uploading blobs to release blobstore "
+  bosh add-blob "src/binaries/jdk/${binary_name}" "${binary_name}"
+  create_bosh_config
+  bosh upload-blobs
+popd > /dev/null
+
+printf "\n"
 
 # Step 3 --> update bosh java package references
 echo "- updating bosh java packages..."
 # shellcheck disable=SC2038
-find . -type f ! -name "*.yml" ! -name "update_java_package.sh" ! -path '*/\.*' -exec grep --files-with-matches "openjdk-${current_major_version}" {} \;| xargs sed --in-place "s/openjdk-${current_major_version}/openjdk-${desired_major_version}/g"
-mv ./packages/openjdk-"${current_major_version}" ./packages/openjdk-"${desired_major_version}"
+# only change java references if major versions are different
+if [ "${current_major_version}" != "${desired_major_version}" ]; then
+  find "${autoscaler_dir}" -type f ! -name "*.yml" ! -name "update_java_package.sh" ! -path '*/\.*' -exec grep -l "openjdk-${current_major_version}" {} \;| xargs sed -i "s/openjdk-${current_major_version}/openjdk-${desired_major_version}/g"
+  mv "${autoscaler_dir}/packages/openjdk-${current_major_version}" "${autoscaler_dir}/packages/openjdk-${desired_major_version}"
+  exit 0
+fi
 
 echo " - creating spec file"
-cat > "packages/openjdk-$desired_major_version/spec" <<EOF
+cat > "${autoscaler_dir}/packages/openjdk-$desired_major_version/spec" <<EOF
 ---
 name: openjdk-${desired_major_version}
 dependencies: []
@@ -51,7 +83,7 @@ files:
 EOF
 
 echo " - creating packaging script "
-cat > "packages/openjdk-$desired_major_version/packaging" <<EOF
+cat > "${autoscaler_dir}/packages/openjdk-$desired_major_version/packaging" <<EOF
 set -ex
 # compile and runtime bosh env vars
 export JAVA_HOME=/var/vcap/packages/openjdk-$desired_major_version
@@ -59,12 +91,10 @@ export PATH=\$JAVA_HOME/bin:\$PATH
 
 cd \${BOSH_INSTALL_TARGET}
 
-# extract jdk from src/binaries/jdk
 tar zxvf \${BOSH_COMPILE_TARGET}/*.tar.gz --strip 1
 EOF
 
-# creates pr
-echo -n "${JAVA_VERSION}" > "${AUTOSCALER_DIR}/version"
-echo -n "${JAVA_VERSION}" > "${AUTOSCALER_DIR}/vendored-commit"
-
-echo -n "${JAVA_VERSION}" > "./packages/openjdk-${desired_major_version}/version"
+#required for PR creation
+echo -n "${JAVA_VERSION}" > "${autoscaler_dir}/version"
+echo -n "${JAVA_VERSION}" > "${autoscaler_dir}/vendored-commit"
+echo -n "${JAVA_VERSION}" > "${autoscaler_dir}/packages/openjdk-${desired_major_version}/version"

--- a/ci/autoscaler/tasks/update-sdk/update_package.sh
+++ b/ci/autoscaler/tasks/update-sdk/update_package.sh
@@ -5,8 +5,7 @@ set -euo pipefail
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${script_dir}/vars.source.sh"
 create_pr=${CREATE_PR:-"false"}
-java_version=${1:-"21.0.3"} # default java version
 
 # shellcheck disable=SC2154
-"${script_dir}"/update_"${type}"_package.sh "$java_version"
+"${script_dir}"/update_"${type}"_package.sh
 [[ ${create_pr} == "true" ]] && "${script_dir}"/create_pr.sh


### PR DESCRIPTION
This PR fixes  [update-java](https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release-fix-update-java-job/jobs/update-java/) CI Job which was somehow broken as apart of [PR#3087 ](https://github.com/cloudfoundry/app-autoscaler-release/pull/3087) ( change from java-bosh-release to Sapmachine JDK 21)

The jobs updates the JDK 21 LTS versions only.

Test PR # https://github.com/cloudfoundry/app-autoscaler-release/pull/3106 (should not be merged)