### PR TITLE
fix(metricsforwarder): Clear allowed metrics cache once policy is removed.

### DIFF
--- a/src/autoscaler/metricsforwarder/manager/policyManager.go
+++ b/src/autoscaler/metricsforwarder/manager/policyManager.go
@@ -118,6 +118,9 @@ func (pm *PolicyManager) RefreshAllowedMetricCache(policies map[string]*models.A
 				pm.logger.Error("Error updating allowedMetricCache", err)
 				return err
 			}
+		} else {
+			//If the policy is not present in the cache, remove the entry from the cache
+			pm.allowedMetricCache.Delete(applicationId)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Issue

If an app was bound with a policy using custom metrics, even after the
policy being removed the app was still allowed to submit the custom
metrics previously used.

# Fix

Correctly clear the entry in the cache if the policy was removed.
