### PR TITLE
(fix) Fix mtar cleanup for acceptance tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,5 +24,8 @@ indent_size = 4
 indent_style = tab
 
 [{*.bash,*.sh}]
+indent_style = space
 indent_size = 2
-indent_style = tab
+softtabstop = 2
+
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,7 @@ indent_size = 4
 indent_style = tab
 
 [{*.bash,*.sh}]
-indent_style = space
+indent_style = tab
 indent_size = 2
 softtabstop = 2
 

--- a/ci/autoscaler/scripts/common.sh
+++ b/ci/autoscaler/scripts/common.sh
@@ -81,17 +81,19 @@ function cleanup_credhub(){
 }
 
 function cleanup_apps(){
-	step "cleaning up apps"
+  step "cleaning up apps"
   local mtar_app
   local space_guid
 
   cf_target "${autoscaler_org}" "${autoscaler_space}"
 
-	space_guid="$(cf space --guid "${autoscaler_space}")"
+  space_guid="$(cf space --guid "${autoscaler_space}")"
   mtar_app="$(curl --header "Authorization: $(cf oauth-token)" "deploy-service.${system_domain}/api/v2/spaces/${space_guid}/mtas"  | jq ". | .[] | .metadata | .id" -r)"
 
   if [ -n "${mtar_app}" ]; then
-    cf undeploy "${mtar_app}" -f
+    set +e
+    cf undeploy "${mtar_app}" -f --delete-service-brokers --delete-service-keys --delete-services --do-not-fail-on-missing-permissions
+    set -e
   else
      echo "No app to undeploy"
   fi


### PR DESCRIPTION
### Problem

When undeployment fails during the acceptance test teardown phase—specifically in the `autoscaler-cleanup` step—it can leave behind orphaned (zombie) orgs and spaces. These residual resources can clutter the environment and cause issues for subsequent test runs.

### Example

In [this workflow run](https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/13784567998/job/38553327654), the cleanup process did not successfully remove all resources.

This occurred in [PR #3629](https://github.com/cloudfoundry/app-autoscaler-release/pull/3629), where the test org and space were not cleaned up as expected.

### Fix / Improvement

Now `cf undeploy` fails gracefully 