### PR TITLE
chore(asdf2devbox): Switch to Java 21

### DIFF
--- a/.github/workflows/asdf2devbox.yaml
+++ b/.github/workflows/asdf2devbox.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - ".tool-versions"
+      - "scripts/asdf2devbox.py"
+      - ".github/workflows/asdf2devbox.yaml"
 jobs:
   asdf2devbox:
     runs-on: ubuntu-latest

--- a/devbox.json
+++ b/devbox.json
@@ -39,7 +39,6 @@
     "cloudfoundry-cli":                  "8.7.11",
     "google-cloud-sdk":                  "latest",
     "ginkgo":                            "2.20.0",
-    "temurin-bin-17":                    "latest",
     "ruby":                              "latest"
   },
   "shell": {

--- a/devbox.json
+++ b/devbox.json
@@ -37,8 +37,9 @@
     "yq-go":                             "4.44.2",
     "postgresql":                        "latest",
     "cloudfoundry-cli":                  "8.7.11",
-    "google-cloud-sdk":                  "latest",
     "ginkgo":                            "2.20.0",
+    "google-cloud-sdk":                  "latest",
+    "temurin-bin-21":                    "latest",
     "ruby":                              "latest"
   },
   "shell": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -1666,6 +1666,7 @@
     },
     "ruby@latest": {
       "last_modified": "2024-07-31T08:48:38Z",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/c3392ad349a5227f4a3464dce87bcc5046692fce#ruby_3_3",
       "source": "devbox-search",
       "version": "3.3.4",
@@ -1925,54 +1926,6 @@
             }
           ],
           "store_path": "/nix/store/qpg44hby6wm39ycp9d7qas7apgv8nhal-swagger-cli-4.0.4"
-        }
-      }
-    },
-    "temurin-bin-17@latest": {
-      "last_modified": "2024-07-07T07:43:47Z",
-      "resolved": "github:NixOS/nixpkgs/b60793b86201040d9dee019a05089a9150d08b5b#temurin-bin-17",
-      "source": "devbox-search",
-      "version": "17.0.11",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/2d6rfr7i5zk5w8zvfmd1r2l09pmzgz0c-temurin-bin-17.0.11",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/2d6rfr7i5zk5w8zvfmd1r2l09pmzgz0c-temurin-bin-17.0.11"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/xk5an6bvr31255wswn1xamx0lvsfn7pf-temurin-bin-17.0.11",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/xk5an6bvr31255wswn1xamx0lvsfn7pf-temurin-bin-17.0.11"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/scinqaw1rmfddmmxprnym4ccn5k94c6l-temurin-bin-17.0.11",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/scinqaw1rmfddmmxprnym4ccn5k94c6l-temurin-bin-17.0.11"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/8a3b40b63waavsyvdv1y822rv7lqm6kj-temurin-bin-17.0.11",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/8a3b40b63waavsyvdv1y822rv7lqm6kj-temurin-bin-17.0.11"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -1666,7 +1666,6 @@
     },
     "ruby@latest": {
       "last_modified": "2024-07-31T08:48:38Z",
-      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/c3392ad349a5227f4a3464dce87bcc5046692fce#ruby_3_3",
       "source": "devbox-search",
       "version": "3.3.4",
@@ -1926,6 +1925,54 @@
             }
           ],
           "store_path": "/nix/store/qpg44hby6wm39ycp9d7qas7apgv8nhal-swagger-cli-4.0.4"
+        }
+      }
+    },
+    "temurin-bin-21@latest": {
+      "last_modified": "2024-07-31T08:48:38Z",
+      "resolved": "github:NixOS/nixpkgs/c3392ad349a5227f4a3464dce87bcc5046692fce#temurin-bin-21",
+      "source": "devbox-search",
+      "version": "21.0.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/an74vw8d3n04g223h5rs6nn8rv5a2pdm-temurin-bin-21.0.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/an74vw8d3n04g223h5rs6nn8rv5a2pdm-temurin-bin-21.0.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kn70i47biavh790xrsym6hv3qq6w1kv5-temurin-bin-21.0.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kn70i47biavh790xrsym6hv3qq6w1kv5-temurin-bin-21.0.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qlcv8f0dqfxmdqkd7bi1y1n1vfplbk8l-temurin-bin-21.0.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/qlcv8f0dqfxmdqkd7bi1y1n1vfplbk8l-temurin-bin-21.0.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xnkkwdy3pgfpgh061njl2hrrq2bm0xl2-temurin-bin-21.0.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/xnkkwdy3pgfpgh061njl2hrrq2bm0xl2-temurin-bin-21.0.3"
         }
       }
     },

--- a/scripts/asdf2devbox.py
+++ b/scripts/asdf2devbox.py
@@ -11,7 +11,10 @@ script_dir = os.path.dirname(os.path.realpath(__file__))
 def get_installed_version(package):
     with open(os.path.join(script_dir, '..', 'devbox.json'), 'r') as f:
         data = json.load(f)
-        return data['packages'][package]
+        try:
+            return data['packages'][package]
+        except KeyError:
+            return None
 
 # Read the .tool-versions file and process each line
 if __name__ == "__main__":
@@ -27,7 +30,7 @@ if __name__ == "__main__":
                 "credhub": "credhub-cli",
                 "gcloud": "google-cloud-sdk",
                 "golang": "go",
-                "java": "temurin-bin-17",
+                "java": "temurin-bin-21",
                 "make": "gnumake",
                 "yq": "yq-go"
             }


### PR DESCRIPTION
# Issue

As the Nix package name contains the Java major version, the translation
needs to be updated now that we have switched to version 21

# Fix

Just a static string change. Parsing it from the version number would be
possible, but as it is a LTS release the next update should be in the
far future.
