### PR TITLE
chore(renovate): Disable OpenTelementry SDK updates

### DIFF
--- a/.github/workflows/renovate_config_validation.yaml
+++ b/.github/workflows/renovate_config_validation.yaml
@@ -1,0 +1,22 @@
+name: Renovate Config validation
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches:
+      - main
+    paths:
+      - .github/workflows/renovate_config_validation.yaml
+      - renovate.json
+
+jobs:
+  renovate-config-validation:
+    runs-on: ubuntu-latest
+    name: Validate the Renovate configuration
+    steps:
+      - name: Validate the Renovate JSON
+        run: |
+          set -euxo pipefail
+          npx --yes --package renovate -- renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -50,11 +50,13 @@
       ]
     },
     {
-      "description": "Group OpenTelemetry updates together",
+      "description": "Disable OpenTelemetry-relevant updates",
       "groupName": "opentelemetry",
       "matchPackageNames": [
-        "/opentelemetry/"
-      ]
+        "/opentelemetry/",
+        "/ogen-go/ogen/"
+      ],
+      "enabled": false
     },
     {
       "description": "Group Cloud Foundry Logging and Metrics updates together",


### PR DESCRIPTION
# Issue

Updating the OpenTelemetry SDK can break consumers of OpenTelemetry
tracing data such as Dynatrace if they do not support the SDK version.

# Fix

For now disable updates through Renovate.

# Note

As soon as the supported versions are documented we can addd some
automation back to update to the latest supported versions.
