### PR TITLE
chore(oauth): Replace deprecated `check_token` usage with `introspect`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,7 +5,6 @@ credhub 2.9.29
 cf 8.8.3
 concourse 7.10.0
 direnv 2.35.0
-gcloud 502.0.0
 ginkgo 2.22.0
 golang 1.22.5
 golangci-lint 1.62.2

--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,6 @@ alerts-silence:
 .PHONY: docker-login docker docker-image
 docker-login: target/docker-login
 target/docker-login:
-	gcloud auth login
 	docker login ghcr.io
 	@touch $@
 docker-image: docker-login

--- a/devbox.json
+++ b/devbox.json
@@ -38,7 +38,6 @@
     "yq-go":                             "4.44.5",
     "act":                               "0.2.68",
     "cloudfoundry-cli":                  "8.8.1",
-    "google-cloud-sdk":                  "latest",
     "ginkgo":                            "2.20.2",
     "golangci-lint":                     "1.62.0",
     "temurin-bin-21":                    "latest",

--- a/devbox.json
+++ b/devbox.json
@@ -39,7 +39,7 @@
     "act":                               "0.2.68",
     "cloudfoundry-cli":                  "8.8.1",
     "ginkgo":                            "2.20.2",
-    "golangci-lint":                     "1.62.0",
+    "golangci-lint":                     "1.62.2",
     "temurin-bin-21":                    "latest",
     "ruby":                              "3.3.5"
   },

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,8 +2,8 @@
   "lockfile_version": "1",
   "packages": {
     "act@0.2.68": {
-      "last_modified": "2024-11-16T04:25:12Z",
-      "resolved": "github:NixOS/nixpkgs/34a626458d686f1b58139620a8b2793e9e123bba#act",
+      "last_modified": "2024-11-28T07:51:56Z",
+      "resolved": "github:NixOS/nixpkgs/226216574ada4c3ecefcbbec41f39ce4655f78ef#act",
       "source": "devbox-search",
       "version": "0.2.68",
       "systems": {
@@ -901,51 +901,51 @@
         }
       }
     },
-    "golangci-lint@1.62.0": {
-      "last_modified": "2024-11-16T04:25:12Z",
-      "resolved": "github:NixOS/nixpkgs/34a626458d686f1b58139620a8b2793e9e123bba#golangci-lint",
+    "golangci-lint@1.62.2": {
+      "last_modified": "2024-11-28T07:51:56Z",
+      "resolved": "github:NixOS/nixpkgs/226216574ada4c3ecefcbbec41f39ce4655f78ef#golangci-lint",
       "source": "devbox-search",
-      "version": "1.62.0",
+      "version": "1.62.2",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3n3m7z2y3wsgsd69r551jqqc1zrq8lwj-golangci-lint-1.62.0",
+              "path": "/nix/store/yp07jnqgrbnvdibqz1m2i1fgj30vhd2b-golangci-lint-1.62.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/3n3m7z2y3wsgsd69r551jqqc1zrq8lwj-golangci-lint-1.62.0"
+          "store_path": "/nix/store/yp07jnqgrbnvdibqz1m2i1fgj30vhd2b-golangci-lint-1.62.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/kcp7197947lansarn4x4ddnyh8m7hw0z-golangci-lint-1.62.0",
+              "path": "/nix/store/77qnd3ix2nrb8f5vppnv1pfd35h4vz04-golangci-lint-1.62.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/kcp7197947lansarn4x4ddnyh8m7hw0z-golangci-lint-1.62.0"
+          "store_path": "/nix/store/77qnd3ix2nrb8f5vppnv1pfd35h4vz04-golangci-lint-1.62.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ymg3531fpln5b8bfwnf9gq7c1sr81f2y-golangci-lint-1.62.0",
+              "path": "/nix/store/ri36lilgaf8d4z2r96xfsk33162zrvwy-golangci-lint-1.62.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ymg3531fpln5b8bfwnf9gq7c1sr81f2y-golangci-lint-1.62.0"
+          "store_path": "/nix/store/ri36lilgaf8d4z2r96xfsk33162zrvwy-golangci-lint-1.62.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3vzfj43k05qsxdhiphw60j3gfvv6yhak-golangci-lint-1.62.0",
+              "path": "/nix/store/gr55w2x6wrzdvhhbzm4wc28cs4k7g7vr-golangci-lint-1.62.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/3vzfj43k05qsxdhiphw60j3gfvv6yhak-golangci-lint-1.62.0"
+          "store_path": "/nix/store/gr55w2x6wrzdvhhbzm4wc28cs4k7g7vr-golangci-lint-1.62.2"
         }
       }
     },
@@ -1713,9 +1713,9 @@
       }
     },
     "ruby@3.3.5": {
-      "last_modified": "2024-11-16T04:25:12Z",
+      "last_modified": "2024-11-28T07:51:56Z",
       "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/34a626458d686f1b58139620a8b2793e9e123bba#ruby",
+      "resolved": "github:NixOS/nixpkgs/226216574ada4c3ecefcbbec41f39ce4655f78ef#ruby",
       "source": "devbox-search",
       "version": "3.3.5",
       "systems": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -949,54 +949,6 @@
         }
       }
     },
-    "google-cloud-sdk@latest": {
-      "last_modified": "2024-11-22T01:27:12Z",
-      "resolved": "github:NixOS/nixpkgs/8edf06bea5bcbee082df1b7369ff973b91618b8d#google-cloud-sdk",
-      "source": "devbox-search",
-      "version": "501.0.0",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/8wq5wd1qkis3q44gvl91kdrbvmcx5rjc-google-cloud-sdk-501.0.0",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/8wq5wd1qkis3q44gvl91kdrbvmcx5rjc-google-cloud-sdk-501.0.0"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/bpdjikf06vw6q6pva89gfrnak4i9qbkd-google-cloud-sdk-501.0.0",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/bpdjikf06vw6q6pva89gfrnak4i9qbkd-google-cloud-sdk-501.0.0"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/jimm2rhh182spr2vz60k6wiqq9jwf7cr-google-cloud-sdk-501.0.0",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/jimm2rhh182spr2vz60k6wiqq9jwf7cr-google-cloud-sdk-501.0.0"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/qary2z3z06wf56aqhirxq39scz8rw0kh-google-cloud-sdk-501.0.0",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/qary2z3z06wf56aqhirxq39scz8rw0kh-google-cloud-sdk-501.0.0"
-        }
-      }
-    },
     "gopls@latest": {
       "last_modified": "2024-08-31T10:12:23Z",
       "resolved": "github:NixOS/nixpkgs/5629520edecb69630a3f4d17d3d33fc96c13f6fe#gopls",

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,6 @@
               go-tools
               golangci-lint
               gopls # See: <https://github.com/golang/vscode-go/blob/master/docs/tools.md>
-              google-cloud-sdk
               jq
               maven
               nodejs

--- a/renovate.json
+++ b/renovate.json
@@ -112,17 +112,6 @@
         "\\.tool-versions$"
       ],
       "matchStrings": [
-        "(^|\\n)gcloud (?<currentValue>.+?)\\n"
-      ],
-      "depNameTemplate": "google/cloud-sdk",
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "\\.tool-versions$"
-      ],
-      "matchStrings": [
         "(^|\\n)ginkgo (?<currentValue>.+?)\\n"
       ],
       "depNameTemplate": "onsi/ginkgo",

--- a/src/autoscaler/cf/client.go
+++ b/src/autoscaler/cf/client.go
@@ -320,7 +320,12 @@ func (c *CtxClient) introspectToken(ctx context.Context, token string) (*Introsp
 	if err != nil {
 		return nil, err
 	}
-	request.SetBasicAuth(c.conf.ClientID, c.conf.Secret)
+
+	err = c.addAuth(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
 
 	resp, err := c.Client.Do(request)
@@ -344,4 +349,14 @@ func (c *CtxClient) introspectToken(ctx context.Context, token string) (*Introsp
 	}
 
 	return introspectionResponse, nil
+}
+
+func (c *CtxClient) addAuth(ctx context.Context, req *http.Request) error {
+	tokens, err := c.GetTokens(ctx)
+	if err != nil {
+		return fmt.Errorf("get token failed: %w", err)
+	}
+
+	req.Header.Set("Authorization", TokenTypeBearer+" "+tokens.AccessToken)
+	return nil
 }

--- a/src/autoscaler/cf/mocks/mocks.go
+++ b/src/autoscaler/cf/mocks/mocks.go
@@ -158,8 +158,8 @@ func (a AddMock) UserInfo(statusCode int, testUserId string) AddMock {
 	return a
 }
 
-func (a AddMock) CheckToken(testUserScope []string) AddMock {
-	a.server.RouteToHandler(http.MethodPost, "/check_token",
+func (a AddMock) Introspect(testUserScope []string) AddMock {
+	a.server.RouteToHandler(http.MethodPost, "/introspect",
 		ghttp.RespondWithJSONEncoded(http.StatusOK,
 			struct {
 				Scope []string `json:"scope"`

--- a/src/autoscaler/cf/mocks/mocks_test.go
+++ b/src/autoscaler/cf/mocks/mocks_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Cf cloud controller", func() {
 			BeforeEach(func() {
 				testUserScope := []string{"cloud_controller.admin"}
 				mocks.Add().Info(mocks.URL())
-				mocks.Add().CheckToken(testUserScope).OauthToken("a-test-access-token")
+				mocks.Add().Introspect(testUserScope).OauthToken("a-test-access-token")
 				setCfcClient(0, mocks.URL())
 				DeferCleanup(mocks.Close)
 			})

--- a/src/autoscaler/cf/oauth_test.go
+++ b/src/autoscaler/cf/oauth_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Oauth", func() {
 		fakeCCServer = mocks.NewServer()
 		fakeTokenServer = mocks.NewServer()
 		fakeTokenServer.RouteToHandler(http.MethodGet, "/userinfo", ghttp.RespondWithJSONEncodedPtr(&userInfoStatus, &userInfoResponse))
-		fakeTokenServer.RouteToHandler(http.MethodPost, "/check_token", ghttp.RespondWithJSONEncodedPtr(&userScopeStatus, &userScopeResponse))
+		fakeTokenServer.RouteToHandler(http.MethodPost, "/introspect", ghttp.RespondWithJSONEncodedPtr(&userScopeStatus, &userScopeResponse))
 		fakeTokenServer.RouteToHandler("POST", cf.PathCFAuth, ghttp.RespondWithJSONEncoded(http.StatusOK, cf.Tokens{
 			AccessToken: "test-access-token",
 			ExpiresIn:   12000,
@@ -265,13 +265,13 @@ var _ = Describe("Oauth", func() {
 			It("should return false", func() {
 				Expect(isUserAdminFlag).To(BeFalse())
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("Failed to get user scope, statusCode : 400"))
+				Expect(err).To(MatchError(ContainSubstring("400")))
 			})
 		})
 
 		Context("userscope response is not in json format", func() {
 			BeforeEach(func() {
-				fakeTokenServer.RouteToHandler(http.MethodPost, "/check_token", ghttp.RespondWith(http.StatusOK, "non-json-response"))
+				fakeTokenServer.RouteToHandler(http.MethodPost, "/introspect", ghttp.RespondWith(http.StatusOK, "non-json-response"))
 			})
 			It("should error", func() {
 				Expect(isUserAdminFlag).To(BeFalse())

--- a/src/autoscaler/integration/integration_golangapi_eventgenerator_test.go
+++ b/src/autoscaler/integration/integration_golangapi_eventgenerator_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Integration_GolangApi_EventGenerator", func() {
 			BeforeEach(func() {
 				fakeCCNOAAUAA.Reset()
 				fakeCCNOAAUAA.AllowUnhandledRequests = true
-				fakeCCNOAAUAA.Add().Info(fakeCCNOAAUAA.URL()).CheckToken(testUserScope).UserInfo(http.StatusUnauthorized, "ERR")
+				fakeCCNOAAUAA.Add().Info(fakeCCNOAAUAA.URL()).Introspect(testUserScope).UserInfo(http.StatusUnauthorized, "ERR")
 			})
 			It("should error with status code 401", func() {
 				checkPublicAPIResponseContentWithParameters(getAppAggregatedMetrics, components.Ports[GolangAPIServer], pathVariables,

--- a/src/autoscaler/integration/integration_golangapi_scalingengine_test.go
+++ b/src/autoscaler/integration/integration_golangapi_scalingengine_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Integration_GolangApi_ScalingEngine", func() {
 			BeforeEach(func() {
 				fakeCCNOAAUAA.Reset()
 				fakeCCNOAAUAA.AllowUnhandledRequests = true
-				fakeCCNOAAUAA.Add().Info(fakeCCNOAAUAA.URL()).CheckToken(testUserScope).UserInfo(http.StatusUnauthorized, "ERR")
+				fakeCCNOAAUAA.Add().Info(fakeCCNOAAUAA.URL()).Introspect(testUserScope).UserInfo(http.StatusUnauthorized, "ERR")
 				parameters = map[string]string{"start-time": "1111", "end-time": "9999", "order-direction": "desc", "page": "1", "results-per-page": "5"}
 			})
 			It("should error with status code 401", func() {

--- a/src/autoscaler/integration/integration_golangapi_scheduler_test.go
+++ b/src/autoscaler/integration/integration_golangapi_scheduler_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Integration_GolangApi_Scheduler", func() {
 			BeforeEach(func() {
 				fakeCCNOAAUAA.Reset()
 				fakeCCNOAAUAA.AllowUnhandledRequests = true
-				fakeCCNOAAUAA.Add().Info(fakeCCNOAAUAA.URL()).CheckToken(testUserScope).UserInfo(http.StatusUnauthorized, "ERR")
+				fakeCCNOAAUAA.Add().Info(fakeCCNOAAUAA.URL()).Introspect(testUserScope).UserInfo(http.StatusUnauthorized, "ERR")
 			})
 			Context("Create policy", func() {
 				It("should error with status code 401", func() {

--- a/src/autoscaler/integration/integration_suite_test.go
+++ b/src/autoscaler/integration/integration_suite_test.go
@@ -726,6 +726,6 @@ func startFakeCCNOAAUAA(instanceCount int) {
 		ServicePlan("autoscaler-free-plan-id").
 		Info(fakeCCNOAAUAA.URL()).
 		OauthToken(testUserToken).
-		CheckToken(testUserScope).
+		Introspect(testUserScope).
 		UserInfo(http.StatusOK, testUserId)
 }


### PR DESCRIPTION
# Issue

UAA has deprecated the `check_token` endpoint and recommends using the
`introspect` endpoint:
https://docs.cloudfoundry.org/api/uaa/version/77.19.0/index.html#check-token

# Fix 

- **chore(oauth): Replace deprecated `check_token` usage with `introspect`**

# Also

- **chore(devbox): Remove superfluous `google-cloud-sdk`**
There's no need for  `google-cloud-sdk` in this repo, accessing the CI environment cloud provider this should happen through the `app-runtime-interface-wg` repo.