### PR TITLE
Optionally allow seconds in start_time and end_time

### DIFF
--- a/src/autoscaler/api/policyvalidator/policy_json.schema.json
+++ b/src/autoscaler/api/policyvalidator/policy_json.schema.json
@@ -764,13 +764,13 @@
                 "$id": "#/properties/schedules/properties/recurring_schedule/items/properties/start_time",
                 "type": "string",
                 "title": "The Start_time Schema",
-                "pattern": "^(2[0-3]|1[0-9]|0[0-9]):([0-5][0-9])$"
+                "pattern": "^(2[0-3]|1[0-9]|0[0-9]):([0-5][0-9])(:([0-5][0-9]))?$"
               },
               "end_time": {
                 "$id": "#/properties/schedules/properties/recurring_schedule/items/properties/end_time",
                 "type": "string",
                 "title": "The End_time Schema",
-                "pattern": "^(2[0-3]|1[0-9]|0[0-9]):([0-5][0-9])$"
+                "pattern": "^(2[0-3]|1[0-9]|0[0-9]):([0-5][0-9])(:([0-5][0-9]))?$"
               },
               "days_of_week": {
                 "$id": "#/properties/schedules/properties/recurring_schedule/items/properties/days_of_week",

--- a/src/autoscaler/api/policyvalidator/policy_validator.go
+++ b/src/autoscaler/api/policyvalidator/policy_validator.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	DateTimeLayout = "2006-01-02T15:04"
-	DateLayout     = "2006-01-02"
-	TimeLayout     = "15:04"
+	DateTimeSecondsLayout = "2006-01-02T15:04:05"
+	DateTimeLayout        = "2006-01-02T15:04"
+	DateLayout            = "2006-01-02"
+	TimeLayout            = "15:04"
 )
 
 type (
@@ -66,9 +67,18 @@ func (v ValidationErrors) Error() string {
 func newDateTimeRange(startDateTime string, endDateTime string, timezone string) *DateTimeRange {
 	location, _ := time.LoadLocation(timezone)
 	dateTimeRange := DateTimeRange{}
-	dateTimeRange.startDateTime, _ = time.ParseInLocation(DateTimeLayout, startDateTime, location)
-	dateTimeRange.endDateTime, _ = time.ParseInLocation(DateTimeLayout, endDateTime, location)
+	dateTimeRange.startDateTime, _ = parseTime(startDateTime, location)
+	dateTimeRange.endDateTime, _ = parseTime(endDateTime, location)
 	return &dateTimeRange
+}
+
+func parseTime(value string, location *time.Location) (result time.Time, err error) {
+	result, err = time.ParseInLocation(DateTimeSecondsLayout, value, location)
+	if err != nil {
+		result, err = time.ParseInLocation(DateTimeLayout, value, location)
+	}
+
+	return
 }
 
 func (dtr *DateTimeRange) overlaps(otherDtr *DateTimeRange) bool {

--- a/src/autoscaler/api/policyvalidator/policy_validator_test.go
+++ b/src/autoscaler/api/policyvalidator/policy_validator_test.go
@@ -1558,6 +1558,34 @@ var _ = Describe("PolicyValidator", func() {
 						Expect(policyJson).To(MatchJSON(policyString))
 					})
 				})
+				Context("when start_time and/or end_time includes seconds", func() {
+					BeforeEach(func() {
+						policyString = `{
+							"instance_max_count":4,
+							"instance_min_count":1,
+							"schedules":{
+								"timezone":"Asia/Kolkata",
+								"recurring_schedule":[
+									{
+										"start_time":"10:00:01",
+										"end_time":"18:00:59",
+										"days_of_week":[
+											1,
+											2,
+											3
+										],
+										"instance_min_count":2,
+										"instance_max_count":5
+									}
+								]
+							}
+						}
+					`
+					})
+					It("should succeed", func() {
+						Expect(policyJson).To(MatchJSON(policyString))
+					})
+				})
 				Context("when instance_min_count is greater than instance_max_count", func() {
 					BeforeEach(func() {
 						policyString = `{


### PR DESCRIPTION
By allowing to define seconds for `start_time` and `end_time` the chance of scaling down to the default `instance_min_count` is reduced.
Potential fix for https://github.com/cloudfoundry/app-autoscaler-release/issues/3356.