### PR TITLE
 Fix failing case in publicapi test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ blobs
 *.swp
 src/changeloglockcleaner/vendor
 **/coverprofile.out
+**/ginkgo.report
 **/coverprofile.out.*
 **/pom.xml.versionsBackup
 bosh-lite/deployments/*

--- a/src/autoscaler/api/publicapiserver/middleware_test.go
+++ b/src/autoscaler/api/publicapiserver/middleware_test.go
@@ -1,6 +1,7 @@
 package publicapiserver_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -258,3 +259,19 @@ var _ = Describe("Middleware", func() {
 	})
 
 })
+
+func GetTestHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("Success"))
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func CheckResponse(resp *httptest.ResponseRecorder, statusCode int, errResponse models.ErrorResponse) {
+	GinkgoHelper()
+	Expect(resp.Code).To(Equal(statusCode))
+	var errResp models.ErrorResponse
+	err := json.NewDecoder(resp.Body).Decode(&errResp)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(errResp).To(Equal(errResponse))
+}

--- a/src/autoscaler/api/publicapiserver/public_api_server_test.go
+++ b/src/autoscaler/api/publicapiserver/public_api_server_test.go
@@ -398,6 +398,7 @@ var _ = Describe("PublicApiServer", func() {
 					BeforeEach(func() {
 						eventGeneratorStatus = http.StatusOK
 					})
+
 					It("should succeed", func() {
 						verifyResponse(httpClient, serverUrl, "/v1/apps/"+TEST_APP_ID+"/aggregated_metric_histories/"+TEST_METRIC_TYPE,
 							map[string]string{"Authorization": TEST_USER_TOKEN, "X-Autoscaler-Token": TEST_CLIENT_TOKEN}, http.MethodGet, "", http.StatusOK)

--- a/src/autoscaler/helpers/httpclient.go
+++ b/src/autoscaler/helpers/httpclient.go
@@ -60,10 +60,10 @@ func (t *TLSReloadTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 	// Checks for cert validity within 5m timeframe. See https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html
 	if t.certificateExpiringWithin(5 * time.Minute) {
-		t.logger.Debug("reloading-cert", lager.Data{"request": req})
+		t.logger.Debug("reloading-cert")
 		t.reloadCert()
 	} else {
-		t.logger.Debug("cert-not-expiring", lager.Data{"request": req})
+		t.logger.Debug("cert-not-expiring")
 	}
 
 	return t.Base.RoundTrip(req)


### PR DESCRIPTION
 - Add `ginkgo.report` to .gitignore
 - Introduce `GetTestHandler` and `CheckResponse` functions in middleware tests
 - Remove duplicated test utility functions from `publicapiserver_suite_test.go`
 - Add missing stub routes for eventgenerator
 - Adjust logging in `TLSReloadTransport` to exclude request data