### PR TITLE
feat(devbox): Only install plugins if needed

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -43,8 +43,12 @@
   },
   "shell": {
     "init_hook": [
-      "cf install-plugin -f $(which app-autoscaler-cli-plugin)",
-      "cf install-plugin -f $(which log-cache-cli)"
+      "install_plugin_if_needed() {",
+      "  sum=$(sha1sum $(which $1) | cut -d ' ' -f 1)",
+      "  cf plugins --checksum | grep -q $sum || cf install-plugin -f $(which $1)",
+      "}",
+      "install_plugin_if_needed 'app-autoscaler-cli-plugin'",
+      "install_plugin_if_needed 'log-cache-cli'"
     ]
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1101,6 +1101,7 @@
     },
     "ruby@latest": {
       "last_modified": "2024-07-07T07:43:47Z",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/b60793b86201040d9dee019a05089a9150d08b5b#ruby_3_3",
       "source": "devbox-search",
       "version": "3.3.2",


### PR DESCRIPTION
# Issue

On starting the devbox all CF plugins were installed, regardless if
already installed or not, wasting time and screenspace.

# Fix

Check if already installed (comparing the checksums) before installing.
