### PR TITLE
feat(scalingengine): Use cf scalingengine in golangapi

### DIFF
--- a/src/autoscaler/api/config/config.go
+++ b/src/autoscaler/api/config/config.go
@@ -217,8 +217,15 @@ func loadVcapConfig(conf *Config, vcapReader configutil.VCAPConfigurationReader)
 
 	configureEventGenerator(conf)
 	configureScheduler(conf)
+	configureScalingEngine(conf)
 
 	return nil
+}
+
+func configureScalingEngine(conf *Config) {
+	conf.ScalingEngine.TLSClientCerts.CACertFile = os.Getenv("CF_INSTANCE_CERT")
+	conf.ScalingEngine.TLSClientCerts.CertFile = os.Getenv("CF_INSTANCE_CERT")
+	conf.ScalingEngine.TLSClientCerts.KeyFile = os.Getenv("CF_INSTANCE_KEY")
 }
 
 func configureEventGenerator(conf *Config) {

--- a/src/autoscaler/api/config/config_test.go
+++ b/src/autoscaler/api/config/config_test.go
@@ -71,36 +71,44 @@ var _ = Describe("Config", func() {
 
 			When("vcap CF_INSTANCE_CERT is set", func() {
 				BeforeEach(func() {
-					os.Setenv("CF_INSTANCE_KEY", "some/path/in/container/eventgenerator.key")
-					os.Setenv("CF_INSTANCE_CERT", "some/path/in/container/eventgenerator.crt")
+					os.Setenv("CF_INSTANCE_KEY", "some/path/in/container/cfcert.key")
+					os.Setenv("CF_INSTANCE_CERT", "some/path/in/container/cfcert.crt")
 				})
 
 				AfterEach(func() {
 					os.Unsetenv("CF_INSTANCE_KEY")
 					os.Unsetenv("CF_INSTANCE_CERT")
-
 				})
 
 				It("sets EventGenerator TlSClientCert", func() {
-					Expect(conf.EventGenerator.TLSClientCerts.KeyFile).To(Equal("some/path/in/container/eventgenerator.key"))
-					Expect(conf.EventGenerator.TLSClientCerts.CertFile).To(Equal("some/path/in/container/eventgenerator.crt"))
+					Expect(conf.EventGenerator.TLSClientCerts.KeyFile).To(Equal("some/path/in/container/cfcert.key"))
+					Expect(conf.EventGenerator.TLSClientCerts.CertFile).To(Equal("some/path/in/container/cfcert.crt"))
+					Expect(conf.EventGenerator.TLSClientCerts.CACertFile).To(Equal("some/path/in/container/cfcert.crt"))
 				})
 
 				It("sets Scheduler TlSClientCert", func() {
-					Expect(conf.Scheduler.TLSClientCerts.KeyFile).To(Equal("some/path/in/container/eventgenerator.key"))
-					Expect(conf.Scheduler.TLSClientCerts.CertFile).To(Equal("some/path/in/container/eventgenerator.crt"))
-				})
-			})
-
-			When("vcap PORT is set to a number", func() {
-				BeforeEach(func() {
-					mockVCAPConfigurationReader.GetPortReturns(3333)
+					Expect(conf.Scheduler.TLSClientCerts.KeyFile).To(Equal("some/path/in/container/cfcert.key"))
+					Expect(conf.Scheduler.TLSClientCerts.CertFile).To(Equal("some/path/in/container/cfcert.crt"))
+					Expect(conf.Scheduler.TLSClientCerts.CACertFile).To(Equal("some/path/in/container/cfcert.crt"))
 				})
 
-				It("sets env variable over config file", func() {
-					Expect(err).NotTo(HaveOccurred())
-					Expect(conf.VCAPServer.Port).To(Equal(3333))
+				It("sets ScalingEngine TlSClientCert", func() {
+					Expect(conf.ScalingEngine.TLSClientCerts.KeyFile).To(Equal("some/path/in/container/cfcert.key"))
+					Expect(conf.ScalingEngine.TLSClientCerts.CertFile).To(Equal("some/path/in/container/cfcert.crt"))
+					Expect(conf.ScalingEngine.TLSClientCerts.CACertFile).To(Equal("some/path/in/container/cfcert.crt"))
 				})
+
+				When("vcap PORT is set to a number", func() {
+					BeforeEach(func() {
+						mockVCAPConfigurationReader.GetPortReturns(3333)
+					})
+
+					It("sets env variable over config file", func() {
+						Expect(err).NotTo(HaveOccurred())
+						Expect(conf.VCAPServer.Port).To(Equal(3333))
+					})
+				})
+
 			})
 
 			When("service is empty", func() {


### PR DESCRIPTION
Add TLS client cert configuration for ScalingEngine in api component:
 • Implement configureScalingEngine function to set TLS client certificates for the ScalingEngine using CF environment variables.
 • Add test cases to verify TLS client cert configuration for ScalingEngine.