### PR TITLE
 Update GitHub Actions workflow and Devbox configuration for Java linting

### DIFF
--- a/.github/workflows/java-ci-lint.yaml
+++ b/.github/workflows/java-ci-lint.yaml
@@ -16,11 +16,17 @@ concurrency:
 jobs:
   code-style:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/cloudfoundry/app-autoscaler-release-tools:main@sha256:a850ee87a32ae11003e1343714b8af06d2be377744510472601f3ff4b153968e
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
+      - name: Get Repository content
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@975fb35b9a6472bed4edf51e5db534d5efec2817 # v0.12.0
+        with:
+          enable-cache: 'true'
+      - name: Make devbox shellenv available
+        run: |
+          eval "$(devbox shellenv)"
+          printenv >> "$GITHUB_ENV"
       - name: Check Code Formatting
         run: |
           sh ./style-guide/google-format-ci-v0.1.sh

--- a/devbox.json
+++ b/devbox.json
@@ -39,7 +39,8 @@
     "cloudfoundry-cli":                     "8.8.1",
     "go":                                   "1.23.0",
     "temurin-bin-21":                       "latest",
-    "redocly":                              "latest"
+    "redocly":                              "latest",
+    "google-java-format":                   "latest"
   },
   "shell": {
     "init_hook": [

--- a/devbox.lock
+++ b/devbox.lock
@@ -949,6 +949,54 @@
         }
       }
     },
+    "google-java-format@latest": {
+      "last_modified": "2025-01-25T23:17:58Z",
+      "resolved": "github:NixOS/nixpkgs/b582bb5b0d7af253b05d58314b85ab8ec46b8d19#google-java-format",
+      "source": "devbox-search",
+      "version": "1.25.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rh260il5bm08n5zmvc92lq3p3xlh9d7i-google-java-format-1.25.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/rh260il5bm08n5zmvc92lq3p3xlh9d7i-google-java-format-1.25.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i416b4p5icb1r8fcgkhsjx2f9mrhsd0i-google-java-format-1.25.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i416b4p5icb1r8fcgkhsjx2f9mrhsd0i-google-java-format-1.25.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8ag9xqp04ybppz8ijbvy4i221q5cyd7h-google-java-format-1.25.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8ag9xqp04ybppz8ijbvy4i221q5cyd7h-google-java-format-1.25.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ysq79irjjk4bbc4zl9my0739xs81mfj6-google-java-format-1.25.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ysq79irjjk4bbc4zl9my0739xs81mfj6-google-java-format-1.25.2"
+        }
+      }
+    },
     "gopls@latest": {
       "last_modified": "2024-08-31T10:12:23Z",
       "resolved": "github:NixOS/nixpkgs/5629520edecb69630a3f4d17d3d33fc96c13f6fe#gopls",

--- a/src/scheduler/Makefile
+++ b/src/scheduler/Makefile
@@ -12,5 +12,4 @@ format:
 # Check if files need formatting without modifying them
 check-format:
 	@echo "Checking Java file formatting..."
-	echo "$(JAVA_FILES)"
 	@$(FORMATTER) --skip-javadoc-formatting --dry-run $(JAVA_FILES)

--- a/src/scheduler/Makefile
+++ b/src/scheduler/Makefile
@@ -1,0 +1,16 @@
+# Define the Java formatter command using Devbox
+FORMATTER = devbox run google-java-format
+JAVA_FILES = $(shell find . -name "*.java" -print | xargs realpath)
+
+.PHONY: format check-format install
+
+# Format all Java files in the src/ directory
+format:
+	@echo "Formatting Java files..."
+	@$(FORMATTER) --skip-javadoc-formatting --replace $(JAVA_FILES)
+
+# Check if files need formatting without modifying them
+check-format:
+	@echo "Checking Java file formatting..."
+	echo "$(JAVA_FILES)"
+	@$(FORMATTER) --skip-javadoc-formatting --dry-run $(JAVA_FILES)


### PR DESCRIPTION
 - Remove use of app autoscaler release 
 - Add steps to install Devbox and make its shell environment available
 - Add google-java-format to devbox
 - Create new Makefile in src/scheduler for Java formatting and checking