### PR TITLE
fix(operator): continue deletion of non-existent application records on error

### DIFF
--- a/.github/workflows/acceptance_tests_broker.yaml
+++ b/.github/workflows/acceptance_tests_broker.yaml
@@ -1,7 +1,7 @@
 name: Acceptance Tests - BOSH release
 on:
   pull_request:
-    types: [ opened, labeled, synchronize ]
+    types: [ opened, synchronize ]
 
 concurrency:
   group: "${{ github.workflow }}/${{ github.ref }}"

--- a/src/autoscaler/operator/applicationsyncer.go
+++ b/src/autoscaler/operator/applicationsyncer.go
@@ -49,8 +49,7 @@ func (as ApplicationSynchronizer) Operate(ctx context.Context) {
 				err = as.policyDb.DeletePolicy(ctx, appID)
 				if err != nil {
 					as.logger.Error("failed-to-prune-non-existent-application-details", err)
-					//TODO make this a continue and write a test.
-					return
+					continue
 				}
 				as.logger.Info("successfully-pruned-non-existent-application", lager.Data{"appid": appID})
 			}


### PR DESCRIPTION
# Issue

We exit early rather than continuing over the rest of the list. This could cause a single continuous failure in the db to create a buildup of autoscaler policies without apps.

# Fix

Continue instead.

Fixes: #837

# Also takes care of:

## Issue

Acceptance tests were retriggered by labeling.

## Fix

Remove `labeled` trigger.
