### PR TITLE
Adding binding_db to external-db.yml ops file

### DIFF
--- a/operations/external-db.yml
+++ b/operations/external-db.yml
@@ -129,3 +129,10 @@
 - type: replace
   path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/storedprocedure_db_connection_config?
   value: *databaseConnectionConfig
+
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/binding_db
+  value: *external_database
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/binding_db_connection_config?
+  value: *databaseConnectionConfig


### PR DESCRIPTION
The v14.4.0 release of autoscaler introduces a db named `binding_db`, if you are using an external db, like RDS, and the ops file in `operations/external-db.yml` the templating errors out during deployment with:

```
Task 628502 | 15:28:11 | Error: Unable to render instance groups for deployment. Errors are:
  - Unable to render jobs for instance group 'metricsforwarder'. Errors are:
    - Unable to render templates for job 'metricsforwarder'. Errors are:
      - Error filling in template 'metricsforwarder.yml.erb' (line 9: Can't find property '["autoscaler.binding_db.port"]')
```

By adding `binding_db` to the `external-db.yml` ops file, there is no longer a bosh templating error when not using the built in postgres instance.