### PR TITLE
Adds missing pr variable to set-pipeline job

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -188,6 +188,7 @@ jobs:
       acceptance_deployment_name_logcache_metron: ((acceptance_deployment_name_logcache_metron))
       acceptance_deployment_name_logcache_syslog: ((acceptance_deployment_name_logcache_syslog))
       acceptance_deployment_name_logcache_syslog_cf: ((acceptance_deployment_name_logcache_syslog_cf))
+      pr_number: ((pr_number))
 
 - name: unit-tests
   public: true


### PR DESCRIPTION
## Issue 

[set-pipeline](https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/set-pipeline/builds/557) task does not have a variable required to run [cf acceptance tests](https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/acceptance-log-cache-syslog-cf/builds/105)

## Solution 

Add missing variable to pipeline