### PR TITLE
fix(ci): workaround skipped jobs being considered successful

### DIFF
--- a/.github/workflows/acceptance_tests_reusable.yaml
+++ b/.github/workflows/acceptance_tests_reusable.yaml
@@ -67,6 +67,7 @@ jobs:
     name: Acceptance Tests
     needs: [ deploy_autoscaler ]
     strategy:
+      fail-fast: false
       matrix:
         suite: "${{ fromJSON(inputs.suites) }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance_tests_reusable.yaml
+++ b/.github/workflows/acceptance_tests_reusable.yaml
@@ -97,7 +97,7 @@ jobs:
   deployment_cleanup:
     needs: [ deploy_autoscaler, acceptance_tests ]
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-cleanup')"
-    name: "Result"
+    name: Cleanup
     runs-on: ubuntu-latest
     container:
       image: "${{ inputs.self_hosted_image }}"
@@ -114,3 +114,17 @@ jobs:
       - name: Perform deployment cleanup
         run: |
           make --directory="${AUTOSCALER_DIR}" deploy-cleanup
+
+  # This job will run and fail if any of the jobs it depends on fail or are cancelled.
+  # It is an "ugly workaround" for an issue on GitHub Actions side, where
+  # skipped jobs are considered successful.
+  # See https://github.com/actions/runner/issues/2566#issuecomment-1523814835
+  result:
+      needs: acceptance_tests
+      if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+      name: Result
+      runs-on: ubuntu-latest
+      steps:
+        - run: |
+            echo "Some required workflows have failed!"
+            exit 1


### PR DESCRIPTION
# Issue

Due to https://github.com/actions/runner/issues/2566 skipped "Result" jobs are considered successful checks. This breaks our PR validation.

# Fix

Introduce an ugly workaround: A new Result job that will be always skipped except when a required job fails, in which case it also fails.

# Note

We could probably improve the naming and not call it "Result" but "Acceptance test failure blocker" or something to that end, but as the branch protection is controlled via another repo, let's keep it for now until we have validated everything to work as intended.