### PR TITLE
Remove PR_NUMBER check from build-extension-file.sh in autoscaler module

### DIFF
--- a/src/autoscaler/build-extension-file.sh
+++ b/src/autoscaler/build-extension-file.sh
@@ -15,11 +15,6 @@ if [ -z "${DEPLOYMENT_NAME}" ]; then
   exit 1
 fi
 
-if [ -z "${PR_NUMBER}" ]; then
-  echo "PR_NUMBER is not set"
-  exit 1
-fi
-
 export SYSTEM_DOMAIN="autoscaler.app-runtime-interfaces.ci.cloudfoundry.org"
 export POSTGRES_ADDRESS="${DEPLOYMENT_NAME}-postgres.tcp.${SYSTEM_DOMAIN}"
 export POSTGRES_EXTERNAL_PORT="${PR_NUMBER:-5432}"


### PR DESCRIPTION
The pipeline is currently failing:

https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/acceptance-log-cache-syslog-cf/builds/118

The PR number in the build extension file is not required, default port 5432 will be assigned to the autoscaler Postgres TCP route when not available.

Removing this check would allow the pipeline to run for the concourse branch in main and for PRs
