### PR TITLE
fix(db): set correct dbms short name `postgresql`

### DIFF
--- a/src/autoscaler/eventgenerator/db/dataaggregator.db.changelog.yml
+++ b/src/autoscaler/eventgenerator/db/dataaggregator.db.changelog.yml
@@ -60,7 +60,7 @@ databaseChangeLog:
   - changeSet:
       id: 3
       author: tanmoypal
-      dbms: postgres
+      dbms: postgresql
       logicalFilePath: /var/vcap/packages/eventgenerator/dataaggregator.db.changelog.yml
       changes:
         - createIndex:


### PR DESCRIPTION
# Issue

The index `index_app_metrics` was not created on PostgreSQL leading to bad performance.

# Fix

The correct `DBMS/shortname` for PostgreSQL is  `postgresql` as [documented](https://docs.liquibase.com/start/tutorials/home.html)
