### PR TITLE
Add missing Make-dependency;

### DIFF
--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -97,7 +97,7 @@ ${go-vendoring-folder} ${go-vendored-files} &: ${app-fakes-dir} ${app-fakes-file
 
 
 # CGO_ENABLED := 1 is required to enforce dynamic linking which is a requirement of dynatrace.
-build-%:
+build-%: generate-openapi-generated-clients-and-servers
 	@echo "# building $*"
 	@CGO_ENABLED=1 go build $(BUILDTAGS) $(BUILDFLAGS) -o build/$* $*/cmd/$*/main.go
 


### PR DESCRIPTION
Building autoscaler's executables requires clients and servers defined in the openapi-v3-specification. The lack of having defined this dependency in the Makefiles led to bugs like <https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/integration-tests/builds/2262#L68064499:229>.