### PR TITLE
Potential fix for code scanning alert no. 422: Clear-text logging of sensitive information

### DIFF
--- a/src/autoscaler/db/sqldb/storedprocedure_sqldb.go
+++ b/src/autoscaler/db/sqldb/storedprocedure_sqldb.go
@@ -121,10 +121,10 @@ func (sdb *StoredProcedureSQLDb) ValidateCredentials(ctx context.Context, creds 
 		Scan(&credOptions.InstanceId, &credOptions.BindingId)
 
 	if err != nil {
+		sanitizedCreds := models.Credential{Username: creds.Username, Password: "***"}
 		sdb.logger.Error(
 			"credential-validation-with-stored-function-errored",
-			err, lager.Data{"query": query, "creds": creds, "appId": appId})
-
+			err, lager.Data{"query": query, "creds": sanitizedCreds, "appId": appId})
 		return nil, err
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/app-autoscaler-release/security/code-scanning/422](https://github.com/cloudfoundry/app-autoscaler-release/security/code-scanning/422)

To fix the issue, we need to ensure that sensitive information, such as the `Password` field, is not logged in clear text. The best approach is to exclude the `Password` field from the log entirely or replace it with a placeholder (e.g., `"***"`). This ensures that sensitive data is not exposed in the logs while still allowing other non-sensitive information to be logged for debugging purposes.

Specifically:
1. Modify the logging statement on line 126 in `src/autoscaler/db/sqldb/storedprocedure_sqldb.go` to exclude the `Password` field from the `creds` object.
2. Create a sanitized version of the `creds` object that omits or masks the `Password` field before passing it to the logger.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
