### PR TITLE
chore(scheduler): Replace deprectated Mockito annotations

### DIFF
--- a/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/dao/ActiveScheduleDaoImplFailureTest.java
+++ b/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/dao/ActiveScheduleDaoImplFailureTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -24,7 +24,7 @@ public class ActiveScheduleDaoImplFailureTest {
 
   @Autowired private ActiveScheduleDao activeScheduleDao;
 
-  @SpyBean private DataSource dataSource;
+  @MockitoSpyBean private DataSource dataSource;
 
   @Autowired TestDataDbUtil testDataDbUtil;
 

--- a/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/quartz/AppScalingScheduleJobTest.java
+++ b/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/quartz/AppScalingScheduleJobTest.java
@@ -47,10 +47,10 @@ import org.quartz.impl.StdSchedulerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestOperations;
@@ -62,9 +62,9 @@ public class AppScalingScheduleJobTest {
   private static EmbeddedTomcatUtil embeddedTomcatUtil;
   @Autowired private MessageBundleResourceHelper messageBundleResourceHelper;
   private Scheduler memScheduler;
-  @MockBean private Scheduler scheduler;
-  @MockBean private ActiveScheduleDao activeScheduleDao;
-  @SpyBean private RestOperations restOperations;
+  @MockitoBean private Scheduler scheduler;
+  @MockitoBean private ActiveScheduleDao activeScheduleDao;
+  @MockitoSpyBean private RestOperations restOperations;
   @Autowired private TestDataDbUtil testDataDbUtil;
   @Autowired private ApplicationContext applicationContext;
 

--- a/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestControllerTest.java
+++ b/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleRestControllerTest.java
@@ -38,10 +38,10 @@ import org.quartz.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -54,9 +54,9 @@ import org.springframework.web.context.WebApplicationContext;
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 public class ScheduleRestControllerTest {
 
-  @MockBean private Scheduler scheduler;
+  @MockitoBean private Scheduler scheduler;
 
-  @MockBean private ActiveScheduleDao activeScheduleDao;
+  @MockitoBean private ActiveScheduleDao activeScheduleDao;
 
   @Autowired private SpecificDateScheduleDao specificDateScheduleDao;
 

--- a/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleSyncRestControllerTest.java
+++ b/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/rest/ScheduleSyncRestControllerTest.java
@@ -21,9 +21,9 @@ import org.quartz.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -35,9 +35,9 @@ import org.springframework.web.context.WebApplicationContext;
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 public class ScheduleSyncRestControllerTest {
 
-  @MockBean private Scheduler scheduler;
+  @MockitoBean private Scheduler scheduler;
 
-  @MockBean private ActiveScheduleDao activeScheduleDao;
+  @MockitoBean private ActiveScheduleDao activeScheduleDao;
 
   @Autowired private TestDataDbUtil testDataDbUtil;
 

--- a/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleJobManagerTest.java
+++ b/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleJobManagerTest.java
@@ -55,16 +55,16 @@ import org.quartz.Trigger;
 import org.quartz.TriggerKey;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class ScheduleJobManagerTest {
 
-  @MockBean private Scheduler scheduler;
+  @MockitoBean private Scheduler scheduler;
 
-  @MockBean private ActiveScheduleDao activeScheduleDao;
+  @MockitoBean private ActiveScheduleDao activeScheduleDao;
 
   @Autowired private ScheduleJobManager scheduleJobManager;
 

--- a/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManagerTest.java
+++ b/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManagerTest.java
@@ -58,10 +58,10 @@ import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -75,15 +75,15 @@ public class ScheduleManagerTest {
 
   @Autowired private ScheduleManager scheduleManager;
 
-  @MockBean private PolicyJsonDao policyJsonDao;
+  @MockitoBean private PolicyJsonDao policyJsonDao;
 
-  @MockBean private SpecificDateScheduleDao specificDateScheduleDao;
+  @MockitoBean private SpecificDateScheduleDao specificDateScheduleDao;
 
-  @MockBean private RecurringScheduleDao recurringScheduleDao;
+  @MockitoBean private RecurringScheduleDao recurringScheduleDao;
 
-  @MockBean private ActiveScheduleDao activeScheduleDao;
+  @MockitoBean private ActiveScheduleDao activeScheduleDao;
 
-  @MockBean private ScheduleJobManager scheduleJobManager;
+  @MockitoBean private ScheduleJobManager scheduleJobManager;
 
   @Autowired private MessageBundleResourceHelper messageBundleResourceHelper;
 
@@ -91,7 +91,7 @@ public class ScheduleManagerTest {
 
   @Autowired private TestDataDbUtil testDataDbUtil;
 
-  @SpyBean private RestOperations restOperations;
+  @MockitoSpyBean private RestOperations restOperations;
 
   @Value("${autoscaler.scalingengine.url}")
   private String scalingEngineUrl;


### PR DESCRIPTION
# Issue

```
Warning:  /__w/app-autoscaler-release/app-autoscaler-release/src/scheduler/src/test/java/org/cloudfoundry/autoscaler/scheduler/service/ScheduleManagerTest.java:[94,4] org.springframework.boot.test.mock.mockito.SpyBean in org.springframework.boot.test.mock.mockito has been deprecated and marked for removal

```

# Fix

Run [Replace `@MockBean` and `@SpyBean`
](https://docs.openrewrite.org/recipes/java/boot3/replacemockbeanandspybean) OpenRewrite recipe:

```
$ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:RELEASE -Drewrite.exportDatatables=true -Drewrite.activeRecipes=org.openrewrite.java.spring.boot3.ReplaceMockBeanAndSpyBean
...
Estimate time saved: 30m
```
