### PR TITLE
Add generate-openapi-generated-clients-and-servers as a dependency for the integration target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ stop-db: check-db_type
 	@docker rm -f ${db_type} &> /dev/null || echo " - we could not stop and remove docker named '${db_type}'"
 
 .PHONY: integration
-integration: build init-db test-certs ## Run all integration tests
+integration: generate-openapi-generated-clients-and-servers build init-db test-certs ## Run all integration tests
 	@echo " - using DBURL=${DBURL}"
 	@make --directory='./src/autoscaler' integration DBURL="${DBURL}"
 


### PR DESCRIPTION
This pull request includes a change to the `Makefile` to ensure that the `integration` target runs the `generate-openapi-generated-clients-and-servers` task before building, initializing the database, and testing certificates.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L221-R221): Modified the `integration` target to include `generate-openapi-generated-clients-and-servers` as a prerequisite task.