### PR TITLE
Sets postgres port to current pr number if open pr exists

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -332,6 +332,7 @@ jobs:
     file: ci/ci/autoscaler/tasks/cleanup-autoscaler.yml
     params: &acceptance-log-cache-syslog-cf-params
       DEPLOYMENT_NAME: ((acceptance_deployment_name_logcache_syslog_cf))
+      PR_NUMBER: ((pr_number))
   plan:
   - in_parallel:
     - get: bbl-state

--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -63,12 +63,20 @@ function setup_autoscaler_uaac(){
       --secret "$autoscaler_secret" > /dev/null
   fi
 }
+function get_postgres_external_port(){
+	if [ -z "${PR_NUMBER}" ]; then
+		echo "5432"
+	else
+		echo "${PR_NUMBER}"
+	fi
+}
 
 function create_manifest(){
   # Set the local tmp_dir depending on if we run on github-actions or not, see:
   # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
   local tmp_dir
   local perform_as_gh_action
+
   perform_as_gh_action="${GITHUB_ACTIONS:-false}"
   if "${perform_as_gh_action}" != 'false'
   then
@@ -102,6 +110,7 @@ function create_manifest(){
       -v metricscollector_ca_cert="$(credhub get -n /bosh-autoscaler/cf/log_cache --key ca --quiet)"\
       -v metricscollector_client_cert="$(credhub get -n /bosh-autoscaler/cf/log_cache --key certificate --quiet)"\
       -v metricsforwarder_host="${metricsforwarder_host}"\
+      -v postgres_external_port="$(get_postgres_external_port)"\
       -v metricscollector_client_key="$(credhub get -n /bosh-autoscaler/cf/log_cache --key private_key --quiet)"\
       -v skip_ssl_validation=true \
       > "${tmp_manifest_file}"

--- a/ci/autoscaler/set-pipeline.sh
+++ b/ci/autoscaler/set-pipeline.sh
@@ -30,11 +30,13 @@ function set_pipeline(){
   local pipeline_name="$1"
   add_var branch_name "${CURRENT_BRANCH}"
   if [[ -z $PR_NUMBER ]]; then
+    add_var pr_number "${PR_NUMBER}"
     add_var acceptance_deployment_name          "acceptance"
     add_var acceptance_deployment_name_logcache_metron "acceptance-lc"
     add_var acceptance_deployment_name_logcache_syslog "acceptance-lc-sl"
     add_var acceptance_deployment_name_logcache_syslog_cf "acceptance-lc-sl-cf"
   else
+    add_var pr_number "${PR_NUMBER}"
     add_var acceptance_deployment_name          "${PR_NUMBER}-acceptance"
     add_var acceptance_deployment_name_logcache_metron "${PR_NUMBER}-acceptance-lc"
     add_var acceptance_deployment_name_logcache_syslog "${PR_NUMBER}-acceptance-lc-sl"

--- a/operations/use-cf-services.yml
+++ b/operations/use-cf-services.yml
@@ -37,7 +37,7 @@
           - name: autoscaler_postgres
             registration_interval: 20s
             port: 5432
-            external_port: 5432
+            external_port: ((postgres_external_port))
             type: tcp
             router_group: default-tcp
             tags:

--- a/src/autoscaler/metricsforwarder/Makefile
+++ b/src/autoscaler/metricsforwarder/Makefile
@@ -5,6 +5,8 @@ METIRCSFORWARDER_VM := $(shell bosh -d $(DEPLOYMENT_NAME) vms --json | jq '.Tabl
 POSTGRES_ADDRESS := $(DEPLOYMENT_NAME)-postgres.tcp.$(SYSTEM_DOMAIN)
 LOG_CACHE_IP := $(shell bosh -d cf vms --json | jq -r '.Tables | .[] | .Rows  | .[] | select(.instance|test("log-cache")) | .ips' )
 MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+POSTGRES_EXTERNAL_PORT := $(or $(PR_NUMBER),5432)
+
 
 .PHONY: fetch-config
 fetch-config: start-metricsforwarder-vm
@@ -36,7 +38,7 @@ fetch-config: start-metricsforwarder-vm
 	cp build/assets/metricsforwarder.yml build/metricsforwarder.yml
 
 	sed -i'' -e 's|\/var\/vcap\/jobs\/metricsforwarder\/config|\/home\/vcap\/app/assets|g' build/metricsforwarder.yml
-	sed -i'' -e 's|$(DEPLOYMENT_NAME).autoscalerpostgres.service.cf.internal|$(POSTGRES_ADDRESS)|g' build/metricsforwarder.yml
+	sed -i'' -e 's|$(DEPLOYMENT_NAME).autoscalerpostgres.service.cf.internal:5432|$(POSTGRES_ADDRESS):$(POSTGRES_EXTERNAL_PORT)|g' build/metricsforwarder.yml
 
 
 


### PR DESCRIPTION
## Dynamic PostgreSQL Port for Concurrent CF Workflows

This PR allows the PostgreSQL port to be set dynamically when accessed through the TCP route. This change enables us to run multiple Cloud Foundry (CF) workflows simultaneously, with each workflow connecting to a different PostgreSQL instance.

## Key Changes:

Modified TCP route to use dynamic ports matching PR number
Updated PostgreSQL connection on metriscforwarder cf app

WORKING BUILD: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release-autoscaler-775-dynamic-postgres-tcp-port/jobs/acceptance-log-cache-syslog-cf/builds/6
