### PR TITLE
chore(renovate): disable Go version updates in devbox

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,16 @@
       "enabled": false
     },
     {
+      "description": "Disable devbox Go version updates, as they are taken care by our bosh-package-golang-release-based automation",
+      "matchManagers": [
+        "devbox"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Strip of v prefix from version number in certain github releases",
       "matchPackageNames": [
         "bosh-cli"


### PR DESCRIPTION
# Issue

Now that Renovate supports `devbox` we need to disable the automatic update of Go here as well.

# Fix

Disable `go` version updates in `devbox`.
