### PR TITLE
Fix(Broker): Return the Same Instance Binding Parameters As Given In Binding Process

### DIFF
--- a/src/acceptance/broker/broker_test.go
+++ b/src/acceptance/broker/broker_test.go
@@ -107,13 +107,6 @@ var _ = Describe("AutoScaler Service Broker", func() {
 			instance.unbind(appName)
 		})
 
-		It("bind&unbinds without policy", func() {
-			helpers.BindServiceToApp(cfg, appName, instance.name())
-			bindingParameters := helpers.GetServiceCredentialBindingParameters(cfg, instance.name(), appName)
-			Expect(bindingParameters).Should(MatchJSON("{}"))
-			instance.unbind(appName)
-		})
-
 		It("binds&unbinds with policy having credential-type as x509", func() {
 			policyFile := "../assets/file/policy/policy-with-credential-type.json"
 			_, err := os.ReadFile(policyFile)
@@ -132,6 +125,13 @@ var _ = Describe("AutoScaler Service Broker", func() {
 			Expect(appEnvCmdOutput).NotTo(ContainSubstring("\"url\": \"https://"))
 			Expect(appEnvCmdOutput).To(ContainSubstring("\"mtls_url\": \"https://"))
 
+			instance.unbind(appName)
+		})
+
+		It("bind&unbinds without policy", func() {
+			helpers.BindServiceToApp(cfg, appName, instance.name())
+			bindingParameters := helpers.GetServiceCredentialBindingParameters(cfg, instance.name(), appName)
+			Expect(bindingParameters).Should(MatchJSON("{}"))
 			instance.unbind(appName)
 		})
 

--- a/src/acceptance/broker/broker_test.go
+++ b/src/acceptance/broker/broker_test.go
@@ -95,28 +95,22 @@ var _ = Describe("AutoScaler Service Broker", func() {
 
 		It("binds&unbinds with policy", func() {
 			policyFile := "../assets/file/policy/all.json"
-
-			err := helpers.BindServiceToAppWithPolicy(cfg, appName, instance.name(), policyFile)
-			Expect(err).NotTo(HaveOccurred())
-			expectedPolicyFile := "../assets/file/policy/policy-with-configuration-same-app.json"
-			expectedPolicyWithConfig, err := os.ReadFile(expectedPolicyFile)
-			Expect(err).NotTo(HaveOccurred())
-			bindingParameters := helpers.GetServiceCredentialBindingParameters(cfg, instance.name(), appName)
-			Expect(bindingParameters).Should(MatchJSON(expectedPolicyWithConfig))
-
-			instance.unbind(appName)
-		})
-		It("binds&unbinds with configurations and policy", func() {
-			policyFile := "../assets/file/policy/policy-with-configuration.json"
 			policy, err := os.ReadFile(policyFile)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = helpers.BindServiceToAppWithPolicy(cfg, appName, instance.name(), policyFile)
 			Expect(err).NotTo(HaveOccurred())
-			By("checking broker bind parameter response should have policy and configuration")
+
 			bindingParameters := helpers.GetServiceCredentialBindingParameters(cfg, instance.name(), appName)
 			Expect(bindingParameters).Should(MatchJSON(policy))
 
+			instance.unbind(appName)
+		})
+
+		It("bind&unbinds without policy", func() {
+			helpers.BindServiceToApp(cfg, appName, instance.name())
+			bindingParameters := helpers.GetServiceCredentialBindingParameters(cfg, instance.name(), appName)
+			Expect(bindingParameters).Should(MatchJSON("{}"))
 			instance.unbind(appName)
 		})
 
@@ -141,21 +135,17 @@ var _ = Describe("AutoScaler Service Broker", func() {
 			instance.unbind(appName)
 		})
 
-		It("bind&unbinds without policy and gives only configuration", func() {
-			helpers.BindServiceToApp(cfg, appName, instance.name())
-			By("checking broker bind parameter response does not have policy but configuration only")
-			bindingParameters := helpers.GetServiceCredentialBindingParameters(cfg, instance.name(), appName)
-			expectedJSON := `{
-							"configuration": {
-							  "custom_metrics": {
-								"metric_submission_strategy": {
-								  "allow_from": "same_app"
-								}
-							  }
-							}
-						  }`
+		It("binds&unbinds with configurations and policy", func() {
+			policyFile := "../assets/file/policy/policy-with-configuration.json"
+			policyWithConfig, err := os.ReadFile(policyFile)
+			Expect(err).NotTo(HaveOccurred())
 
-			Expect(bindingParameters).Should(MatchJSON(expectedJSON))
+			err = helpers.BindServiceToAppWithPolicy(cfg, appName, instance.name(), policyFile)
+			Expect(err).NotTo(HaveOccurred())
+			By("checking broker bind parameter response should have policy and configuration")
+			bindingParameters := helpers.GetServiceCredentialBindingParameters(cfg, instance.name(), appName)
+			Expect(bindingParameters).Should(MatchJSON(policyWithConfig))
+
 			instance.unbind(appName)
 		})
 
@@ -167,7 +157,7 @@ var _ = Describe("AutoScaler Service Broker", func() {
 	Describe("allows setting default policies", func() {
 		var instance serviceInstance
 		var defaultPolicy []byte
-		var expectedDefaultPolicyWithConfigsJSON []byte
+		var policy []byte
 
 		BeforeEach(func() {
 			instance = createServiceWithParameters(cfg.ServicePlan, "../assets/file/policy/default_policy.json")
@@ -183,13 +173,7 @@ var _ = Describe("AutoScaler Service Broker", func() {
 			err = json.Unmarshal(defaultPolicy, &serviceParameters)
 			Expect(err).NotTo(HaveOccurred())
 
-			expectedDefaultPolicyWithConfigsJSON, err = os.ReadFile("../assets/file/policy/default_policy-with-configuration.json")
-			Expect(err).NotTo(HaveOccurred())
-			var serviceParametersWithConfigs = struct {
-				Configuration interface{} `json:"configuration"`
-				DefaultPolicy interface{} `json:"default_policy"`
-			}{}
-			err = json.Unmarshal(expectedDefaultPolicyWithConfigsJSON, &serviceParametersWithConfigs)
+			policy, err = json.Marshal(serviceParameters.DefaultPolicy)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -200,9 +184,9 @@ var _ = Describe("AutoScaler Service Broker", func() {
 
 		It("sets the default policy if no policy is set during binding and allows retrieving the policy via the binding parameters", func() {
 			helpers.BindServiceToApp(cfg, appName, instance.name())
-			By("checking broker bind parameter response should have default policy and configuration")
+			By("checking broker bind parameter response should have default policy")
 			bindingParameters := helpers.GetServiceCredentialBindingParameters(cfg, instance.name(), appName)
-			Expect(bindingParameters).Should(MatchJSON(expectedDefaultPolicyWithConfigsJSON))
+			Expect(bindingParameters).Should(MatchJSON(policy))
 
 			unbindService := cf.Cf("unbind-service", appName, instance.name()).Wait(cfg.DefaultTimeoutDuration())
 			Expect(unbindService).To(Exit(0), "failed unbinding service from app")
@@ -222,7 +206,6 @@ var _ = Describe("AutoScaler Service Broker", func() {
 		var instance serviceInstance
 		It("should update a service instance from one plan to another plan", func() {
 			servicePlans := GetServicePlans(cfg)
-			fmt.Println("servicePlans", servicePlans)
 			source, target, err := servicePlans.getSourceAndTargetForPlanUpdate()
 			Expect(err).NotTo(HaveOccurred(), "failed getting source and target service plans")
 			instance = createService(source.Name)

--- a/src/autoscaler/api/brokerserver/broker_handler_test.go
+++ b/src/autoscaler/api/brokerserver/broker_handler_test.go
@@ -923,9 +923,129 @@ var _ = Describe("BrokerHandler", func() {
 				verifyCredentialsGenerated(resp)
 			})
 		})
-		When("Binding configurations and policy are present", func() {
-			BeforeEach(func() {
-				bindingPolicy = `{
+		Context("Binding configurations", func() {
+			When("invalid custom strategy provided in the binding parameters", func() {
+				BeforeEach(func() {
+					bindingPolicy = `{
+				  "configuration": {
+					"custom_metrics": {
+					  "metric_submission_strategy": {
+						"allow_from": "same_app"
+					  }
+					}
+				  },
+				  "instance_max_count":4,
+				  "instance_min_count":1,
+				  "schedules": {
+					"timezone": "Asia/Shanghai",
+					"recurring_schedule": [{
+					  "start_time": "10:00",
+					  "end_time": "18:00",
+					  "days_of_week": [
+						1,
+						2,
+						3
+					  ],
+					  "instance_min_count": 1,
+					  "instance_max_count": 10,
+					  "initial_min_instance_count": 5
+					}]
+				  },
+				  "scaling_rules":[
+					{
+					  "metric_type":"memoryused",
+					  "threshold":30,
+					  "operator":"<",
+					  "adjustment":"-1"
+					}]
+				}`
+					bindingRequestBody.Policy = json.RawMessage(bindingPolicy)
+					body, err = json.Marshal(bindingRequestBody)
+					Expect(err).NotTo(HaveOccurred())
+					bindingPolicy = `{
+				  "instance_max_count":4,
+				  "instance_min_count":1,
+				  "schedules": {
+					"timezone": "Asia/Shanghai",
+					"recurring_schedule": [{
+					  "start_time": "10:00",
+					  "end_time": "18:00",
+					  "days_of_week": [
+						1,
+						2,
+						3
+					  ],
+					  "instance_min_count": 1,
+					  "instance_max_count": 10,
+					  "initial_min_instance_count": 5
+					}]
+				  },
+				  "scaling_rules":[
+					{
+					  "metric_type":"memoryused",
+					  "threshold":30,
+					  "operator":"<",
+					  "adjustment":"-1"
+					}]
+				}`
+					verifyScheduleIsUpdatedInScheduler(testAppId, bindingPolicy)
+				})
+				It("should fail with 400", func() {
+					Expect(resp.Code).To(Equal(http.StatusBadRequest))
+					Expect(resp.Body.String()).To(MatchJSON(`{"error": "verify-custom-metrics-strategy", "description": "error: custom metrics strategy not supported"}`))
+
+				})
+			})
+			When("are empty", func() {
+				BeforeEach(func() {
+					bindingPolicy = `{
+				  "instance_max_count":4,
+				  "instance_min_count":1,
+				  "schedules": {
+					"timezone": "Asia/Shanghai",
+					"recurring_schedule": [{
+					  "start_time": "10:00",
+					  "end_time": "18:00",
+					  "days_of_week": [
+						1,
+						2,
+						3
+					  ],
+					  "instance_min_count": 1,
+					  "instance_max_count": 10,
+					  "initial_min_instance_count": 5
+					}]
+				  },
+				  "scaling_rules":[
+					{
+					  "metric_type":"memoryused",
+					  "threshold":30,
+					  "operator":"<",
+					  "adjustment":"-1"
+					}]
+				}`
+					bindingRequestBody.Policy = json.RawMessage(bindingPolicy)
+					body, err = json.Marshal(bindingRequestBody)
+					Expect(err).NotTo(HaveOccurred())
+
+					verifyScheduleIsUpdatedInScheduler(testAppId, bindingPolicy)
+				})
+				It("set the default custom metrics strategy", func() {
+					_, _, _, _, customMetricsStrategy := bindingdb.CreateServiceBindingArgsForCall(0)
+					Expect(customMetricsStrategy).To(Equal(models.CustomMetricsSameApp))
+
+				})
+				It("succeeds with 201", func() {
+					Expect(resp.Code).To(Equal(http.StatusCreated))
+					By("updating the scheduler")
+					Expect(schedulerServer.ReceivedRequests()).To(HaveLen(1))
+					Expect(bindingdb.CreateServiceBindingCallCount()).To(Equal(1))
+					verifyCredentialsGenerated(resp)
+				})
+			})
+			When("policy and binding configuration are present", func() {
+				BeforeEach(func() {
+					bindingPolicy = `{
 				  "configuration": {
 					"custom_metrics": {
 					  "auth": {
@@ -961,10 +1081,10 @@ var _ = Describe("BrokerHandler", func() {
 					  "adjustment":"-1"
 					}]
 				}`
-				bindingRequestBody.Policy = json.RawMessage(bindingPolicy)
-				body, err = json.Marshal(bindingRequestBody)
-				Expect(err).NotTo(HaveOccurred())
-				bindingPolicy = `{
+					bindingRequestBody.Policy = json.RawMessage(bindingPolicy)
+					body, err = json.Marshal(bindingRequestBody)
+					Expect(err).NotTo(HaveOccurred())
+					bindingPolicy = `{
 				  "instance_max_count":4,
 				  "instance_min_count":1,
 				  "schedules": {
@@ -990,61 +1110,15 @@ var _ = Describe("BrokerHandler", func() {
 					  "adjustment":"-1"
 					}]
 				}`
-				verifyScheduleIsUpdatedInScheduler(testAppId, bindingPolicy)
-			})
-			It("succeeds with 201", func() {
-				Expect(resp.Code).To(Equal(http.StatusCreated))
-				By("updating the scheduler")
-				Expect(schedulerServer.ReceivedRequests()).To(HaveLen(1))
-				Expect(bindingdb.CreateServiceBindingCallCount()).To(Equal(1))
-				verifyCredentialsGenerated(resp)
-			})
-		})
-		When("Binding configurations are empty", func() {
-			BeforeEach(func() {
-				bindingPolicy = `{
-				  "instance_max_count":4,
-				  "instance_min_count":1,
-				  "schedules": {
-					"timezone": "Asia/Shanghai",
-					"recurring_schedule": [{
-					  "start_time": "10:00",
-					  "end_time": "18:00",
-					  "days_of_week": [
-						1,
-						2,
-						3
-					  ],
-					  "instance_min_count": 1,
-					  "instance_max_count": 10,
-					  "initial_min_instance_count": 5
-					}]
-				  },
-				  "scaling_rules":[
-					{
-					  "metric_type":"memoryused",
-					  "threshold":30,
-					  "operator":"<",
-					  "adjustment":"-1"
-					}]
-				}`
-				bindingRequestBody.Policy = json.RawMessage(bindingPolicy)
-				body, err = json.Marshal(bindingRequestBody)
-				Expect(err).NotTo(HaveOccurred())
-
-				verifyScheduleIsUpdatedInScheduler(testAppId, bindingPolicy)
-			})
-			It("set the default custom metrics strategy", func() {
-				_, _, _, _, customMetricsStrategy := bindingdb.CreateServiceBindingArgsForCall(0)
-				Expect(customMetricsStrategy).To(Equal(models.CustomMetricsSameApp))
-
-			})
-			It("succeeds with 201", func() {
-				Expect(resp.Code).To(Equal(http.StatusCreated))
-				By("updating the scheduler")
-				Expect(schedulerServer.ReceivedRequests()).To(HaveLen(1))
-				Expect(bindingdb.CreateServiceBindingCallCount()).To(Equal(1))
-				verifyCredentialsGenerated(resp)
+					verifyScheduleIsUpdatedInScheduler(testAppId, bindingPolicy)
+				})
+				It("succeeds with 201", func() {
+					Expect(resp.Code).To(Equal(http.StatusCreated))
+					By("updating the scheduler")
+					Expect(schedulerServer.ReceivedRequests()).To(HaveLen(1))
+					Expect(bindingdb.CreateServiceBindingCallCount()).To(Equal(1))
+					verifyCredentialsGenerated(resp)
+				})
 			})
 		})
 

--- a/src/autoscaler/models/binding_configs.go
+++ b/src/autoscaler/models/binding_configs.go
@@ -17,7 +17,8 @@ package models
 
 const (
 	CustomMetricsBoundApp = "bound_app"
-	CustomMetricsSameApp  = "same_app"
+	// CustomMetricsSameApp default value if not specified
+	CustomMetricsSameApp = "same_app"
 )
 
 type BindingConfig struct {


### PR DESCRIPTION
**Problem**

The behavior of instance binding parameters was altered in [PR#3211](https://github.com/cloudfoundry/app-autoscaler-release/pull/3211). Specifically, the binding configuration object was always included, even when the binding was created with a policy instead of the configuration object.

**Fix**

Restore the previous behavior in the acceptance test. The endpoint `GET /v3/service_credential_bindings/:guid/parameters `should return the exact parameters that were provided during the binding process.