### PR TITLE
chore(devbox): Introduce special nix flake for devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,10 +1,10 @@
 {
   "packages": {
-    "path:.#bosh-bootloader":            "",
-    "path:.#app-autoscaler-cli-plugin":  "",
-    "path:.#log-cache-cli-plugin":       "",
-    "path:.#cloud-mta-build-tool":       "",
-    "path:.#uaac":                       "",
+    "path:./nix#bosh-bootloader":            "",
+    "path:./nix#app-autoscaler-cli-plugin":  "",
+    "path:./nix#log-cache-cli-plugin":       "",
+    "path:./nix#cloud-mta-build-tool":       "",
+    "path:./nix#uaac":                       "",
     "bosh-cli":                          "7.3.1",
     "bundix":                            "latest",
     "coreutils":                         "latest",

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733015953,
+        "narHash": "sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE+crk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac35b104800bff9028425fec3b6e8a41de2bbfff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-bosh-cli-v7-3-1": {
+      "locked": {
+        "lastModified": 1689621684,
+        "narHash": "sha256-a7nGZZezo5s3STRCHl5e73eNTmU/Zg/QcrtzyrfZ5Qg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1179c6c3705509ba25bd35196fca507d2a227bd0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1179c6c3705509ba25bd35196fca507d2a227bd0",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-bosh-cli-v7-3-1": "nixpkgs-bosh-cli-v7-3-1"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Extra dependencies of app-autoscaler-release for the devbox";
+
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
+    nixpkgs-bosh-cli-v7-3-1.url = github:NixOS/nixpkgs/1179c6c3705509ba25bd35196fca507d2a227bd0;
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-bosh-cli-v7-3-1 }:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+      nixpkgsFor-bosh-cli-v7-3-1 = forAllSystems (system: import nixpkgs-bosh-cli-v7-3-1 { inherit system; });
+    in {
+      packages = forAllSystems (system:
+        let
+          nixpkgs = nixpkgsFor.${system};
+          callPackages = nixpkgs.lib.customisation.callPackagesWith nixpkgs;
+        in callPackages ./packages.nix {}
+      );
+  };
+}


### PR DESCRIPTION
# Issue

Using the main flake for the devbox is slow as the nix commands executed via devbox have to copy around the main repo:

```
$ nix --extra-experimental-features ca-derivations --option experimental-features 'nix-command flakes fetch-closure' search 'path:/home/mysuser/app-autoscaler-release#cloud-mta-build-tool' ^ --json

copying '/home/myuser/as/app-autoscaler-release'
```

# Fix

Use a special nix flake in a subdirectory where copying it is fast.
