### PR TITLE
chore(dependencies): replace `"dario.cat/mergo` with a custom implementation

### DIFF
--- a/packages/eventgenerator/spec
+++ b/packages/eventgenerator/spec
@@ -34,7 +34,6 @@ files:
 - autoscaler/vendor/code.cloudfoundry.org/lager/v3/* # gosub
 - autoscaler/vendor/code.cloudfoundry.org/lager/v3/internal/truncate/* # gosub
 - autoscaler/vendor/code.cloudfoundry.org/tlsconfig/* # gosub
-- autoscaler/vendor/dario.cat/mergo/* # gosub
 - autoscaler/vendor/filippo.io/edwards25519/* # gosub
 - autoscaler/vendor/filippo.io/edwards25519/field/* # gosub
 - autoscaler/vendor/github.com/beorn7/perks/quantile/* # gosub

--- a/src/autoscaler/envelopeprocessor/envelopeprocessor_test.go
+++ b/src/autoscaler/envelopeprocessor/envelopeprocessor_test.go
@@ -41,8 +41,7 @@ var _ = Describe("Envelopeprocessor", func() {
 
 			It("sends standard app instance metrics to channel", func() {
 				timestamp := time.Now().UnixNano()
-				metrics, err := envelopeprocessor.GetGaugeInstanceMetrics(envelopes, timestamp)
-				Expect(err).NotTo(HaveOccurred())
+				metrics := envelopeprocessor.GetGaugeInstanceMetrics(envelopes, timestamp)
 				Expect(metrics).To(ContainElement(models.AppInstanceMetric{
 					AppId:         "test-app-id",
 					InstanceIndex: 1,
@@ -87,8 +86,7 @@ var _ = Describe("Envelopeprocessor", func() {
 
 			It("sends standard app instance metrics to channel", func() {
 				timestamp := time.Now().UnixNano()
-				metrics, err := processor.GetGaugeMetrics(envelopes, timestamp)
-				Expect(err).NotTo(HaveOccurred())
+				metrics := processor.GetGaugeMetrics(envelopes, timestamp)
 				Expect(len(metrics)).To(Equal(18))
 				Expect(metrics).To(ContainElement(models.AppInstanceMetric{
 					AppId:         "test-app-id",

--- a/src/autoscaler/eventgenerator/metric/fetcher.go
+++ b/src/autoscaler/eventgenerator/metric/fetcher.go
@@ -156,9 +156,9 @@ func (l *logCacheFetcher) getMetricsRestAPI(appId string, metricType string, sta
 	}
 	l.logger.Info("received-rest-api-result", lager.Data{"envelopes": envelopes})
 
-	metrics, err := l.envelopeProcessor.GetGaugeMetrics(envelopes, time.Now().UnixNano())
+	metrics := l.envelopeProcessor.GetGaugeMetrics(envelopes, time.Now().UnixNano())
 
-	return l.filter(metrics, metricType), err
+	return l.filter(metrics, metricType), nil
 }
 
 func (l *logCacheFetcher) readOptions(endTime time.Time, metricType string) (readOptions []logcache.ReadOption) {

--- a/src/autoscaler/eventgenerator/metric/fetcher_test.go
+++ b/src/autoscaler/eventgenerator/metric/fetcher_test.go
@@ -264,7 +264,7 @@ var _ = Describe("logCacheFetcher", func() {
 							Name:  metricType,
 						},
 					}
-					mockEnvelopeProcess.GetGaugeMetricsReturns(expectedMetrics, nil)
+					mockEnvelopeProcess.GetGaugeMetricsReturns(expectedMetrics)
 					mockLogCacheClient.ReadReturns([]*loggregator_v2.Envelope{
 						{
 							SourceId: "app-id",

--- a/src/autoscaler/go.mod
+++ b/src/autoscaler/go.mod
@@ -10,7 +10,6 @@ require (
 	code.cloudfoundry.org/lager/v3 v3.0.3
 	code.cloudfoundry.org/loggregator-agent-release/src v0.0.0-20240723222507-f3307e073100
 	code.cloudfoundry.org/tlsconfig v0.0.0-20240712175922-ffce9516cec8
-	dario.cat/mergo v1.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-faster/errors v0.7.1

--- a/src/autoscaler/go.sum
+++ b/src/autoscaler/go.sum
@@ -610,8 +610,6 @@ code.cloudfoundry.org/loggregator-agent-release/src v0.0.0-20240723222507-f3307e
 code.cloudfoundry.org/loggregator-agent-release/src v0.0.0-20240723222507-f3307e073100/go.mod h1:LlTzJMtG7oiiRdtyHjNzH7ylMyGqJK3AFumu4BAE8Sg=
 code.cloudfoundry.org/tlsconfig v0.0.0-20240712175922-ffce9516cec8 h1:YWUbqlyYX4nf+mfbacMAgYxM/C9jWcFCurWssGmJJXI=
 code.cloudfoundry.org/tlsconfig v0.0.0-20240712175922-ffce9516cec8/go.mod h1:NBHWa9Nc4D4F67/xur/iZrELZ36+1l7JYzNht0g6naI=
-dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
-dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=


### PR DESCRIPTION
# Problem
The `dario.cat/mergo` library is being used to copy attributes between flat structs of the same type. However, this functionality is simple enough to implement directly, making the dependency unnecessary.

# Solution
* Implement a custom function to copy a specific set of attributes from one struct to another.
* Remove the `dario.cat/mergo` dependency from the project.