### PR TITLE
(feat) Add XFCC authenticated scaling engine endpoint

### DIFF
--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -1,65 +1,55 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2086,SC2034,SC2155
 set -euo pipefail
 
-script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 source "${script_dir}/vars.source.sh"
+source "${script_dir}/common.sh"
 
 deployment_manifest="${autoscaler_dir}/templates/app-autoscaler.yml"
 bosh_deploy_opts="${BOSH_DEPLOY_OPTS:-""}"
+BOSH_DEPLOY_VARS="${BOSH_DEPLOY_VARS:-""}"
 bosh_upload_release_opts="${BOSH_UPLOAD_RELEASE_OPTS:-""}"
 bosh_upload_stemcell_opts="${BOSH_UPLOAD_STEMCELL_OPTS:-""}"
-ops_files=${OPS_FILES:-"${autoscaler_dir}/operations/add-releases.yml\
-  ${autoscaler_dir}/operations/instance-identity-cert-from-cf.yml\
-  ${autoscaler_dir}/operations/add-postgres-variables.yml\
-  ${autoscaler_dir}/operations/connect_to_postgres_with_certs.yml\
-  ${autoscaler_dir}/operations/enable-nats-tls.yml\
-  ${autoscaler_dir}/operations/add-extra-plan.yml\
-  ${autoscaler_dir}/operations/set-release-version.yml\
-  ${autoscaler_dir}/operations/enable-metricsforwarder-via-syslog-agent.yml\
-  ${autoscaler_dir}/operations/enable-scheduler-logging.yml"}
 
-
-## if mtar_deployment_enabled, then apply the use-cf operator file
-if [[  "${enable_mtar}"  == "true" ]]; then
-  echo "Deploying with mtar enabled"
-  ops_files+=" ${autoscaler_dir}/operations/use-cf-services.yml"
-fi
+ops_files=${OPS_FILES:-$(cat <<EOF
+${autoscaler_dir}/operations/add-releases.yml
+${autoscaler_dir}/operations/instance-identity-cert-from-cf.yml
+${autoscaler_dir}/operations/add-postgres-variables.yml
+${autoscaler_dir}/operations/connect_to_postgres_with_certs.yml
+${autoscaler_dir}/operations/enable-nats-tls.yml
+${autoscaler_dir}/operations/add-extra-plan.yml
+${autoscaler_dir}/operations/set-release-version.yml
+${autoscaler_dir}/operations/enable-metricsforwarder-via-syslog-agent.yml
+${autoscaler_dir}/operations/enable-scheduler-logging.yml
+EOF
+)}
 
 case "${cpu_upper_threshold}" in
-  "100")
-  # default
-  ;;
-  "200")
-  ops_files+=" ${autoscaler_dir}/operations/cpu_upper_threshold_200.yml"
-  ;;
-  "400")
-  ops_files+=" ${autoscaler_dir}/operations/cpu_upper_threshold_400.yml"
-  ;;
-  *)
-  echo "No Ops file for cpu_upper_threshold of ${cpu_upper_threshold}"
-  exit 1
-  ;;
+  "100") ;;
+  "200") ops_files+=" ${autoscaler_dir}/operations/cpu_upper_threshold_200.yml" ;;
+  "400") ops_files+=" ${autoscaler_dir}/operations/cpu_upper_threshold_400.yml" ;;
+  *) echo "No Ops file for cpu_upper_threshold of ${cpu_upper_threshold}"; exit 1 ;;
 esac
 
 CURRENT_COMMIT_HASH=$(cd "${autoscaler_dir}"; git log -1 --pretty=format:"%H")
 bosh_release_version=${RELEASE_VERSION:-${CURRENT_COMMIT_HASH}-${deployment_name}}
 
 pushd "${bbl_state_path}" > /dev/null
-  eval "$(bbl print-env)"
+eval "$(bbl print-env)"
 popd > /dev/null
 
-function setup_autoscaler_uaac(){
+function setup_autoscaler_uaac() {
   local uaac_authorities="cloud_controller.read,cloud_controller.admin,uaa.resource,routing.routes.write,routing.routes.read,routing.router_groups.read"
   local autoscaler_secret="autoscaler_client_secret"
   local uaa_client_secret=$(credhub get -n /bosh-autoscaler/cf/uaa_admin_client_secret --quiet)
+
   uaac target "https://uaa.${system_domain}" --skip-ssl-validation > /dev/null
   uaac token client get admin -s "${uaa_client_secret}" > /dev/null
 
   if uaac client get autoscaler_client_id >/dev/null; then
     step "updating autoscaler uaac client"
-    uaac client update "autoscaler_client_id" \
-      --authorities "$uaac_authorities" > /dev/null
+    uaac client update "autoscaler_client_id" --authorities "$uaac_authorities" > /dev/null
   else
     step "creating autoscaler uaac client"
     uaac client add "autoscaler_client_id" \
@@ -68,59 +58,58 @@ function setup_autoscaler_uaac(){
       --secret "$autoscaler_secret" > /dev/null
   fi
 }
-function get_postgres_external_port(){
-	if [ -z "${PR_NUMBER}" ]; then
-		echo "5432"
-	else
-		echo "${PR_NUMBER}"
-	fi
+
+function get_postgres_external_port() {
+  [[ -z "${PR_NUMBER}" ]] && echo "5432" || echo "${PR_NUMBER}"
 }
 
-function create_manifest(){
-  # Set the local tmp_dir depending on if we run on github-actions or not, see:
-  # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+function create_manifest() {
   local tmp_dir
-  local perform_as_gh_action
+  local perform_as_gh_action="${GITHUB_ACTIONS:-false}"
 
-  perform_as_gh_action="${GITHUB_ACTIONS:-false}"
-  if "${perform_as_gh_action}" != 'false'
-  then
+  if "${perform_as_gh_action}" != 'false'; then
     tmp_dir="${RUNNER_TEMP}"
-  else # local system
+  else
     tmp_dir="$(pwd)/dev_releases"
     mkdir -p "${tmp_dir}"
   fi
 
-  # on MacOS mktemp does not know the --tmpdir option
   tmp_manifest_file="$(mktemp "${tmp_dir}/${deployment_name}.bosh-manifest.yaml.XXX")"
-
-
   credhub interpolate -f "${autoscaler_dir}/ci/autoscaler/scripts/autoscaler-secrets.yml.tpl" > /tmp/autoscaler-secrets.yml
 
-  bosh -n -d "${deployment_name}" \
-      interpolate "${deployment_manifest}" \
-      ${OPS_FILES_TO_USE} \
-      ${bosh_deploy_opts} \
-      -v system_domain="${system_domain}" \
-      -v deployment_name="${deployment_name}" \
-      -v app_autoscaler_version="${bosh_release_version}" \
-      -v cf_client_id=autoscaler_client_id \
-      -v cf_client_secret=autoscaler_client_secret \
-      -v postgres_external_port="$(get_postgres_external_port)"\
-			--vars-file=/tmp/autoscaler-secrets.yml \
-      -v skip_ssl_validation=true \
-      > "${tmp_manifest_file}"
+	add_variable "deployment_name" "${deployment_name}"
+	add_variable "system_domain" "${system_domain}"
+	add_variable "app_autoscaler_version" "${bosh_release_version}"
+	add_variable "cf_client_id" "autoscaler_client_id"
+	add_variable "cf_client_secret" "autoscaler_client_secret"
+	add_variable "postgres_external_port" "$(get_postgres_external_port)"
 
 
+	bosh_deploy_vars=""
+
+	# add deployment name
+  bosh -n -d "${deployment_name}" interpolate "${deployment_manifest}" ${OPS_FILES_TO_USE} \
+    ${bosh_deploy_opts} ${BOSH_DEPLOY_VARS} \
+    --vars-file=/tmp/autoscaler-secrets.yml -v skip_ssl_validation=true > "${tmp_manifest_file}"
+
+  if [[ -z "${debug}" || "${debug}" = "false" ]]; then
     # shellcheck disable=SC2064
-  if [ -z "${debug}" ] || [ "${debug}" = "false" ] ; then  trap "rm ${tmp_manifest_file}" EXIT ; fi
+    trap "rm ${tmp_manifest_file}" EXIT
+  fi
 }
 
-function check_ops_files(){
+add_variable() {
+	local variable_name=$1
+	local variable_value=$2
+	BOSH_DEPLOY_VARS="${BOSH_DEPLOY_VARS} -v ${variable_name}=${variable_value}"
+}
+
+function check_ops_files() {
   step "Using Ops files: '${ops_files}'"
+
   OPS_FILES_TO_USE=""
   for OPS_FILE in ${ops_files}; do
-    if [ -f "${OPS_FILE}" ]; then
+    if [[ -f "${OPS_FILE}" ]]; then
       OPS_FILES_TO_USE="${OPS_FILES_TO_USE} -o ${OPS_FILE}"
     else
       echo "ERROR: could not find ops file ${OPS_FILE} in ${PWD}"
@@ -130,34 +119,25 @@ function check_ops_files(){
 }
 
 function deploy() {
-  # Try to silence Prometheus but do not fail deployment if there's an error
-# ${script_dir}/silence_prometheus_alert.sh "BOSHJobEphemeralDiskPredictWillFill" || true
-#  ${script_dir}/silence_prometheus_alert.sh "BOSHJobProcessUnhealthy" || true
-#  ${script_dir}/silence_prometheus_alert.sh "BOSHJobUnhealthy" || true
-
   create_manifest
-
-  log "creating Bosh deployment '${deployment_name}' with version '${bosh_release_version}' in system domain '${system_domain}'   "
+  log "creating Bosh deployment '${deployment_name}' with version '${bosh_release_version}' in system domain '${system_domain}'"
   debug "tmp_manifest_file=${tmp_manifest_file}"
   step "Using Ops files: '${OPS_FILES_TO_USE}'"
   step "Deploy options: '${bosh_deploy_opts}'"
   bosh -n -d "${deployment_name}" deploy "${tmp_manifest_file}"
-	postgres_ip="$(bosh curl "/deployments/${deployment_name}/vms" | jq '. | .[] | select(.job == "postgres") | .ips[0]' -r)"
-	credhub set -n "/bosh-autoscaler/${deployment_name}/postgres_ip" -t value -v "${postgres_ip}"
-
+  postgres_ip="$(bosh curl "/deployments/${deployment_name}/vms" | jq '. | .[] | select(.job == "postgres") | .ips[0]' -r)"
+  credhub set -n "/bosh-autoscaler/${deployment_name}/postgres_ip" -t value -v "${postgres_ip}"
 }
 
 function find_or_upload_stemcell() {
-  # Determine if we need to upload a stemcell at this point.
-  stemcell_os=$(yq eval '.stemcells[] | select(.alias == "default").os' ${deployment_manifest})
-  stemcell_version=$(yq eval '.stemcells[] | select(.alias == "default").version' ${deployment_manifest})
+  local stemcell_os stemcell_version stemcell_name
+  stemcell_os=$(yq eval '.stemcells[] | select(.alias == "default").os' "${deployment_manifest}")
+  stemcell_version=$(yq eval '.stemcells[] | select(.alias == "default").version' "${deployment_manifest}")
   stemcell_name="bosh-google-kvm-${stemcell_os}-go_agent"
 
   if ! bosh stemcells | grep "${stemcell_name}" >/dev/null; then
-    URL="https://bosh.io/d/stemcells/${stemcell_name}"
-    if [ "${stemcell_version}" != "latest" ]; then
-      URL="${URL}?v=${stemcell_version}"
-    fi
+    local URL="https://bosh.io/d/stemcells/${stemcell_name}"
+    [[ "${stemcell_version}" != "latest" ]] && URL="${URL}?v=${stemcell_version}"
     wget "${URL}" -O stemcell.tgz
     bosh -n upload-stemcell $bosh_upload_stemcell_opts stemcell.tgz
   fi
@@ -165,10 +145,8 @@ function find_or_upload_stemcell() {
 
 function find_or_upload_release() {
   if ! bosh releases | grep -E "${bosh_release_version}[*]*\s" > /dev/null; then
-
-    local -r release_desc_file="dev_releases/app-autoscaler/app-autoscaler-${bosh_release_version}.yml"
-    if [ ! -f "${release_desc_file}" ]
-    then
+    local release_desc_file="dev_releases/app-autoscaler/app-autoscaler-${bosh_release_version}.yml"
+    if [[ ! -f "${release_desc_file}" ]]; then
       echo "Creating Release with bosh version ${bosh_release_version}"
       bosh create-release --force --version="${bosh_release_version}"
     else
@@ -185,11 +163,26 @@ function find_or_upload_release() {
   fi
 }
 
-log "Deploying autoscaler '${bosh_release_version}' with name '${deployment_name}' "
+function pre_deploy() {
+	if [[ "${enable_mtar}" == "true" ]]; then
+		ops_files+=" ${autoscaler_dir}/operations/use-cf-services.yml"
+		cf_login
+
+		local autoscaler_cf_server_xfcc_valid_org_guid=$(cf org ${AUTOSCALER_ORG} --guid)
+		local autoscaler_cf_server_xfcc_valid_space_guid=$(cf space ${AUTOSCALER_SPACE} --guid)
+
+		add_variable "autoscaler_cf_server_xfcc_valid_org_guid" "${autoscaler_cf_server_xfcc_valid_org_guid}"
+		add_variable "autoscaler_cf_server_xfcc_valid_space_guid" "${autoscaler_cf_server_xfcc_valid_space_guid}"
+	fi
+}
+
+log "Deploying autoscaler '${bosh_release_version}' with name '${deployment_name}'"
 setup_autoscaler_uaac
 pushd "${autoscaler_dir}" > /dev/null
-  check_ops_files
-  find_or_upload_stemcell
-  find_or_upload_release
-  deploy
+pre_deploy
+check_ops_files
+find_or_upload_stemcell
+find_or_upload_release
+deploy
 popd > /dev/null
+

--- a/jobs/scalingengine/spec
+++ b/jobs/scalingengine/spec
@@ -169,6 +169,17 @@ properties:
   autoscaler.scalingengine.server_key:
     description: "PEM-encoded server key"
 
+  autoscaler.cf_server.port:
+    description: "the listening port of cf xfcc endpoint"
+    default: 8080
+
+  autoscaler.cf_server.xfcc.valid_org_guid:
+    description: approve org guid for xfcc endpoint
+    default: ''
+
+  autoscaler.cf_server.xfcc.valid_space_guid:
+    description: approve space guid for xfcc endpoint
+    default: ''
 
   autoscaler.scalingengine.health.port:
     description: "the listening port of health endpoint"

--- a/jobs/scalingengine/spec
+++ b/jobs/scalingengine/spec
@@ -174,7 +174,7 @@ properties:
     default: 8080
 
   autoscaler.cf_server.xfcc.valid_org_guid:
-    description: approve org guid for xfcc endpoint
+    description: allowed org guid for xfcc endpoint
     default: ''
 
   autoscaler.cf_server.xfcc.valid_space_guid:

--- a/jobs/scalingengine/spec
+++ b/jobs/scalingengine/spec
@@ -178,7 +178,7 @@ properties:
     default: ''
 
   autoscaler.cf_server.xfcc.valid_space_guid:
-    description: approve space guid for xfcc endpoint
+    description: allowed space guid for xfcc endpoint
     default: ''
 
   autoscaler.scalingengine.health.port:

--- a/jobs/scalingengine/templates/scalingengine.yml.erb
+++ b/jobs/scalingengine/templates/scalingengine.yml.erb
@@ -51,6 +51,11 @@ cf:
   idle_connection_timeout_ms: <%= p("autoscaler.cf.idle_connection_timeout_ms") %>
   max_idle_conns_per_host_ms: <%= p("autoscaler.cf.max_idle_conns_per_host_ms") %>
 
+cf_server:
+  port: <%= p("autoscaler.cf_server.port") %>
+  xfcc:
+    valid_org_guid: <%= p("autoscaler.cf_server.xfcc.valid_org_guid") %>
+    valid_space_guid: <%= p("autoscaler.cf_server.xfcc.valid_space_guid") %>
 
 server:
   port:  <%= p("autoscaler.scalingengine.server.port") %>

--- a/operations/use-cf-services.yml
+++ b/operations/use-cf-services.yml
@@ -50,3 +50,30 @@
 
 - type: remove
   path: /instance_groups/name=metricsforwarder
+
+
+## SCALINGENGINE - Enable cf Server to receive calls from api running on cf --
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scalingengine/cf_server?/xfcc?/valid_org_guid?
+  value: ((autoscaler_cf_server_xfcc_valid_org_guid))
+
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scalingengine/cf_server?/xfcc?/valid_space_guid?
+  value: ((autoscaler_cf_server_xfcc_valid_space_guid))
+
+
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scalingengine/cf_server?/port?
+  value: &scalingEngineCfPort 6205
+
+- type: replace
+  path: /instance_groups/name=postgres/jobs/name=route_registrar/properties/route_registrar/routes/-
+  value:
+    name: ((deployment_name))-cf-scalingengine
+    registration_interval: 20s
+    port: *scalingEngineCfPort
+    tags:
+      component: autoscaler_cf_scalingengine
+    uris:
+      - ((deployment_name))-cf-scalingengine.((system_domain))
+

--- a/packages/scalingengine/spec
+++ b/packages/scalingengine/spec
@@ -14,6 +14,7 @@ files:
 - autoscaler/db/sqldb/* # gosub
 - autoscaler/healthendpoint/* # gosub
 - autoscaler/helpers/* # gosub
+- autoscaler/helpers/auth/* # gosub
 - autoscaler/helpers/handlers/* # gosub
 - autoscaler/metricsforwarder/server/common/* # gosub
 - autoscaler/models/* # gosub

--- a/spec/jobs/scalingengine/scalingengine_spec.rb
+++ b/spec/jobs/scalingengine/scalingengine_spec.rb
@@ -39,6 +39,23 @@ describe "scalingengine" do
       end
     end
 
+    context "cf server" do
+      it "includes default port for cf server" do
+        expect(rendered_template["cf_server"]["port"]).to eq(8080)
+      end
+
+      it "defaults xfcc valid org and space " do
+        properties["autoscaler"]["cf_server"] = {}
+        properties["autoscaler"]["cf_server"]["xfcc"] = {
+          "valid_org_guid" => "some-valid-org-guid",
+          "valid_space_guid" => "some-valid-space-guid"
+        }
+
+        expect(rendered_template["cf_server"]["xfcc"]["valid_org_guid"]).to eq(properties["autoscaler"]["cf_server"]["xfcc"]["valid_org_guid"])
+        expect(rendered_template["cf_server"]["xfcc"]["valid_space_guid"]).to eq(properties["autoscaler"]["cf_server"]["xfcc"]["valid_space_guid"])
+      end
+    end
+
     context "uses tls" do
       context "policy_db" do
         it "includes the ca, cert and key in url when configured" do

--- a/src/autoscaler/api/brokerserver/broker_server.go
+++ b/src/autoscaler/api/brokerserver/broker_server.go
@@ -63,7 +63,7 @@ func (am *AuthMiddleware) authenticate(r *http.Request) bool {
 }
 
 type BrokerServer interface {
-	GetServer() (ifrit.Runner, error)
+	CreateServer() (ifrit.Runner, error)
 	GetRouter() (*chi.Mux, error)
 }
 
@@ -89,7 +89,7 @@ func NewBrokerServer(logger lager.Logger, conf *config.Config, bindingDB db.Bind
 	}
 }
 
-func (s *brokerServer) GetServer() (ifrit.Runner, error) {
+func (s *brokerServer) CreateServer() (ifrit.Runner, error) {
 	router, err := s.GetRouter()
 	if err != nil {
 		return nil, err

--- a/src/autoscaler/api/brokerserver/broker_server_suite_test.go
+++ b/src/autoscaler/api/brokerserver/broker_server_suite_test.go
@@ -145,7 +145,7 @@ var _ = BeforeSuite(func() {
 	fakeCredentials := &fakes.FakeCredentials{}
 	httpStatusCollector := &fakes.FakeHTTPStatusCollector{}
 	bs := brokerserver.NewBrokerServer(lager.NewLogger("test"), conf, fakeBindingDB, fakePolicyDB, httpStatusCollector, nil, fakeCredentials)
-	httpServer, err := bs.GetServer()
+	httpServer, err := bs.CreateServer()
 	Expect(err).NotTo(HaveOccurred())
 
 	serverUrl, err = url.Parse("http://localhost:" + strconv.Itoa(port))

--- a/src/autoscaler/api/cmd/api/api_test.go
+++ b/src/autoscaler/api/cmd/api/api_test.go
@@ -25,15 +25,15 @@ var _ = Describe("Api", func() {
 		runner *ApiRunner
 		rsp    *http.Response
 
-		brokerHttpClient        *http.Client
-		healthHttpClient        *http.Client
-		apiHttpClient           *http.Client
-		unifiedServerHttpClient *http.Client
+		brokerHttpClient   *http.Client
+		healthHttpClient   *http.Client
+		apiHttpClient      *http.Client
+		cfServerHttpClient *http.Client
 
-		serverURL        *url.URL
-		brokerURL        *url.URL
-		healthURL        *url.URL
-		unifiedServerURL *url.URL
+		serverURL   *url.URL
+		brokerURL   *url.URL
+		healthURL   *url.URL
+		cfServerURL *url.URL
 
 		vcapPort int
 		err      error
@@ -47,7 +47,7 @@ var _ = Describe("Api", func() {
 		brokerHttpClient = NewServiceBrokerClient()
 		healthHttpClient = &http.Client{}
 		apiHttpClient = NewPublicApiClient()
-		unifiedServerHttpClient = &http.Client{}
+		cfServerHttpClient = &http.Client{}
 
 		serverURL, err = url.Parse(fmt.Sprintf("https://127.0.0.1:%d", cfg.Server.Port))
 		Expect(err).NotTo(HaveOccurred())
@@ -58,7 +58,7 @@ var _ = Describe("Api", func() {
 		healthURL, err = url.Parse(fmt.Sprintf("http://127.0.0.1:%d", cfg.Health.ServerConfig.Port))
 		Expect(err).NotTo(HaveOccurred())
 
-		unifiedServerURL, err = url.Parse(fmt.Sprintf("http://127.0.0.1:%d", vcapPort))
+		cfServerURL, err = url.Parse(fmt.Sprintf("http://127.0.0.1:%d", vcapPort))
 
 	})
 	Describe("Api configuration check", func() {
@@ -212,7 +212,7 @@ var _ = Describe("Api", func() {
 			runner.Interrupt()
 			Eventually(runner.Session, 5).Should(Exit(0))
 		})
-		Context("when a request to query health comes", func() {
+		When("a request to query health comes", func() {
 			It("returns with a 200", func() {
 				rsp, err := healthHttpClient.Get(healthURL.String())
 
@@ -239,7 +239,7 @@ var _ = Describe("Api", func() {
 			runner.Interrupt()
 			Eventually(runner.Session, 5).Should(Exit(0))
 		})
-		Context("when username and password are incorrect for basic authentication during health check", func() {
+		When("username and password are incorrect for basic authentication during health check", func() {
 			It("should return 401", func() {
 
 				req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/health", healthport), nil)
@@ -253,7 +253,7 @@ var _ = Describe("Api", func() {
 			})
 		})
 
-		Context("when username and password are correct for basic authentication during health check", func() {
+		When("username and password are correct for basic authentication during health check", func() {
 			It("should return 200", func() {
 
 				req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/health", healthport), nil)
@@ -279,7 +279,7 @@ var _ = Describe("Api", func() {
 			runner.Interrupt()
 			Eventually(runner.Session, 5).Should(Exit(0))
 		})
-		Context("when a request to query health comes", func() {
+		When("a request to query health comes", func() {
 			It("returns with a 200", func() {
 				serverURL.Path = "/v1/info"
 				req, err := http.NewRequest(http.MethodGet, serverURL.String(), nil)
@@ -296,45 +296,49 @@ var _ = Describe("Api", func() {
 		})
 	})
 
-	When("running in CF", func() {
-		BeforeEach(func() {
-			os.Setenv("VCAP_APPLICATION", "{}")
-			os.Setenv("VCAP_SERVICES", getVcapServices())
-			os.Setenv("PORT", fmt.Sprintf("%d", vcapPort))
-			runner.Start()
+	When("running CF server", func() {
+		XWhen("running in outside cf", func() {})
+		When("running in CF", func() {
+
+			BeforeEach(func() {
+				os.Setenv("VCAP_APPLICATION", "{}")
+				os.Setenv("VCAP_SERVICES", getVcapServices())
+				os.Setenv("PORT", fmt.Sprintf("%d", vcapPort))
+				runner.Start()
+			})
+			AfterEach(func() {
+				runner.Interrupt()
+				Eventually(runner.Session, 5).Should(Exit(0))
+				os.Unsetenv("VCAP_APPLICATION")
+				os.Unsetenv("VCAP_SERVICES")
+				os.Unsetenv("PORT")
+			})
+
+			It("should start a cf server", func() {
+				req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/info", cfServerURL), nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				rsp, err = cfServerHttpClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+
+				bodyBytes, err := io.ReadAll(rsp.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bodyBytes).To(ContainSubstring("Automatically increase or decrease the number of application instances based on a policy you define."))
+
+				req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v2/catalog", cfServerURL), nil)
+				Expect(err).NotTo(HaveOccurred())
+				req.SetBasicAuth(username, password)
+
+				rsp, err = cfServerHttpClient.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rsp.StatusCode).To(Equal(http.StatusOK))
+
+				bodyBytes, err = io.ReadAll(rsp.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bodyBytes).To(ContainSubstring("autoscaler-free-plan-id"))
+			})
+
 		})
-		AfterEach(func() {
-			runner.Interrupt()
-			Eventually(runner.Session, 5).Should(Exit(0))
-			os.Unsetenv("VCAP_APPLICATION")
-			os.Unsetenv("VCAP_SERVICES")
-			os.Unsetenv("PORT")
-		})
-
-		It("should start a unified server", func() {
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/info", unifiedServerURL), nil)
-			Expect(err).NotTo(HaveOccurred())
-
-			rsp, err = unifiedServerHttpClient.Do(req)
-			Expect(err).ToNot(HaveOccurred())
-
-			bodyBytes, err := io.ReadAll(rsp.Body)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(bodyBytes).To(ContainSubstring("Automatically increase or decrease the number of application instances based on a policy you define."))
-
-			req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v2/catalog", unifiedServerURL), nil)
-			Expect(err).NotTo(HaveOccurred())
-			req.SetBasicAuth(username, password)
-
-			rsp, err = unifiedServerHttpClient.Do(req)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(rsp.StatusCode).To(Equal(http.StatusOK))
-
-			bodyBytes, err = io.ReadAll(rsp.Body)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(bodyBytes).To(ContainSubstring("autoscaler-free-plan-id"))
-		})
-
 	})
 
 })

--- a/src/autoscaler/api/cmd/api/main.go
+++ b/src/autoscaler/api/cmd/api/main.go
@@ -94,31 +94,25 @@ func main() {
 		credentialProvider, checkBindingFunc, cfClient, httpStatusCollector,
 		rateLimiter, brokerServer)
 
-	err = publicApiServer.Setup()
-	if err != nil {
-		logger.Error("failed to setup public api server", err)
-		os.Exit(1)
-	}
-
-	mtlsServer, err := publicApiServer.GetMtlsServer()
+	mtlsServer, err := publicApiServer.CreateMtlsServer()
 	if err != nil {
 		logger.Error("failed to create public api http server", err)
 		os.Exit(1)
 	}
 
-	healthServer, err := publicApiServer.GetHealthServer()
+	healthServer, err := publicApiServer.CreateHealthServer()
 	if err != nil {
 		logger.Error("failed to create health http server", err)
 		os.Exit(1)
 	}
 
-	brokerHttpServer, err := brokerServer.GetServer()
+	brokerHttpServer, err := brokerServer.CreateServer()
 	if err != nil {
 		logger.Error("failed to create broker http server", err)
 		os.Exit(1)
 	}
 
-	unifiedServer, err := publicApiServer.GetUnifiedServer()
+	unifiedServer, err := publicApiServer.CreateCFServer()
 	if err != nil {
 		logger.Error("failed to create public api http server", err)
 		os.Exit(1)

--- a/src/autoscaler/api/publicapiserver/public_api_server.go
+++ b/src/autoscaler/api/publicapiserver/public_api_server.go
@@ -102,14 +102,9 @@ func (s *PublicApiServer) CreateCFServer() (ifrit.Runner, error) {
 		return nil, err
 	}
 
-	mainRouter := mux.NewRouter()
 	r := s.autoscalerRouter.GetRouter()
-	mainRouter.PathPrefix("/v2").Handler(r)
-	mainRouter.PathPrefix("/v1").Handler(r)
-	mainRouter.PathPrefix("/health").Handler(r)
-	mainRouter.PathPrefix("/").Handler(s.healthRouter)
 
-	return helpers.NewHTTPServer(s.logger, s.conf.VCAPServer, mainRouter)
+	return helpers.NewHTTPServer(s.logger, s.conf.VCAPServer, r)
 }
 
 func (s *PublicApiServer) CreateMtlsServer() (ifrit.Runner, error) {

--- a/src/autoscaler/api/publicapiserver/public_api_server.go
+++ b/src/autoscaler/api/publicapiserver/public_api_server.go
@@ -20,7 +20,6 @@ import (
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/routes"
 
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tedsuo/ifrit"
@@ -41,10 +40,14 @@ type PublicApiServer struct {
 	checkBindingFunc    api.CheckBindingFunc
 	cfClient            cf.CFClient
 	httpStatusCollector healthendpoint.HTTPStatusCollector
-	rateLimiter         ratelimiter.Limiter
-	brokerServer        brokerserver.BrokerServer
 
-	healthRouter *mux.Router
+	brokerServer brokerserver.BrokerServer
+
+	autoscalerRouter *routes.Router
+
+	healthRouter              *mux.Router
+	publicApiServerMiddleware *Middleware
+	rateLimiterMiddleware     *ratelimiter.RateLimiterMiddleware
 }
 
 func NewPublicApiServer(logger lager.Logger, conf *config.Config, policyDB db.PolicyDB,
@@ -52,112 +55,127 @@ func NewPublicApiServer(logger lager.Logger, conf *config.Config, policyDB db.Po
 	cfClient cf.CFClient, httpStatusCollector healthendpoint.HTTPStatusCollector,
 	rateLimiter ratelimiter.Limiter, brokerServer brokerserver.BrokerServer) *PublicApiServer {
 	return &PublicApiServer{
-		logger:              logger,
-		conf:                conf,
-		policyDB:            policyDB,
-		bindingDB:           bindingDB,
-		credentials:         credentials,
-		checkBindingFunc:    checkBindingFunc,
-		cfClient:            cfClient,
-		httpStatusCollector: httpStatusCollector,
-		rateLimiter:         rateLimiter,
-		brokerServer:        brokerServer,
+		logger:                    logger,
+		conf:                      conf,
+		policyDB:                  policyDB,
+		bindingDB:                 bindingDB,
+		credentials:               credentials,
+		checkBindingFunc:          checkBindingFunc,
+		cfClient:                  cfClient,
+		httpStatusCollector:       httpStatusCollector,
+		brokerServer:              brokerServer,
+		autoscalerRouter:          routes.NewRouter(),
+		publicApiServerMiddleware: NewMiddleware(logger, cfClient, checkBindingFunc, conf.APIClientId),
+		rateLimiterMiddleware:     ratelimiter.NewRateLimiterMiddleware("appId", rateLimiter, logger.Session("api-ratelimiter-middleware")),
 	}
 }
 
-func (s *PublicApiServer) Setup() error {
-	hr, err := s.createHealthRouter()
+func (s *PublicApiServer) CreateHealthServer() (ifrit.Runner, error) {
+	if err := s.setupHealthRouter(); err != nil {
+		return nil, err
+	}
+
+	return helpers.NewHTTPServer(s.logger, s.conf.Health.ServerConfig, s.healthRouter)
+}
+
+func (s *PublicApiServer) setupBrokerRouter() error {
+	brokerRouter, err := s.brokerServer.GetRouter()
 	if err != nil {
 		return err
 	}
 
-	s.healthRouter = hr
+	s.autoscalerRouter.GetRouter().PathPrefix("/v2").Handler(brokerRouter)
 
 	return nil
 }
 
-func (s *PublicApiServer) GetHealthServer() (ifrit.Runner, error) {
-	return helpers.NewHTTPServer(s.logger, s.conf.Health.ServerConfig, s.healthRouter)
-}
-
-func (s *PublicApiServer) GetUnifiedServer() (ifrit.Runner, error) {
-	pah := NewPublicApiHandler(s.logger, s.conf, s.policyDB, s.bindingDB, s.credentials)
-	scalingHistoryHandler, err := s.newScalingHistoryHandler()
-	if err != nil {
+func (s *PublicApiServer) CreateCFServer() (ifrit.Runner, error) {
+	if err := s.setupBrokerRouter(); err != nil {
 		return nil, err
 	}
 
-	r := s.setupApiRoutes(pah, scalingHistoryHandler)
-
-	brokerRouter, err := s.brokerServer.GetRouter()
-	if err != nil {
+	if err := s.setupHealthRouter(); err != nil {
 		return nil, err
 	}
 
-	return helpers.NewHTTPServer(s.logger, s.conf.VCAPServer, s.setupVCAPRouter(r, s.healthRouter, brokerRouter))
-}
-
-func (s *PublicApiServer) GetMtlsServer() (ifrit.Runner, error) {
-	pah := NewPublicApiHandler(s.logger, s.conf, s.policyDB, s.bindingDB, s.credentials)
-	scalingHistoryHandler, err := s.newScalingHistoryHandler()
-	if err != nil {
+	if err := s.setupApiRoutes(); err != nil {
 		return nil, err
 	}
 
-	r := s.setupApiRoutes(pah, scalingHistoryHandler)
+	mainRouter := mux.NewRouter()
+	r := s.autoscalerRouter.GetRouter()
+	mainRouter.PathPrefix("/v2").Handler(r)
+	mainRouter.PathPrefix("/v1").Handler(r)
+	mainRouter.PathPrefix("/health").Handler(r)
+	mainRouter.PathPrefix("/").Handler(s.healthRouter)
 
-	return helpers.NewHTTPServer(s.logger, s.conf.Server, s.setupMainRouter(r, s.healthRouter))
+	return helpers.NewHTTPServer(s.logger, s.conf.VCAPServer, mainRouter)
 }
 
-func (s *PublicApiServer) setupApiRoutes(pah *PublicApiHandler, scalingHistoryHandler http.Handler) *mux.Router {
-	r := routes.ApiOpenRoutes()
-	r.Use(otelmux.Middleware("apiserver"))
-	r.Use(healthendpoint.NewHTTPStatusCollectMiddleware(s.httpStatusCollector).Collect)
+func (s *PublicApiServer) CreateMtlsServer() (ifrit.Runner, error) {
+	if err := s.setupApiRoutes(); err != nil {
+		return nil, err
+	}
 
-	r.Get(routes.PublicApiInfoRouteName).Handler(VarsFunc(pah.GetApiInfo))
-	r.Get(routes.PublicApiHealthRouteName).Handler(VarsFunc(pah.GetHealth))
-
-	rp := routes.ApiRoutes()
-	rateLimiterMiddleware := ratelimiter.NewRateLimiterMiddleware("appId", s.rateLimiter, s.logger.Session("api-ratelimiter-middleware"))
-	rp.Use(rateLimiterMiddleware.CheckRateLimit)
-	rp.Use(NewMiddleware(s.logger, s.cfClient, s.checkBindingFunc, s.conf.APIClientId).HasClientToken)
-	rp.Use(NewMiddleware(s.logger, s.cfClient, s.checkBindingFunc, s.conf.APIClientId).Oauth)
-	rp.Use(NewMiddleware(s.logger, s.cfClient, s.checkBindingFunc, s.conf.APIClientId).CheckServiceBinding)
-	rp.Use(healthendpoint.NewHTTPStatusCollectMiddleware(s.httpStatusCollector).Collect)
-
-	rp.Get(routes.PublicApiScalingHistoryRouteName).Handler(scalingHistoryHandler)
-	rp.Get(routes.PublicApiAggregatedMetricsHistoryRouteName).Handler(VarsFunc(pah.GetAggregatedMetricsHistories))
-
-	s.setupPolicyRoutes(rp, pah)
-
-	return r
+	return helpers.NewHTTPServer(s.logger, s.conf.Server, s.autoscalerRouter.GetRouter())
 }
 
-func (s *PublicApiServer) setupPolicyRoutes(rp *mux.Router, pah *PublicApiHandler) {
-	rpolicy := routes.ApiPolicyRoutes()
-	rlm := ratelimiter.NewRateLimiterMiddleware("appId", s.rateLimiter, s.logger.Session("api-ratelimiter-middleware"))
-	pasm := NewMiddleware(s.logger, s.cfClient, s.checkBindingFunc, s.conf.APIClientId)
-	rpolicy.Use(rlm.CheckRateLimit)
-	rpolicy.Use(pasm.HasClientToken)
-	rpolicy.Use(pasm.Oauth)
-	rpolicy.Use(pasm.CheckServiceBinding)
+func (s *PublicApiServer) setupApiProtectedRoutes(pah *PublicApiHandler, scalingHistoryHandler http.Handler) {
+	apiProtectedRouter := s.autoscalerRouter.CreateApiSubrouter()
+	apiProtectedRouter.Use(otelmux.Middleware("apiserver"))
+	apiProtectedRouter.Use(healthendpoint.NewHTTPStatusCollectMiddleware(s.httpStatusCollector).Collect)
+	apiProtectedRouter.Use(s.rateLimiterMiddleware.CheckRateLimit)
+	apiProtectedRouter.Use(s.publicApiServerMiddleware.HasClientToken)
+	apiProtectedRouter.Use(s.publicApiServerMiddleware.Oauth)
+	apiProtectedRouter.Use(s.publicApiServerMiddleware.CheckServiceBinding)
+	apiProtectedRouter.Use(healthendpoint.NewHTTPStatusCollectMiddleware(s.httpStatusCollector).Collect)
+	apiProtectedRouter.Get(routes.PublicApiScalingHistoryRouteName).Handler(scalingHistoryHandler)
+	apiProtectedRouter.Get(routes.PublicApiAggregatedMetricsHistoryRouteName).Handler(VarsFunc(pah.GetAggregatedMetricsHistories))
+}
+
+func (s *PublicApiServer) setupPolicyRoutes(pah *PublicApiHandler) {
+	rpolicy := s.autoscalerRouter.CreateApiPolicySubrouter()
+	rpolicy.Use(s.rateLimiterMiddleware.CheckRateLimit)
+	rpolicy.Use(s.publicApiServerMiddleware.HasClientToken)
+	rpolicy.Use(s.publicApiServerMiddleware.Oauth)
+	rpolicy.Use(s.publicApiServerMiddleware.CheckServiceBinding)
 	rpolicy.Use(healthendpoint.NewHTTPStatusCollectMiddleware(s.httpStatusCollector).Collect)
-
 	rpolicy.Get(routes.PublicApiGetPolicyRouteName).Handler(VarsFunc(pah.GetScalingPolicy))
 	rpolicy.Get(routes.PublicApiAttachPolicyRouteName).Handler(VarsFunc(pah.AttachScalingPolicy))
 	rpolicy.Get(routes.PublicApiDetachPolicyRouteName).Handler(VarsFunc(pah.DetachScalingPolicy))
 }
 
-func (s *PublicApiServer) createHealthRouter() (*mux.Router, error) {
+func (s *PublicApiServer) setupPublicApiRoutes(pah *PublicApiHandler) {
+	apiPublicRouter := s.autoscalerRouter.CreateApiPublicSubrouter()
+	apiPublicRouter.Get(routes.PublicApiInfoRouteName).Handler(VarsFunc(pah.GetApiInfo))
+	apiPublicRouter.Get(routes.PublicApiHealthRouteName).Handler(VarsFunc(pah.GetHealth))
+}
+
+func (s *PublicApiServer) setupApiRoutes() error {
+	publicApiHandler := NewPublicApiHandler(s.logger, s.conf, s.policyDB, s.bindingDB, s.credentials)
+	scalingHistoryHandler, err := s.newScalingHistoryHandler()
+	if err != nil {
+		return err
+	}
+	s.setupApiProtectedRoutes(publicApiHandler, scalingHistoryHandler)
+	s.setupPublicApiRoutes(publicApiHandler)
+	s.setupPolicyRoutes(publicApiHandler)
+
+	return nil
+}
+
+func (s *PublicApiServer) setupHealthRouter() error {
 	checkers := []healthendpoint.Checker{}
 	gatherer := s.createPrometheusRegistry()
+
 	healthRouter, err := healthendpoint.NewHealthRouter(s.conf.Health, checkers, s.logger.Session("health-server"), gatherer, time.Now)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create health router: %w", err)
+		return fmt.Errorf("failed to create health router: %w", err)
 	}
 
-	s.logger.Debug("Successfully created health server")
-	return healthRouter, nil
+	s.healthRouter = healthRouter
+
+	return nil
 }
 
 func (s *PublicApiServer) createPrometheusRegistry() *prometheus.Registry {
@@ -179,23 +197,4 @@ func (s *PublicApiServer) newScalingHistoryHandler() (http.Handler, error) {
 		return nil, fmt.Errorf("error creating scaling history handler: %w", err)
 	}
 	return scalinghistory.NewServer(scalingHistoryHandler, ss)
-}
-
-func (s *PublicApiServer) setupVCAPRouter(r *mux.Router, healthRouter *mux.Router, brokerRouter *chi.Mux) *mux.Router {
-	mainRouter := mux.NewRouter()
-
-	mainRouter.PathPrefix("/v2").Handler(brokerRouter)
-	mainRouter.PathPrefix("/v1").Handler(r)
-	mainRouter.PathPrefix("/health").Handler(healthRouter)
-	mainRouter.PathPrefix("/").Handler(healthRouter)
-
-	return mainRouter
-}
-
-func (s *PublicApiServer) setupMainRouter(r *mux.Router, healthRouter *mux.Router) *mux.Router {
-	mainRouter := mux.NewRouter()
-	mainRouter.PathPrefix("/v1").Handler(r)
-	mainRouter.PathPrefix("/health").Handler(healthRouter)
-	mainRouter.PathPrefix("/").Handler(healthRouter)
-	return mainRouter
 }

--- a/src/autoscaler/build-extension-file.sh
+++ b/src/autoscaler/build-extension-file.sh
@@ -20,6 +20,7 @@ export POSTGRES_EXTERNAL_PORT="${PR_NUMBER:-5432}"
 
 export METRICSFORWARDER_HOST="${METRICSFORWARDER_HOST:-"${DEPLOYMENT_NAME}-metricsforwarder"}"
 export METRICSFORWARDER_MTLS_HOST="${METRICSFORWARDER_MTLS_HOST:-"${DEPLOYMENT_NAME}-metricsforwarder-mtls"}"
+export SCALINGENGINE_HOST="${SCALINGENGINE_HOST:-"${DEPLOYMENT_NAME}-cf-scalingengine"}"
 export PUBLICAPISERVER_HOST="${PUBLICAPISERVER_HOST:-"${DEPLOYMENT_NAME}"}"
 export SERVICEBROKER_HOST="${SERVICEBROKER_HOST:-"${DEPLOYMENT_NAME}servicebroker"}"
 
@@ -113,4 +114,6 @@ resources:
         metrics_forwarder:
           metrics_forwarder_url: ${METRICSFORWARDER_HOST}.\${default-domain}
           metrics_forwarder_mtls_url: ${METRICSFORWARDER_MTLS_HOST}.\${default-domain}
+        scaling_engine:
+          scaling_engine_url: ${SCALINGENGINE_HOST}.\${default-domain}
 EOF

--- a/src/autoscaler/generate-fakes.go
+++ b/src/autoscaler/generate-fakes.go
@@ -26,3 +26,4 @@ package fakes
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o ./fakes/fake_log_cache_client.go ./eventgenerator/metric LogCacheClient
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o ./fakes/fake_vcap_configuration_reader.go ./configutil VCAPConfigurationReader
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o ./fakes/fake_broker_server.go ./api/brokerserver BrokerServer
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o ./fakes/fake_xfcc_auth_middleware.go ./helpers/auth XFCCAuthMiddleware

--- a/src/autoscaler/helpers/auth/xfcc_auth.go
+++ b/src/autoscaler/helpers/auth/xfcc_auth.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/models"
 	"code.cloudfoundry.org/lager/v3"
 )
 
@@ -16,13 +17,17 @@ var ErrorWrongSpace = errors.New("space guid is wrong")
 var ErrorWrongOrg = errors.New("org guid is wrong")
 var ErrXFCCHeaderNotFound = errors.New("xfcc header not found")
 
-type XFCCAuthMiddleware struct {
+type XFCCAuthMiddleware interface {
+	XFCCAuthenticationMiddleware(next http.Handler) http.Handler
+}
+
+type xfccAuthMiddleware struct {
 	logger    lager.Logger
 	spaceGuid string
 	orgGuid   string
 }
 
-func (m *XFCCAuthMiddleware) checkAuth(r *http.Request) error {
+func (m *xfccAuthMiddleware) checkAuth(r *http.Request) error {
 	xfccHeader := r.Header.Get("X-Forwarded-Client-Cert")
 	if xfccHeader == "" {
 		return ErrXFCCHeaderNotFound
@@ -38,6 +43,8 @@ func (m *XFCCAuthMiddleware) checkAuth(r *http.Request) error {
 		return fmt.Errorf("failed to parse certificate: %w", err)
 	}
 
+	fmt.Println("BANANAAAA", getSpaceGuid(cert))
+	fmt.Println("BANANAAAA", m.spaceGuid)
 	if getSpaceGuid(cert) != m.spaceGuid {
 		return ErrorWrongSpace
 	}
@@ -49,7 +56,7 @@ func (m *XFCCAuthMiddleware) checkAuth(r *http.Request) error {
 	return nil
 }
 
-func (m *XFCCAuthMiddleware) XFCCAuthenticationMiddleware(next http.Handler) http.Handler {
+func (m *xfccAuthMiddleware) XFCCAuthenticationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		err := m.checkAuth(r)
 
@@ -63,11 +70,11 @@ func (m *XFCCAuthMiddleware) XFCCAuthenticationMiddleware(next http.Handler) htt
 	})
 }
 
-func NewXfccAuthMiddleware(logger lager.Logger, orgGuid, spaceGuid string) *XFCCAuthMiddleware {
-	return &XFCCAuthMiddleware{
+func NewXfccAuthMiddleware(logger lager.Logger, xfccAuth models.XFCCAuth) XFCCAuthMiddleware {
+	return &xfccAuthMiddleware{
 		logger:    logger,
-		orgGuid:   orgGuid,
-		spaceGuid: spaceGuid,
+		orgGuid:   xfccAuth.ValidOrgGuid,
+		spaceGuid: xfccAuth.ValidSpaceGuid,
 	}
 }
 

--- a/src/autoscaler/helpers/auth/xfcc_auth.go
+++ b/src/autoscaler/helpers/auth/xfcc_auth.go
@@ -43,8 +43,6 @@ func (m *xfccAuthMiddleware) checkAuth(r *http.Request) error {
 		return fmt.Errorf("failed to parse certificate: %w", err)
 	}
 
-	fmt.Println("BANANAAAA", getSpaceGuid(cert))
-	fmt.Println("BANANAAAA", m.spaceGuid)
 	if getSpaceGuid(cert) != m.spaceGuid {
 		return ErrorWrongSpace
 	}

--- a/src/autoscaler/helpers/http_server.go
+++ b/src/autoscaler/helpers/http_server.go
@@ -14,6 +14,7 @@ import (
 type ServerConfig struct {
 	Port int             `yaml:"port"`
 	TLS  models.TLSCerts `yaml:"tls"`
+	XFCC models.XFCCAuth `yaml:"xfcc"`
 }
 
 func NewHTTPServer(logger lager.Logger, conf ServerConfig, handler http.Handler) (ifrit.Runner, error) {

--- a/src/autoscaler/models/api.go
+++ b/src/autoscaler/models/api.go
@@ -9,6 +9,11 @@ const (
 	X509Certificate = "x509"
 )
 
+type XFCCAuth struct {
+	ValidOrgGuid   string `yaml:"valid_org_guid"`
+	ValidSpaceGuid string `yaml:"valid_space_guid"`
+}
+
 type BrokerContext struct {
 	OrgGUID   string `json:"organization_guid"`
 	SpaceGUID string `json:"space_guid"`

--- a/src/autoscaler/routes/routes_test.go
+++ b/src/autoscaler/routes/routes_test.go
@@ -3,17 +3,27 @@ package routes_test
 import (
 	"code.cloudfoundry.org/app-autoscaler/src/autoscaler/routes"
 
+	"github.com/gorilla/mux"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Routes", func() {
-
 	var (
-		testAppId      = "testAppId"
-		testScheduleId = "testScheduleId"
-		testMetricType = "testMetricType"
+		autoscalerRouter *routes.Router
+		router           *mux.Router
+		testAppId        = "testAppId"
+		testScheduleId   = "testScheduleId"
+		testMetricType   = "testMetricType"
 	)
+
+	BeforeEach(func() {
+		autoscalerRouter = routes.NewRouter()
+	})
+
+	JustBeforeEach(func() {
+		router = autoscalerRouter.GetRouter()
+	})
 	Describe("MetricsCollectorRoutes", func() {
 		Context("GetMetricHistoriesRoute", func() {
 			Context("when provide correct route variable", func() {
@@ -44,17 +54,21 @@ var _ = Describe("Routes", func() {
 	})
 
 	Describe("PublicApiRoutes", func() {
+		JustBeforeEach(func() {
+			autoscalerRouter.CreateApiPublicSubrouter()
+		})
+
 		Context("PublicApiInfoRouteName", func() {
 			It("should return the correct path", func() {
-				path, err := routes.ApiOpenRoutes().Get(routes.PublicApiInfoRouteName).URLPath()
+				path, err := router.Get(routes.PublicApiInfoRouteName).URLPath()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(path.Path).To(Equal("/v1/info"))
 			})
 		})
 
-		Context("PublicApiHealthRouteName", func() {
+		XContext("PublicApiHealthRouteName", func() {
 			It("should return the correct path", func() {
-				path, err := routes.ApiOpenRoutes().Get(routes.PublicApiHealthRouteName).URLPath()
+				path, err := router.Get(routes.PublicApiHealthRouteName).URLPath()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(path.Path).To(Equal("/health"))
 			})
@@ -62,11 +76,15 @@ var _ = Describe("Routes", func() {
 	})
 
 	Describe("ApiRoutes", func() {
+		JustBeforeEach(func() {
+			autoscalerRouter.CreateApiSubrouter()
+		})
 		Context("PublicApiScalingHistoryRouteName", func() {
 
 			Context("when provide correct route variable", func() {
 				It("should return the correct path", func() {
-					path, err := routes.ApiRoutes().Get(routes.PublicApiScalingHistoryRouteName).URLPath("appId", testAppId)
+
+					path, err := router.Get(routes.PublicApiScalingHistoryRouteName).URLPath("appId", testAppId)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(path.Path).To(Equal("/v1/apps/" + testAppId + "/scaling_histories"))
 				})
@@ -74,7 +92,7 @@ var _ = Describe("Routes", func() {
 
 			Context("when provide wrong route variable", func() {
 				It("should return error", func() {
-					_, err := routes.ApiRoutes().Get(routes.PublicApiScalingHistoryRouteName).URLPath("wrongVariable", testAppId)
+					_, err := router.Get(routes.PublicApiScalingHistoryRouteName).URLPath("wrongVariable", testAppId)
 					Expect(err).To(HaveOccurred())
 
 				})
@@ -82,7 +100,7 @@ var _ = Describe("Routes", func() {
 
 			Context("when provide not enough route variable", func() {
 				It("should return error", func() {
-					_, err := routes.ApiRoutes().Get(routes.PublicApiScalingHistoryRouteName).URLPath()
+					_, err := router.Get(routes.PublicApiScalingHistoryRouteName).URLPath()
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -91,7 +109,7 @@ var _ = Describe("Routes", func() {
 
 			Context("when provide correct route variable", func() {
 				It("should return the correct path", func() {
-					path, err := routes.ApiRoutes().Get(routes.PublicApiAggregatedMetricsHistoryRouteName).URLPath("appId", testAppId, "metricType", testMetricType)
+					path, err := router.Get(routes.PublicApiAggregatedMetricsHistoryRouteName).URLPath("appId", testAppId, "metricType", testMetricType)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(path.Path).To(Equal("/v1/apps/" + testAppId + "/aggregated_metric_histories/" + testMetricType))
 				})
@@ -99,7 +117,7 @@ var _ = Describe("Routes", func() {
 
 			Context("when provide wrong route variable", func() {
 				It("should return error", func() {
-					_, err := routes.ApiRoutes().Get(routes.PublicApiAggregatedMetricsHistoryRouteName).URLPath("wrongVariable", testAppId)
+					_, err := router.Get(routes.PublicApiAggregatedMetricsHistoryRouteName).URLPath("wrongVariable", testAppId)
 					Expect(err).To(HaveOccurred())
 
 				})
@@ -107,7 +125,7 @@ var _ = Describe("Routes", func() {
 
 			Context("when provide not enough route variable", func() {
 				It("should return error", func() {
-					_, err := routes.ApiRoutes().Get(routes.PublicApiAggregatedMetricsHistoryRouteName).URLPath()
+					_, err := router.Get(routes.PublicApiAggregatedMetricsHistoryRouteName).URLPath()
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/src/autoscaler/scalingengine/cmd/scalingengine/scalingengine_suite_test.go
+++ b/src/autoscaler/scalingengine/cmd/scalingengine/scalingengine_suite_test.go
@@ -35,8 +35,6 @@ func TestScalingengine(t *testing.T) {
 var (
 	enginePath       string
 	conf             config.Config
-	port             int
-	healthport       int
 	configFile       *os.File
 	ccUAA            *mocks.Server
 	appId            string
@@ -68,17 +66,20 @@ var _ = SynchronizedBeforeSuite(
 			Secret:   "autoscaler_client_secret",
 		}
 
-		port = 7000 + GinkgoParallelProcess()
-		healthport = 8000 + GinkgoParallelProcess()
 		testCertDir := "../../../../../test-certs"
 
 		verifyCertExistence(testCertDir)
 
-		conf.Server.Port = port
+		// Set services port
+		conf.Server.Port = 7000 + GinkgoParallelProcess()
+		conf.Health.ServerConfig.Port = 8000 + GinkgoParallelProcess()
+		conf.CFServer.Port = 9000 + GinkgoParallelProcess()
+		conf.CFServer.XFCC.ValidOrgGuid = "org-guid"
+		conf.CFServer.XFCC.ValidSpaceGuid = "space-guid"
+
 		conf.Server.TLS.KeyFile = filepath.Join(testCertDir, "scalingengine.key")
 		conf.Server.TLS.CertFile = filepath.Join(testCertDir, "scalingengine.crt")
 		conf.Server.TLS.CACertFile = filepath.Join(testCertDir, "autoscaler-ca.crt")
-		conf.Health.ServerConfig.Port = healthport
 		conf.Logging.Level = "debug"
 
 		dbUrl := GetDbUrl()

--- a/src/autoscaler/scalingengine/config/config.go
+++ b/src/autoscaler/scalingengine/config/config.go
@@ -31,7 +31,7 @@ var defaultHealthConfig = helpers.HealthConfig{
 	},
 }
 
-var defaultCfServerConfig = helpers.ServerConfig{
+var defaultCFServerConfig = helpers.ServerConfig{
 	Port: 8082,
 }
 
@@ -53,7 +53,7 @@ type Config struct {
 	CF                  cf.Config             `yaml:"cf"`
 	Logging             helpers.LoggingConfig `yaml:"logging"`
 	Server              helpers.ServerConfig  `yaml:"server"`
-	CfServer            helpers.ServerConfig  `yaml:"cf_server"`
+	CFServer            helpers.ServerConfig  `yaml:"cf_server"`
 	Health              helpers.HealthConfig  `yaml:"health"`
 	DB                  DBConfig              `yaml:"db"`
 	DefaultCoolDownSecs int                   `yaml:"defaultCoolDownSecs"`
@@ -66,7 +66,7 @@ func LoadConfig(reader io.Reader) (*Config, error) {
 		CF:                defaultCFConfig,
 		Logging:           defaultLoggingConfig,
 		Server:            defaultServerConfig,
-		CfServer:          defaultCfServerConfig,
+		CFServer:          defaultCFServerConfig,
 		Health:            defaultHealthConfig,
 		HttpClientTimeout: DefaultHttpClientTimeout,
 	}

--- a/src/autoscaler/scalingengine/config/config.go
+++ b/src/autoscaler/scalingengine/config/config.go
@@ -31,6 +31,10 @@ var defaultHealthConfig = helpers.HealthConfig{
 	},
 }
 
+var defaultCfServerConfig = helpers.ServerConfig{
+	Port: 8082,
+}
+
 var defaultLoggingConfig = helpers.LoggingConfig{
 	Level: "info",
 }
@@ -49,6 +53,7 @@ type Config struct {
 	CF                  cf.Config             `yaml:"cf"`
 	Logging             helpers.LoggingConfig `yaml:"logging"`
 	Server              helpers.ServerConfig  `yaml:"server"`
+	CfServer            helpers.ServerConfig  `yaml:"cf_server"`
 	Health              helpers.HealthConfig  `yaml:"health"`
 	DB                  DBConfig              `yaml:"db"`
 	DefaultCoolDownSecs int                   `yaml:"defaultCoolDownSecs"`
@@ -61,6 +66,7 @@ func LoadConfig(reader io.Reader) (*Config, error) {
 		CF:                defaultCFConfig,
 		Logging:           defaultLoggingConfig,
 		Server:            defaultServerConfig,
+		CfServer:          defaultCfServerConfig,
 		Health:            defaultHealthConfig,
 		HttpClientTimeout: DefaultHttpClientTimeout,
 	}

--- a/src/autoscaler/scalingengine/config/config_test.go
+++ b/src/autoscaler/scalingengine/config/config_test.go
@@ -55,6 +55,10 @@ var _ = Describe("Config", func() {
 				Expect(conf.Server.TLS.CertFile).To(Equal("/var/vcap/jobs/autoscaler/config/certs/server.crt"))
 				Expect(conf.Server.TLS.CACertFile).To(Equal("/var/vcap/jobs/autoscaler/config/certs/ca.crt"))
 
+				Expect(conf.CfServer.Port).To(Equal(2222))
+				Expect(conf.CfServer.XFCC.ValidOrgGuid).To(Equal("valid_org_guid"))
+				Expect(conf.CfServer.XFCC.ValidSpaceGuid).To(Equal("valid_space_guid"))
+
 				Expect(conf.Health.ServerConfig.Port).To(Equal(9999))
 				Expect(conf.Logging.Level).To(Equal("debug"))
 

--- a/src/autoscaler/scalingengine/config/config_test.go
+++ b/src/autoscaler/scalingengine/config/config_test.go
@@ -55,9 +55,9 @@ var _ = Describe("Config", func() {
 				Expect(conf.Server.TLS.CertFile).To(Equal("/var/vcap/jobs/autoscaler/config/certs/server.crt"))
 				Expect(conf.Server.TLS.CACertFile).To(Equal("/var/vcap/jobs/autoscaler/config/certs/ca.crt"))
 
-				Expect(conf.CfServer.Port).To(Equal(2222))
-				Expect(conf.CfServer.XFCC.ValidOrgGuid).To(Equal("valid_org_guid"))
-				Expect(conf.CfServer.XFCC.ValidSpaceGuid).To(Equal("valid_space_guid"))
+				Expect(conf.CFServer.Port).To(Equal(2222))
+				Expect(conf.CFServer.XFCC.ValidOrgGuid).To(Equal("valid_org_guid"))
+				Expect(conf.CFServer.XFCC.ValidSpaceGuid).To(Equal("valid_space_guid"))
 
 				Expect(conf.Health.ServerConfig.Port).To(Equal(9999))
 				Expect(conf.Logging.Level).To(Equal("debug"))

--- a/src/autoscaler/scalingengine/config/testdata/valid.yml
+++ b/src/autoscaler/scalingengine/config/testdata/valid.yml
@@ -9,6 +9,13 @@ server:
     key_file: /var/vcap/jobs/autoscaler/config/certs/server.key
     cert_file: /var/vcap/jobs/autoscaler/config/certs/server.crt
     ca_file: /var/vcap/jobs/autoscaler/config/certs/ca.crt
+
+cf_server:
+  port: 2222
+  xfcc:
+    valid_org_guid: valid_org_guid
+    valid_space_guid: valid_space_guid
+
 health:
   server_config:
     port: 9999

--- a/src/autoscaler/testhelpers/certs.go
+++ b/src/autoscaler/testhelpers/certs.go
@@ -1,0 +1,46 @@
+package testhelpers
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+)
+
+// generateClientCert generates a client certificate with the specified spaceGUID and orgGUID
+// included in the organizational unit string.
+func GenerateClientCert(orgGUID, spaceGUID string) ([]byte, error) {
+	// Generate a random serial number for the certificate
+	//
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new X.509 certificate template
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization:       []string{"My Organization"},
+			OrganizationalUnit: []string{fmt.Sprintf("space:%s org:%s", spaceGUID, orgGUID)},
+		},
+	}
+	// Generate the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encode the certificate to PEM format
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	return certPEM, nil
+}


### PR DESCRIPTION
This pull request adds a new xfcc unified endpoint to the scaling engine that will be consumed by the API component once it is deployed as a Cloud Foundry application.

 includes several changes to the `deploy-autoscaler.sh` script, configuration files, and tests related to the autoscaler deployment and CF server configurations. The most important changes include refactoring the `deploy-autoscaler.sh` script for better readability and maintainability, adding new CF server configurations, and updating tests to reflect these changes.

### Script Refactoring:
* Refactored the `deploy-autoscaler.sh`. [[1]](diffhunk://#diff-eb92f3568762003dbdddd247a28376d37d1d2177c1cc1f106180a0d8c0f92711L12-R34) [[2]](diffhunk://#diff-eb92f3568762003dbdddd247a28376d37d1d2177c1cc1f106180a0d8c0f92711R63-R113)

### Configuration Updates:
* Added new properties for CF server configuration in `jobs/scalingengine/spec`.
* Updated the `scalingengine.yml.erb` template to include new CF server properties.
* Modified `use-cf-services.yml` to add space and org GUIDs to the scaling engine.

### Test Updates:
* Updated tests in `scalingengine_spec.rb` to include checks for the new CF server configurations.
* Renamed `GetServer` to `CreateServer` in `broker_server.go` and updated corresponding tests. [[1]](diffhunk://#diff-02920aac269cee18e8a40c2be191b0109f0fcd8018900c2fac2c02e2bc73aadaL66-R66) [[2]](diffhunk://#diff-02920aac269cee18e8a40c2be191b0109f0fcd8018900c2fac2c02e2bc73aadaL92-R92) [[3]](diffhunk://#diff-5d2c52abfd0dde7df015d8afd75f955c984cf07b1a13212167f6d464bc756e34L148-R148)
* Refactored tests in `api_test.go`. [[1]](diffhunk://#diff-b3808066a1ffcbecc89223143f6afec7da5cf6835fd1f1145d6aa77b45e57b29L31-R36) [[2]](diffhunk://#diff-b3808066a1ffcbecc89223143f6afec7da5cf6835fd1f1145d6aa77b45e57b29L50-R50) [[3]](diffhunk://#diff-b3808066a1ffcbecc89223143f6afec7da5cf6835fd1f1145d6aa77b45e57b29L61-R61) [[4]](diffhunk://#diff-b3808066a1ffcbecc89223143f6afec7da5cf6835fd1f1145d6aa77b45e57b29R299-R302)