### PR TITLE
fix(test): Fix `scalingengine_sqldb_test.go`

### DIFF
--- a/src/autoscaler/db/sqldb/scalingengine_sqldb_test.go
+++ b/src/autoscaler/db/sqldb/scalingengine_sqldb_test.go
@@ -73,12 +73,10 @@ var _ = Describe("ScalingEngineSqldb", func() {
 		cleanupForApp(appId)
 		cleanupForApp(appId2)
 		cleanupForApp(appId3)
-		cleanUpCooldownTable()
 		DeferCleanup(func() {
 			cleanupForApp(appId)
 			cleanupForApp(appId2)
 			cleanupForApp(appId3)
-			cleanUpCooldownTable()
 		})
 	})
 

--- a/src/autoscaler/db/sqldb/sqldb_suite_test.go
+++ b/src/autoscaler/db/sqldb/sqldb_suite_test.go
@@ -210,11 +210,6 @@ func removeCooldownForApp(appId string) {
 	FailOnError("can not remove scalingcooldown for app", err)
 }
 
-func cleanUpCooldownTable() {
-	_, err := dbHelper.Exec("DELETE from scalingcooldown")
-	FailOnError("can not clean table scalingcooldown", err)
-}
-
 func removeActiveScheduleForApp(appId string) {
 	query := dbHelper.Rebind("DELETE from activeschedule where appId = ?")
 	_, err := dbHelper.Exec(query, appId)


### PR DESCRIPTION
# Issue

The ScalingEngineSqldb tests had become flaky

# Fix

A well-meaning but harmfull test cleanup function was removed.
