### PR TITLE
Use Correct Type Upon Binding Retrieval

### DIFF
--- a/src/autoscaler/api/broker/broker_test.go
+++ b/src/autoscaler/api/broker/broker_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Broker", func() {
 				})
 				It("returns the Binding with parameters", func() {
 					Expect(err).To(BeNil())
-					Expect(Binding).To(Equal(domain.GetBindingSpec{Parameters: scalingPolicy}))
+					Expect(Binding).To(Equal(domain.GetBindingSpec{Parameters: &models.ScalingPolicyWithBindingConfig{ScalingPolicy: *scalingPolicy, BindingConfig: nil}}))
 				})
 			})
 			Context("with configuration and policy", func() {

--- a/src/autoscaler/models/binding_configs.go
+++ b/src/autoscaler/models/binding_configs.go
@@ -56,17 +56,19 @@ func (b *BindingConfig) SetCustomMetricsStrategy(allowFrom string) {
  * @throws an error if no policy or custom metrics strategy is found
 */
 
-func GetBindingConfigAndPolicy(scalingPolicy *ScalingPolicy, customMetricStrategy string) (interface{}, error) {
+func GetBindingConfigAndPolicy(scalingPolicy *ScalingPolicy, customMetricStrategy string) (*ScalingPolicyWithBindingConfig, error) {
 	if scalingPolicy == nil {
 		return nil, fmt.Errorf("policy not found")
 	}
 	if customMetricStrategy != "" && customMetricStrategy != CustomMetricsSameApp { //if customMetricStrategy found
-		return buildCombinedConfig(scalingPolicy, customMetricStrategy), nil
+		return buildPolicyAndConfig(scalingPolicy, customMetricStrategy), nil
 	}
-	return scalingPolicy, nil
+	return &ScalingPolicyWithBindingConfig{
+		ScalingPolicy: *scalingPolicy,
+	}, nil
 }
 
-func buildCombinedConfig(scalingPolicy *ScalingPolicy, customMetricStrategy string) *ScalingPolicyWithBindingConfig {
+func buildPolicyAndConfig(scalingPolicy *ScalingPolicy, customMetricStrategy string) *ScalingPolicyWithBindingConfig {
 	bindingConfig := &BindingConfig{}
 	bindingConfig.SetCustomMetricsStrategy(customMetricStrategy)
 

--- a/src/autoscaler/models/binding_configs_test.go
+++ b/src/autoscaler/models/binding_configs_test.go
@@ -71,7 +71,7 @@ var _ = Describe("BindingConfigs", func() {
 
 			It("should return scaling policy", func() {
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(scalingPolicy))
+				Expect(result).To(Equal(&ScalingPolicyWithBindingConfig{ScalingPolicy: *scalingPolicy, BindingConfig: nil}))
 			})
 		})
 


### PR DESCRIPTION

**Fix**

Use Correct Type upon retrieval of binding