### PR TITLE
fix-> remove contrainst not null

### DIFF
--- a/src/autoscaler/api/db/servicebroker.db.changelog.yaml
+++ b/src/autoscaler/api/db/servicebroker.db.changelog.yaml
@@ -132,8 +132,6 @@ databaseChangeLog:
               - column:
                   name: custom_metrics_strategy
                   type: varchar(40)
-                  constraints:
-                    nullable: false
   - changeSet:
       id: 6
       author: Arsalan

--- a/templates/app-autoscaler.yml
+++ b/templates/app-autoscaler.yml
@@ -479,8 +479,9 @@ instance_groups:
     properties:
       autoscaler:
         policy_db: *database
-        binding_db: *database
         policy_db_connection_config: *databaseConnectionConfig
+        binding_db: *database
+        binding_db_connection_config: *databaseConnectionConfig
         metricsforwarder:
           health:
             port: &metricsforwarderHealthPort 6403


### PR DESCRIPTION
```
 Starting Liquibase at 17:44:58 using Java 21.0.5 (version 4.29.2 #3683 built at 2024-08-29 16:45+0000)
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | Running Changeset: var/vcap/packages/golangapiserver/servicebroker.db.changelog.yaml::5::Arsalan
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout |
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | UPDATE SUMMARY
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | Run:                          0
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | Previously run:               4
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | Filtered out:                 0
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | -------------------------------
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | Total change sets:            7
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout |
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | ERROR: Exception Details
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | ERROR: Exception Primary Class:  PSQLException
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | ERROR: Exception Primary Reason:  ERROR: column "custom_metrics_strategy" of relation "binding" contains null values
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | ERROR: Exception Primary Source:  PostgreSQL 15.7
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout | Unexpected error running Liquibase: liquibase.exception.MigrationFailedException: Migration failed for changeset var/vcap/packages/golangapiserver/servicebroker.db.changelog.yaml::5::Arsalan:
apiserver/bd8aa6fb-3e0f-4d22-b9a6-df96ff7a62b2: stdout |      Reason: liquibase.exception.DatabaseException: ERROR: co
```