### PR TITLE
chore(logcache fetcher): only log number of received envelopes

### DIFF
--- a/src/autoscaler/eventgenerator/metric/fetcher.go
+++ b/src/autoscaler/eventgenerator/metric/fetcher.go
@@ -78,12 +78,12 @@ func (l *logCacheFetcher) getMetricsPromQLAPI(appId string, metricType string, c
 		metricTypeUnit = models.UnitMilliseconds
 	}
 
-	l.logger.Info("query-promql-api", lager.Data{"query": query})
+	l.logger.Debug("query-promql-api", lager.Data{"query": query})
 	result, err := l.logCacheClient.PromQL(context.Background(), query, logcache.WithPromQLTime(now))
 	if err != nil {
 		return []models.AppInstanceMetric{}, fmt.Errorf("failed getting PromQL result (metricType: %s, appId: %s, collectionInterval: %s, query: %s, time: %s): %w", metricType, appId, collectionIntervalSeconds, query, now.String(), err)
 	}
-	l.logger.Info("received-promql-api-result", lager.Data{"result": result, "query": query})
+	l.logger.Debug("received-promql-api-result", lager.Data{"result": result, "query": query})
 
 	// safeguard: the query ensures that we get a vector but let's double-check
 	vector := result.GetVector()

--- a/src/autoscaler/eventgenerator/metric/fetcher.go
+++ b/src/autoscaler/eventgenerator/metric/fetcher.go
@@ -83,7 +83,7 @@ func (l *logCacheFetcher) getMetricsPromQLAPI(appId string, metricType string, c
 	if err != nil {
 		return []models.AppInstanceMetric{}, fmt.Errorf("failed getting PromQL result (metricType: %s, appId: %s, collectionInterval: %s, query: %s, time: %s): %w", metricType, appId, collectionIntervalSeconds, query, now.String(), err)
 	}
-	l.logger.Debug("received-promql-api-result", lager.Data{"result": result, "query": query})
+	l.logger.Info("received-promql-api-result", lager.Data{"result": result, "query": query})
 
 	// safeguard: the query ensures that we get a vector but let's double-check
 	vector := result.GetVector()
@@ -149,7 +149,7 @@ func (l *logCacheFetcher) emptyAppInstanceMetrics(appId string, name string, uni
 func (l *logCacheFetcher) getMetricsRestAPI(appId string, metricType string, startTime time.Time, endTime time.Time) ([]models.AppInstanceMetric, error) {
 	filters := l.readOptions(endTime, metricType)
 
-	l.logger.Info("querying-rest-api-with-filters", lager.Data{"appId": appId, "metricType": metricType, "startTime": startTime, "endTime": endTime, "filters": l.valuesFrom(filters)})
+	l.logger.Info("query-rest-api-with-filters", lager.Data{"appId": appId, "metricType": metricType, "startTime": startTime, "endTime": endTime, "filters": l.valuesFrom(filters)})
 	envelopes, err := l.logCacheClient.Read(context.Background(), appId, startTime, filters...)
 	if err != nil {
 		return []models.AppInstanceMetric{}, fmt.Errorf("fail to Read %s metric from %s GoLogCache client: %w", logcache_v1.EnvelopeType_GAUGE, appId, err)

--- a/src/autoscaler/eventgenerator/metric/fetcher.go
+++ b/src/autoscaler/eventgenerator/metric/fetcher.go
@@ -78,7 +78,7 @@ func (l *logCacheFetcher) getMetricsPromQLAPI(appId string, metricType string, c
 		metricTypeUnit = models.UnitMilliseconds
 	}
 
-	l.logger.Debug("query-promql-api", lager.Data{"query": query})
+	l.logger.Info("query-promql-api", lager.Data{"query": query})
 	result, err := l.logCacheClient.PromQL(context.Background(), query, logcache.WithPromQLTime(now))
 	if err != nil {
 		return []models.AppInstanceMetric{}, fmt.Errorf("failed getting PromQL result (metricType: %s, appId: %s, collectionInterval: %s, query: %s, time: %s): %w", metricType, appId, collectionIntervalSeconds, query, now.String(), err)
@@ -154,7 +154,7 @@ func (l *logCacheFetcher) getMetricsRestAPI(appId string, metricType string, sta
 	if err != nil {
 		return []models.AppInstanceMetric{}, fmt.Errorf("fail to Read %s metric from %s GoLogCache client: %w", logcache_v1.EnvelopeType_GAUGE, appId, err)
 	}
-	l.logger.Info("received-rest-api-result", lager.Data{"envelopes": envelopes})
+	l.logger.Debug("received-rest-api-result", lager.Data{"envelopes": envelopes})
 
 	metrics := l.envelopeProcessor.GetGaugeMetrics(envelopes, time.Now().UnixNano())
 

--- a/src/autoscaler/eventgenerator/metric/fetcher.go
+++ b/src/autoscaler/eventgenerator/metric/fetcher.go
@@ -149,12 +149,12 @@ func (l *logCacheFetcher) emptyAppInstanceMetrics(appId string, name string, uni
 func (l *logCacheFetcher) getMetricsRestAPI(appId string, metricType string, startTime time.Time, endTime time.Time) ([]models.AppInstanceMetric, error) {
 	filters := l.readOptions(endTime, metricType)
 
-	l.logger.Info("query-rest-api-with-filters", lager.Data{"appId": appId, "metricType": metricType, "startTime": startTime, "endTime": endTime, "filters": l.valuesFrom(filters)})
+	l.logger.Info("querying-rest-api-with-filters", lager.Data{"appId": appId, "metricType": metricType, "startTime": startTime, "endTime": endTime, "filters": l.valuesFrom(filters)})
 	envelopes, err := l.logCacheClient.Read(context.Background(), appId, startTime, filters...)
 	if err != nil {
 		return []models.AppInstanceMetric{}, fmt.Errorf("fail to Read %s metric from %s GoLogCache client: %w", logcache_v1.EnvelopeType_GAUGE, appId, err)
 	}
-	l.logger.Debug("received-rest-api-result", lager.Data{"envelopes": envelopes})
+	l.logger.Info("received-rest-api-result", lager.Data{"numEnvelopes": len(envelopes)})
 
 	metrics := l.envelopeProcessor.GetGaugeMetrics(envelopes, time.Now().UnixNano())
 


### PR DESCRIPTION
# Issue

Some `Info` log statements are filling up our log files.

# Fix

don't log all 1k received envelopes but just the number of envelopes