### PR TITLE
fix(apiserver) Handle NPE for Custom Metrics Strategy

### DIFF
--- a/src/autoscaler/api/broker/broker_test.go
+++ b/src/autoscaler/api/broker/broker_test.go
@@ -228,5 +228,4 @@ var _ = Describe("Broker", func() {
 			})
 		})
 	})
-
 })

--- a/src/autoscaler/db/sqldb/sqldb_suite_test.go
+++ b/src/autoscaler/db/sqldb/sqldb_suite_test.go
@@ -127,6 +127,16 @@ func hasServiceBindingWithCustomMetricStrategy(bindingId string, serviceInstance
 	return item
 }
 
+func hasServiceBindingWithCustomMetricStrategyIsNull(bindingId string, serviceInstanceId string) bool {
+	query := dbHelper.Rebind("SELECT * FROM binding WHERE binding_id = ? AND service_instance_id = ? AND custom_metrics_strategy is NULL")
+	rows, e := dbHelper.Query(query, bindingId, serviceInstanceId)
+	FailOnError("can not query table binding", e)
+	defer func() { _ = rows.Close() }()
+	item := rows.Next()
+	FailOnError("can not query table binding", rows.Err())
+	return item
+}
+
 func cleanPolicyTable() {
 	_, e := dbHelper.Exec("DELETE from policy_json")
 	if e != nil {


### PR DESCRIPTION
**Problem**

The apiserver throws type conversion error if the custom metric strategy is defined as null or empty in the existing binding table.


**FIX**

Allow empty/null values for custom metrics strategy in the binding.