### PR TITLE
fix(mta): Ensure apps can be staged in air gapped environments

### DIFF
--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -8,6 +8,7 @@ DEST ?= /tmp/build
 MTAR_FILENAME ?= app-autoscaler-release-v$(VERSION).mtar
 
 GO_VERSION = $(shell go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/')
+GO_MINOR_VERSION = $(shell echo $(GO_VERSION) | cut --delimiter=. --field=2)
 GO_DEPENDENCIES = $(shell find . -type f -name '*.go')
 PACKAGE_DIRS = $(shell go list './...' | grep --invert-match --regexp='/vendor/' \
 								 | grep --invert-match --regexp='e2e')
@@ -176,7 +177,8 @@ mta-logs:
 mta-build: mta-build-clean
 	@echo "building mtar file for version: $(VERSION)"
 	cp mta.tpl.yaml mta.yaml
-	sed -i 's/VERSION/$(VERSION)/g' mta.yaml
+	sed --in-place 's/MTA_VERSION/$(VERSION)/g' mta.yaml
+	sed --in-place 's/GO_MINOR_VERSION/$(GO_MINOR_VERSION)/g' mta.yaml
 	mkdir -p $(DEST)
 	mbt build -t /tmp --mtar $(MTAR_FILENAME)
 	@mv /tmp/$(MTAR_FILENAME) $(DEST)/$(MTAR_FILENAME)

--- a/src/autoscaler/mta.tpl.yaml
+++ b/src/autoscaler/mta.tpl.yaml
@@ -3,15 +3,17 @@ description: Application Autoscaler Release for Cloud Foundry
 _schema-version: "3.3.0"
 provider: Cloud Foundry Foundation
 copyright: Apache License 2.0
-version: VERSION
+version: MTA_VERSION
 
 modules:
   - name: metricsforwarder
     type: go
     path: .
     properties:
-      GO_INSTALL_PACKAGE_SPEC: code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cmd/metricsforwarder
       DT_RELEASE_BUILD_VERSION: ${mta-version}
+      GO_INSTALL_PACKAGE_SPEC: code.cloudfoundry.org/app-autoscaler/src/autoscaler/metricsforwarder/cmd/metricsforwarder
+      GOTOOLCHAIN: local
+      GOVERSION: go1.GO_MINOR_VERSION
     requires:
     - name: metricsforwarder-config
     - name: database
@@ -32,7 +34,10 @@ modules:
     type: go
     path: .
     properties:
+      DT_RELEASE_BUILD_VERSION: ${mta-version}
       GO_INSTALL_PACKAGE_SPEC: code.cloudfoundry.org/app-autoscaler/src/autoscaler/api/cmd/api
+      GOTOOLCHAIN: local
+      GOVERSION: go1.GO_MINOR_VERSION
     requires:
     - name: publicapiserver-config
     - name: database


### PR DESCRIPTION
# Issue

If the default version of the Go toolchain in the Go buildpack was not sufficient for the code to compile, during staging a call to the internet would be made to download the appropriate version. This would fail in air gapped environments.

# Fix

Set `GOTOOLCHAIN=local` and the appropriate `GOVERSION`