### PR TITLE
chore(ci): remove continue-on-error from acceptance tests workflow

### DIFF
--- a/.github/workflows/acceptance_tests_reusable.yaml
+++ b/.github/workflows/acceptance_tests_reusable.yaml
@@ -72,7 +72,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: "${{ inputs.self_hosted_image }}"
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Issue

Failing acceptance_tests jobs did not actually prevent the workflow from suceeding

# Fix

remove continue-on-error from acceptance tests workflow
