### PR TITLE
Fix(database) Add missing binding db connection details for mysql database

### DIFF
--- a/operations/cf-mysql-db.yml
+++ b/operations/cf-mysql-db.yml
@@ -125,7 +125,12 @@
 - type: replace
   path: /instance_groups/name=asapi/jobs/name=metricsforwarder/properties/autoscaler/policy_db_connection_config
   value: *databaseConnectionConfig
-
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=metricsforwarder/properties/autoscaler/binding_db
+  value: *external_database
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=metricsforwarder/properties/autoscaler/binding_db_connection_config
+  value: *databaseConnectionConfig
 
 
 


### PR DESCRIPTION
This PR add binding database connection info for mySQL database via the operation files. The database is used in the metricsForwarder component