### PR TITLE
Adds acceptance-log-cache-syslog-cf job as dependenct to release autoscaler

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -452,6 +452,7 @@ jobs:
       passed:
       - acceptance-log-cache-metron
       - acceptance-log-cache-syslog
+      - acceptance-log-cache-syslog-cf
       trigger: true
     - get: previous-stable-release
   - task: deploy-previous-stable-release


### PR DESCRIPTION
This pull request includes a small change to the `ci/autoscaler/pipeline.yml` file. The change adds a new job to the list of passed jobs in the pipeline configuration.

* [`ci/autoscaler/pipeline.yml`](diffhunk://#diff-10ff83017bf5f3630e6c372c3aa8dc981a23f71cdc48c725cd17509d8d757a03R455): Added `acceptance-log-cache-syslog-cf` to the list of passed jobs.