### PR TITLE
Use postgres IP instead of TCP route when deploying apps

### DIFF
--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -112,6 +112,7 @@ function create_manifest(){
       -v skip_ssl_validation=true \
       > "${tmp_manifest_file}"
 
+
     # shellcheck disable=SC2064
   if [ -z "${debug}" ] || [ "${debug}" = "false" ] ; then  trap "rm ${tmp_manifest_file}" EXIT ; fi
 }
@@ -142,6 +143,9 @@ function deploy() {
   step "Using Ops files: '${OPS_FILES_TO_USE}'"
   step "Deploy options: '${bosh_deploy_opts}'"
   bosh -n -d "${deployment_name}" deploy "${tmp_manifest_file}"
+	postgres_ip="$(bosh curl "/deployments/${deployment_name}/vms" | jq '. | .[] | select(.job == "postgres") | .ips[0]' -r)"
+	credhub set -n "/bosh-autoscaler/${deployment_name}/postgres_ip" -t value -v "${postgres_ip}"
+
 }
 
 function find_or_upload_stemcell() {

--- a/operations/use-cf-services.yml
+++ b/operations/use-cf-services.yml
@@ -30,7 +30,7 @@
           oauth_url: "https://uaa.((system_domain)):443"
         routes:
           - name: ((deployment_name))_postgres
-            registration_interval: 10s
+            registration_interval: 5s
             port: 5432
             external_port: ((postgres_external_port))
             type: tcp

--- a/src/autoscaler/metricsforwarder/security-group.json
+++ b/src/autoscaler/metricsforwarder/security-group.json
@@ -4,5 +4,11 @@
        "destination": "10.0.1.0/24",
        "ports": "6067",
        "description": "Allow syslog traffic from"
+     },
+     {
+       "protocol": "tcp",
+       "destination": "10.0.1.0/24",
+       "ports": "5432",
+       "description": "Allow postgres traffic from"
      }
    ]


### PR DESCRIPTION
This pull request includes several changes to the autoscaler deployment scripts and configuration files to enhance the handling of the PostgreSQL connection which produces flaky tests when running acceptance test.
Enhancements to deployment scripts:

* [`ci/autoscaler/scripts/deploy-autoscaler.sh`](diffhunk://#diff-eb92f3568762003dbdddd247a28376d37d1d2177c1cc1f106180a0d8c0f92711R146-R148): Updated the `deploy` function to retrieve the PostgreSQL IP address and set it in CredHub.

Improvements to extension file handling:

* [`src/autoscaler/build-extension-file.sh`](diffhunk://#diff-8e3987a2578d4a70ff3e420127a452231d5f76e322f6baaadecd612a97932247L19-R22): Added the PostgreSQL IP to the extension file template and adjusted the URI generation to use the PostgreSQL IP if available. [[1]](diffhunk://#diff-8e3987a2578d4a70ff3e420127a452231d5f76e322f6baaadecd612a97932247L19-R22) [[2]](diffhunk://#diff-8e3987a2578d4a70ff3e420127a452231d5f76e322f6baaadecd612a97932247R38-R39) [[3]](diffhunk://#diff-8e3987a2578d4a70ff3e420127a452231d5f76e322f6baaadecd612a97932247R49-R55) [[4]](diffhunk://#diff-8e3987a2578d4a70ff3e420127a452231d5f76e322f6baaadecd612a97932247L73-R82)

Configuration adjustments:

* [`operations/use-cf-services.yml`](diffhunk://#diff-7de07f23104f654ccb6193af92a6818baf1188548760714131937c656ee7d9e4L33-R33): Changed the registration interval for the PostgreSQL service from 10s to 5s.
* [`src/autoscaler/metricsforwarder/security-group.json`](diffhunk://#diff-b903dedfc6520cfdfb06b11f3d00fb7104d81b2ab10e131ecb84dab511c98569R7-R12): Added a new rule to allow PostgreSQL traffic on port 5432.

Minor cleanup:

* [`ci/autoscaler/scripts/deploy-autoscaler.sh`](diffhunk://#diff-eb92f3568762003dbdddd247a28376d37d1d2177c1cc1f106180a0d8c0f92711R115): Added a blank line for better readability.
