### PR TITLE
chore(deps): Remove unintentional usage of `gopkg.in/errgo.v2`

### DIFF
--- a/packages/golangapiserver/spec
+++ b/packages/golangapiserver/spec
@@ -236,7 +236,5 @@ files:
 - autoscaler/vendor/google.golang.org/protobuf/runtime/protoiface/* # gosub
 - autoscaler/vendor/google.golang.org/protobuf/runtime/protoimpl/* # gosub
 - autoscaler/vendor/google.golang.org/protobuf/types/known/timestamppb/* # gosub
-- autoscaler/vendor/gopkg.in/errgo.v2/errors/* # gosub
-- autoscaler/vendor/gopkg.in/errgo.v2/fmt/errors/* # gosub
 - autoscaler/vendor/gopkg.in/yaml.v2/* # gosub
 - autoscaler/vendor/gopkg.in/yaml.v3/* # gosub

--- a/src/autoscaler/api/config/config.go
+++ b/src/autoscaler/api/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/xeipuuv/gojsonschema"
-	"gopkg.in/errgo.v2/fmt/errors"
 	"gopkg.in/yaml.v3"
 
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/db"

--- a/src/autoscaler/go.mod
+++ b/src/autoscaler/go.mod
@@ -46,7 +46,6 @@ require (
 	golang.org/x/net v0.29.0
 	golang.org/x/time v0.6.0
 	google.golang.org/grpc v1.67.0
-	gopkg.in/errgo.v2 v2.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/src/autoscaler/go.sum
+++ b/src/autoscaler/go.sum
@@ -1719,7 +1719,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=


### PR DESCRIPTION
# Issue

During a previous PR an outdated library was unintentionally referenced,
when the standard libray already provides the functionality.

# Fix

Remove the usage of the library and use the standard library's
functionality.
