### PR TITLE
chore(renovate): Also run during office hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
     "config:best-practices",
     "customManagers:dockerfileVersions",
     ":label(dependencies)",
-    ":automergeAll",
-    "schedule:nonOfficeHours"
+    ":automergeAll"
   ],
   "postUpdateOptions": [
     "gomodTidy",


### PR DESCRIPTION
# Issue

Previously we decided to not run renovate during office hours to reserve the limited GitHub actions runners capacity for our own PRs, which on the other hand makes our automated dependency updates slower and less reactive.

With the [enablement of GitHub Enterprise Cloud](https://cloudfoundry.slack.com/archives/C026XJGNC2U/p1739319963575719) we among other benefits get
> 50,000 GitHub Actions minutes per month  instead of 2,000

so we should be good to enable renovate PRs during office hours.

# Fix

Remove `nonOfficeHours` preset.