### PR TITLE
chore(deps) Bump Google Java Formatter to 1.22.0

### DIFF
--- a/.github/workflows/java-ci-lint.yaml
+++ b/.github/workflows/java-ci-lint.yaml
@@ -25,8 +25,8 @@ jobs:
         run: |
           sh ./style-guide/google-format-ci-v0.1.sh
         env:
-          GOOGLE_JAR_VERSION: 1.11.0
-          GOOGLE_JAR_NAME: google-java-format-1.11.0-all-deps.jar
+          GOOGLE_JAR_VERSION: 1.22.0
+          GOOGLE_JAR_NAME: google-java-format-1.22.0-all-deps.jar
 
       - name: Checkstyle
         run: |

--- a/src/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManager.java
+++ b/src/scheduler/src/main/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManager.java
@@ -288,6 +288,7 @@ public class ScheduleManager {
 
     return compenstatorySchedule;
   }
+
   /**
    * Calls private helper methods to delete the schedules from the database and calls
    * ScalingJobManager to delete scaling action jobs.

--- a/style-guide/google-format-ci-v0.1.sh
+++ b/style-guide/google-format-ci-v0.1.sh
@@ -4,18 +4,13 @@ export PATH=${HOME}/go/bin:${PATH}
 ###################################################################################################
  # This script downloads google formatter and displays formatting issues on Github actions
 ###################################################################################################
-GOOGLE_JAR_VERSION=${GOOGLE_JAR_VERSION:-"1.11.0"}
+GOOGLE_JAR_VERSION=${GOOGLE_JAR_VERSION:-"1.22.0"}
 GOOGLE_JAR_NAME=${GOOGLE_JAR_NAME:-"google-java-format-${GOOGLE_JAR_VERSION}-all-deps.jar"}
 ! [ -e "$GOOGLE_JAR_NAME" ] && \
   curl -fLJO "https://github.com/google/google-java-format/releases/download/v$GOOGLE_JAR_VERSION/$GOOGLE_JAR_NAME"
+# shellcheck disable=SC2046
 files_to_be_formatted=$(java \
-              --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-              --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-              --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-              --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-              --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
-              -jar "${GOOGLE_JAR_NAME}" -n --skip-javadoc-formatting $(find . -name '*.java') )
-
+              -jar "${GOOGLE_JAR_NAME}" --dry-run --skip-javadoc-formatting $(find src/scheduler -name '*.java'))
 
 if  [ -n "$files_to_be_formatted" ]; then
   echo "Formatter Results..."


### PR DESCRIPTION
With the update to JDK21 the Google Java Formatter was throwing following exception

``` https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/10076579459/job/27857239602?pr=3099
100 3309k  100 3309k    0     0  4753k      0 --:--:-- --:--:-- --:--:-- 77.7M
./src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestControllerCreateScheduleAndNofifyScalingEngineTest.java: error: 'com.sun.tools.javac.tree.JCTree com.sun.tools.javac.tree.JCTree$JCImport.getQualifiedIdentifier()'
java.lang.NoSuchMethodError: 'com.sun.tools.javac.tree.JCTree com.sun.tools.javac.tree.JCTree$JCImport.getQualifiedIdentifier()'
	at com.google.googlejavaformat.java.RemoveUnusedImports.getSimpleName(RemoveUnusedImports.java:263)
	at com.google.googlejavaformat.java.RemoveUnusedImports.buildReplacements(RemoveUnusedImports.java:245)
	at com.google.googlejavaformat.java.RemoveUnusedImports.removeUnusedImports(RemoveUnusedImports.java:197)
	at com.google.googlejavaformat.java.FormatFileCallable.fixImports(FormatFileCallable.java:55)
	at com.google.googlejavaformat.java.FormatFileCallable.call(FormatFileCallable.java:46)
	at com.google.googlejavaformat.java.FormatFileCallable.call(FormatFileCallable.java:26)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:[15](https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/10076579459/job/27857239602?pr=3099#step:4:16)83)
./src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleSyncRestControllerTest.java: error: 'com.sun.tools.javac.tree.JCTree com.sun.tools.javac.tree.JCTree$JCImport.getQualifiedIdentifier()'
java.lang.NoSuchMethodError: 'com.sun.tools.javac.tree.JCTree com.sun.tools.javac.tree.JCTree$JCImport.getQualifiedIdentifier()'
	at com.google.googlejavaformat.java.RemoveUnusedImports.getSimpleName(RemoveUnusedImports.java:263)
```

Reason: 
 - Change in JDK 21 -> https://github.com/google/google-java-format/issues/898
 
Failing [Build](https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/10076579459/job/27857239602?pr=3099)

### Fix

Bump Google java format to the latest version i.e 1.22.0