### PR TITLE
Check – before creating an index for the app-metrics – if it is already there.

### DIFF
--- a/src/autoscaler/eventgenerator/db/dataaggregator.db.changelog.yml
+++ b/src/autoscaler/eventgenerator/db/dataaggregator.db.changelog.yml
@@ -76,6 +76,11 @@ databaseChangeLog:
                   type: bigint
             indexName: index_app_metrics
             tableName: app_metric
+      preConditions:
+       - onFail: MARK_RAN
+       - not:
+         - indexExists:
+             indexName: index_app_metrics
   - changeSet:
       id: 4
       author: byang


### PR DESCRIPTION
Under certain cases, it may happen that pgaudit on older PostgreSQL-versions gets an internal error when creating the app-metrics-index for the eventgenerator. This change checks, if it is actually needed in advance. This makes a manual fix easy by just creating the index e.g. with psql.