### PR TITLE
poc(metricsforwarder): Use multiapps deploy to run metricsforwarder on cf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,3 +445,7 @@ go-get-u: $(addsuffix .go-get-u,$(go_modules))
 	@echo " - go get -u" $<
 	cd src/$< && \
 	go get -u ./...
+
+
+mta-deploy:
+	@make --directory='./src/autoscaler' mta-deploy

--- a/ci/autoscaler/scripts/common.sh
+++ b/ci/autoscaler/scripts/common.sh
@@ -98,6 +98,7 @@ function find_or_create_org(){
   if ! cf orgs | grep --quiet --regexp="${org_name}"; then
     cf create-org "${org_name}"
   fi
+  echo "targeting org ${org_name}"
   cf target -o "${org_name}"
 }
 
@@ -106,6 +107,7 @@ function find_or_create_space(){
   if ! cf spaces | grep --quiet --regexp="${space_name}"; then
     cf create-space "${space_name}"
   fi
+  echo "targeting space ${space_name}"
   cf target -s "${space_name}"
 }
 

--- a/ci/autoscaler/scripts/deploy-apps.sh
+++ b/ci/autoscaler/scripts/deploy-apps.sh
@@ -8,9 +8,8 @@ source "${script_dir}/vars.source.sh"
 
 function deploy() {
   log "Deploying autoscaler apps for bosh deployment '${deployment_name}' "
-  pushd "${autoscaler_dir}/src/autoscaler/metricsforwarder" > /dev/null
-    log "Deploying autoscaler apps"
-    make cf-push
+  pushd "${autoscaler_dir}/src/autoscaler" > /dev/null
+    make mta-deploy
   popd > /dev/null
 }
 

--- a/ci/dockerfiles/autoscaler-tools/Dockerfile
+++ b/ci/dockerfiles/autoscaler-tools/Dockerfile
@@ -146,9 +146,20 @@ RUN curl -sL "https://deb.nodesource.com/setup_${NODE_VERSION}.x" | bash - \
 # Install swagger-cli as described on <https://apitools.dev/swagger-cli>
 RUN npm install --global --ignore-scripts 'https://github.com/empire-medical/swagger-cli'
 
+# install MBT
+#renovate: datasource=github-releases depName=mbt lookupName=SAP/cloud-mta-build-tool
+ARG MBT_VERSION=1.2.31
+
+RUN wget -q https://github.com/SAP/cloud-mta-build-tool/releases/download/v1.2.31/cloud-mta-build-tool_${MBT_VERSION}_Linux_amd64.tar.gz &&\
+  tar xvfz cloud-mta-build-tool_${MBT_VERSION}_Linux_amd64.tar.gz && \
+  mv mbt /usr/local/bin/mbt &&\
+  rm cloud-mta-build-tool_${MBT_VERSION}_Linux_amd64.tar.gz &&\
+  mbt -v
+
 ENV CF_PLUGIN_HOME "/cf_plugins"
 RUN mkdir -p "${CF_PLUGIN_HOME}" \
     && cf install-plugin -f -r CF-Community app-autoscaler-plugin \
+    && cf install-plugin -f -r CF-Community multiapps \
     && echo "${CF_PLUGIN_HOME}" \
     && ls -la "${CF_PLUGIN_HOME}" \
     && cf plugins

--- a/src/autoscaler/.gitignore
+++ b/src/autoscaler/.gitignore
@@ -1,2 +1,3 @@
 build/
 fakes/
+mta_archives/

--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -12,6 +12,10 @@ PACKAGE_DIRS = $(shell go list './...' | grep --invert-match --regexp='/vendor/'
 DB_HOST ?= localhost
 DBURL ?= "postgres://postgres:postgres@${DB_HOST}/autoscaler?sslmode=disable"
 
+METRICSFORWARDER_APPNAME ?= "metricsforwarder"
+METRICSFORWARDER_HOSTNAME ?= $(METRICSFORWARDER_APPNAME)
+EXTENSION_FILE := $(shell mktemp)
+
 export GOWORK=off
 BUILDFLAGS := -ldflags '-linkmode=external'
 

--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -86,15 +86,16 @@ go-mod-vendor: ${go-vendoring-folder} ${go-vendored-files}
 ${go-vendoring-folder} ${go-vendored-files} &: ${app-fakes-dir} ${app-fakes-files}
 	go mod vendor
 
-build-cf-%:
+cf-build-%: generate-fakes
 	@echo "# building for cf $*"
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $*/$* $*/cmd/$*/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/$* $*/cmd/$*/main.go
+
+cf-build: $(addprefix cf-build-,$(binaries))
 
 # CGO_ENABLED := 1 is required to enforce dynamic linking which is a requirement of dynatrace.
 build-%: ${openapi-generated-clients-and-servers-dir} ${openapi-generated-clients-and-servers-files}
 	@echo "# building $*"
 	@CGO_ENABLED=1 go build $(BUILDTAGS) $(BUILDFLAGS) -o build/$* $*/cmd/$*/main.go
-
 
 build: $(addprefix build-,$(binaries))
 
@@ -146,3 +147,29 @@ clean:
 	@rm --force --recursive 'fakes'
 	@rm --force --recursive 'vendor'
 	@rm --force --recursive "${openapi-generated-clients-and-servers-dir}"
+
+.PHONY: mta-deploy
+mta-deploy: mta-build build-extension-file
+	$(MAKE) -f metricsforwarder/Makefile set-security-group
+	$(MAKE) -f metricsforwarder/Makefile stop-metricsforwarder-vm
+	@echo "Deploying with extension file: $(EXTENSION_FILE)"
+	@CF_TRACE=true cf deploy mta_archives/*.mtar -f -e $(EXTENSION_FILE)
+
+build-extension-file:
+	cp example.mtaext $(EXTENSION_FILE);
+	sed -i "s/APP_NAME/$(METRICSFORWARDER_APPNAME)/g" $(EXTENSION_FILE);
+	sed -i "s/HOSTNAME/$(METRICSFORWARDER_HOSTNAME)/g" $(EXTENSION_FILE);
+	echo "EXTENSION_FILE: $(EXTENSION_FILE)"
+
+mta-logs:
+	rm -rf mta-*
+	cf dmol --mta com.github.cloudfoundry.app-autoscaler-release --last 1
+	vim mta-*
+
+.PHONY: mta-build
+mta-build: mta-build-clean cf-build
+	$(MAKE) -f metricsforwarder/Makefile fetch-config
+	mbt build
+
+mta-build-clean:
+	rm -rf mta_archives

--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -13,7 +13,6 @@ DB_HOST ?= localhost
 DBURL ?= "postgres://postgres:postgres@${DB_HOST}/autoscaler?sslmode=disable"
 
 METRICSFORWARDER_APPNAME ?= "metricsforwarder"
-METRICSFORWARDER_HOSTNAME ?= $(METRICSFORWARDER_APPNAME)
 EXTENSION_FILE := $(shell mktemp)
 
 export GOWORK=off
@@ -162,7 +161,6 @@ mta-deploy: mta-build build-extension-file
 build-extension-file:
 	cp example.mtaext $(EXTENSION_FILE);
 	sed -i "s/APP_NAME/$(METRICSFORWARDER_APPNAME)/g" $(EXTENSION_FILE);
-	sed -i "s/HOSTNAME/$(METRICSFORWARDER_HOSTNAME)/g" $(EXTENSION_FILE);
 	echo "EXTENSION_FILE: $(EXTENSION_FILE)"
 
 mta-logs:

--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -156,7 +156,7 @@ mta-deploy: mta-build build-extension-file
 	$(MAKE) -f metricsforwarder/Makefile set-security-group
 	$(MAKE) -f metricsforwarder/Makefile stop-metricsforwarder-vm
 	@echo "Deploying with extension file: $(EXTENSION_FILE)"
-	@CF_TRACE=true cf deploy mta_archives/*.mtar -f -e $(EXTENSION_FILE)
+	@cf deploy mta_archives/*.mtar -f -e $(EXTENSION_FILE)
 
 build-extension-file:
 	cp example.mtaext $(EXTENSION_FILE);

--- a/src/autoscaler/example.mtaext
+++ b/src/autoscaler/example.mtaext
@@ -1,0 +1,10 @@
+_schema-version: 3.3.0
+ID: development
+extends: com.github.cloudfoundry.app-autoscaler-release
+version: 1.0.0
+
+modules:
+  - name: metricsforwarder
+    parameters:
+      routes:
+      - route: APP_NAME.${default-domain}

--- a/src/autoscaler/metricsforwarder/Makefile
+++ b/src/autoscaler/metricsforwarder/Makefile
@@ -3,49 +3,41 @@ DEPLOYMENT_NAME ?= autoscaler-$(PR_NUMBER)
 METIRCSFORWARDER_VM := $(shell bosh -d $(DEPLOYMENT_NAME) vms --json | jq '.Tables | .[] | .Rows | .[] | select(.instance|test("metricsforwarder")) | .instance')
 POSTGRES_IP := $(shell bosh -d ${DEPLOYMENT_NAME} vms --json | jq -r '.Tables | .[] | .Rows  | .[] | select(.instance|test("postgres")) | .ips' )
 LOG_CACHE_IP := $(shell bosh -d cf vms --json | jq -r '.Tables | .[] | .Rows  | .[] | select(.instance|test("log-cache")) | .ips' )
-METRICSFORWARDER_APPNAME ?= "metricsforwarder"
-METRICSFORWARDER_HOSTNAME ?= $(METRICSFORWARDER_APPNAME)
-SYSTEM_DOMAIN ?= "autoscaler.app-runtime-interfaces.ci.cloudfoundry.org"
+MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-.PHONY: cf-push
-cf-push: fetch-config build-cf set-security-group
-	cf push $(METRICSFORWARDER_APPNAME) -b binary_buildpack -p . --no-start --no-route -c "./metricsforwarder -c metricsforwarder.yml"
-	cf create-route  "$(SYSTEM_DOMAIN)" --hostname "$(METRICSFORWARDER_HOSTNAME)"
-	cf map-route "$(METRICSFORWARDER_APPNAME)" "$(SYSTEM_DOMAIN)" --hostname "$(METRICSFORWARDER_HOSTNAME)"
-	cf start "$(METRICSFORWARDER_APPNAME)"
-	@$(MAKE) stop-metricsforwarder-vm
+
 
 .PHONY: fetch-config
 fetch-config: start-metricsforwarder-vm
 	# how to define variables in deployment name
-	mkdir -p assets/certs/policy_db assets/certs/storedprocedure_db assets/certs/syslog_client
+	mkdir -p build/assets/certs/policy_db build/assets/certs/storedprocedure_db build/assets/certs/syslog_client
 
 	echo "POSTGRES IP: $(POSTGRES_IP)"
 	echo "LOG_CACHE IP: $(LOG_CACHE_IP)"
 
 	@echo "Pulling metricforwarder config from $(METIRCSFORWARDER_VM)..."
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/metricsforwarder.yml assets/metricsforwarder.yml
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/metricsforwarder.yml build/assets/metricsforwarder.yml
 
 	@echo "Pulling policy db certs from $(METIRCSFORWARDER_VM)..."
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/policy_db/ca.crt assets/certs/policy_db/.
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/policy_db/crt    assets/certs/policy_db/.
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/policy_db/key    assets/certs/policy_db/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/policy_db/ca.crt build/assets/certs/policy_db/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/policy_db/crt    build/assets/certs/policy_db/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/policy_db/key    build/assets/certs/policy_db/.
 
 	@echo "Pulling storeprocedure db certs from $(METIRCSFORWARDER_VM)..."
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/storedprocedure_db/ca.crt assets/certs/storedprocedure_db/.
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/storedprocedure_db/crt	 assets/certs/storedprocedure_db/.
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/storedprocedure_db/key    assets/certs/storedprocedure_db/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/storedprocedure_db/ca.crt build/assets/certs/storedprocedure_db/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/storedprocedure_db/crt	 build/assets/certs/storedprocedure_db/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/storedprocedure_db/key    build/assets/certs/storedprocedure_db/.
 
 	@echo "Pulling syslog-client certs from $(METIRCSFORWARDER_VM)..."
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/syslog_client/ca.crt		assets/certs/syslog_client/.
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/syslog_client/client.crt assets/certs/syslog_client/.
-	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/syslog_client/client.key assets/certs/syslog_client/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/syslog_client/ca.crt		build/assets/certs/syslog_client/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/syslog_client/client.crt build/assets/certs/syslog_client/.
+	bosh -d $(DEPLOYMENT_NAME) scp $(METIRCSFORWARDER_VM):/var/vcap/jobs/metricsforwarder/config/certs/syslog_client/client.key build/assets/certs/syslog_client/.
 
 	@echo "Build metricsforwarder config yaml"
-	cp assets/metricsforwarder.yml metricsforwarder.yml
+	cp build/assets/metricsforwarder.yml build/metricsforwarder.yml
 
-	sed -i'' -e 's|\/var\/vcap\/jobs\/metricsforwarder\/config|\/home\/vcap\/app/assets|g' metricsforwarder.yml
-	sed -i'' -e 's|$(DEPLOYMENT_NAME).autoscalerpostgres.service.cf.internal|$(POSTGRES_IP)|g' metricsforwarder.yml
+	sed -i'' -e 's|\/var\/vcap\/jobs\/metricsforwarder\/config|\/home\/vcap\/app/assets|g' build/metricsforwarder.yml
+	sed -i'' -e 's|$(DEPLOYMENT_NAME).autoscalerpostgres.service.cf.internal|$(POSTGRES_IP)|g' build/metricsforwarder.yml
 
 
 PHONY: set-security-group
@@ -53,12 +45,8 @@ set-security-group:
 	$(eval ORG := $(shell cf target |grep "org\:" |cut -d':' -f2 | xargs))
 	$(eval SPACE := $(shell cf target |grep "space\:" |cut -d':' -f2 | xargs))
 
-	cf create-security-group metricsforwarder security-group.json
+	cf create-security-group metricsforwarder $(MAKEFILE_DIR)/security-group.json
 	cf bind-security-group metricsforwarder $(ORG)
-
-PHONY: build-cf
-build-cf:
-	@cd ../; make build-cf-metricsforwarder
 
 PHONY: start-metricsforwarder-vm
 start-metricsforwarder-vm:

--- a/src/autoscaler/mta.yaml
+++ b/src/autoscaler/mta.yaml
@@ -1,0 +1,19 @@
+ID: com.github.cloudfoundry.app-autoscaler-release
+description: Application Autoscaler Release for Cloud Foundry
+_schema-version: "3.3.0"
+provider: SAP
+copyright: Apache License 2.0
+version: 0.0.1
+
+modules:
+  - name: metricsforwarder
+    type: binary
+    path: build
+    parameters:
+      memory: 1G
+      disk-quota: 1G
+      instances: 1
+      stack: cflinuxfs4
+      command: ./metricsforwarder -c metricsforwarder.yml
+      routes:
+

--- a/src/autoscaler/mta.yaml
+++ b/src/autoscaler/mta.yaml
@@ -1,7 +1,7 @@
 ID: com.github.cloudfoundry.app-autoscaler-release
 description: Application Autoscaler Release for Cloud Foundry
 _schema-version: "3.3.0"
-provider: SAP
+provider: Cloud Foundry Foundation
 copyright: Apache License 2.0
 version: 0.0.1
 


### PR DESCRIPTION
## Transitioning MetricsForwarder to MultiApps Controller

As part of our strategic move away from BOSH releases, we are initiating the transition of the MetricsForwarder Cloud Foundry Proof of Concept (POC) to utilize the MultiApps Controller. 

## Objectives and Benefits

**Reduced Dependency:** This transition will gradually eliminate our reliance on existing VMs for fetching MetricsForwarder configurations.
**Enhanced Configuration Management:** By implementing MultiTarget Application (MTA) and MTA extension files, we establish a new configuration structure. This approach will eventually replace the BOSH job spec file configuration.
**Future-Proofing:** This change sets the foundation for further improvements and easier integration with other SAP Cloud Platform services.

## Goal



**Test the new deployment process using the MultiApps Controller:** Replace `cf push` deployment with an mta `cf deploy` and get the acceptance test running against it.

## Next step
Gradually phase out BOSH-related configurations as we validate the new approach.