### PR TITLE
chore(ci): Disable Cloud Controller v2 API in CI

### DIFF
--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -267,7 +267,7 @@ jobs:
       vars-files: autoscaler-env-vars-store
     params:
       SYSTEM_DOMAIN: autoscaler.app-runtime-interfaces.ci.cloudfoundry.org
-      OPS_FILES: "operations/cf/scale-to-one-az.yml operations/cf/experimental/add-cflinuxfs4.yml operations/autoscaler/scale_out_cf_for_app-autoscaler.yaml operations/autoscaler/set-cpu-entitlement-per-share.yaml operations/autoscaler/add-trusted-certs.yaml operations/cf/use-compiled-releases.yml operations/autoscaler/enable_mtls.yml operations/prometheus/operators/cf/add-prometheus-uaa-clients.yml operations/prometheus/operators/cf/add-grafana-uaa-clients.yml"
+      OPS_FILES: "operations/cf/scale-to-one-az.yml operations/autoscaler/scale_out_cf_for_app-autoscaler.yaml operations/autoscaler/set-cpu-entitlement-per-share.yaml operations/autoscaler/add-trusted-certs.yaml operations/cf/use-compiled-releases.yml operations/autoscaler/enable_mtls.yml operations/prometheus/operators/cf/add-prometheus-uaa-clients.yml operations/prometheus/operators/cf/add-grafana-uaa-clients.yml operations/cf/experimental/disable-v2-api.yml"
       BOSH_DEPLOY_ARGS: "-v diego_cell_instances=3 -v grafana_redirect_uri=https://grafana.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org/login/generic_oauth"
     ensure:
       put: autoscaler-env-vars-store


### PR DESCRIPTION
# Issue

The app-autoscaler-release should be able to run on foundations with only the Cloud Controller v3 API available.

# Fix

Disable the v2 API.

# Notes

- Might break stuff.
- `add-cflinuxfs4.yml` is deprecated and a no-op as `cflinuxfs4` is the default stack.