### PR TITLE
Adding binding_db to external-db.yml ops file

### DIFF
--- a/operations/external-db.yml
+++ b/operations/external-db.yml
@@ -129,3 +129,10 @@
 - type: replace
   path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/storedprocedure_db_connection_config?
   value: *databaseConnectionConfig
+
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/binding_db
+  value: *external_database
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/binding_db_connection_config?
+  value: *databaseConnectionConfig


### PR DESCRIPTION
Adding binding_db to external-db.yml ops file

(Change cherry-picked from https://github.com/cloudfoundry/app-autoscaler-release/pull/3302/commits/8f8f5b80939e6a2cad1004fb7541ac62711d57b8)