### PR TITLE
 (feature): Refactor module names and update dependencies in autoscaler configs

### DIFF
--- a/src/autoscaler/api/cmd/api/api_test.go
+++ b/src/autoscaler/api/cmd/api/api_test.go
@@ -394,7 +394,7 @@ func getVcapServices() (result string) {
 
 	result = `{
 			"user-provided": [
-			  { "name": "publicapiserver-config", "tags": ["publicapiserver-config"], "credentials": { "publicapiserver-config": { } }},
+			  { "name": "apiserver-config", "tags": ["apiserver-config"], "credentials": { "apiserver-config": { } }},
 			  { "name": "broker-catalog", "tags": ["broker-catalog"], "credentials": { "broker-catalog": ` + string(catalogBytes) + ` }}
             ],
 			"autoscaler": [ {

--- a/src/autoscaler/api/config/config.go
+++ b/src/autoscaler/api/config/config.go
@@ -165,7 +165,7 @@ func defaultConfig() Config {
 	}
 }
 func loadPublicApiServerConfig(conf *Config, vcapReader configutil.VCAPConfigurationReader) error {
-	data, err := vcapReader.GetServiceCredentialContent("publicapiserver-config", "publicapiserver-config")
+	data, err := vcapReader.GetServiceCredentialContent("apiserver-config", "apiserver-config")
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrPublicApiServerConfigNotFound, err)
 	}

--- a/src/autoscaler/api/default_config.json
+++ b/src/autoscaler/api/default_config.json
@@ -1,5 +1,5 @@
 {
-  "publicapiserver-config": {
+  "apiserver-config": {
     "cf": {
       "skip_ssl_validation": false,
       "max_retries": 3,

--- a/src/autoscaler/build-extension-file.sh
+++ b/src/autoscaler/build-extension-file.sh
@@ -75,12 +75,16 @@ version: 1.0.0
 _schema-version: 3.3.0
 
 modules:
-  - name: publicapiserver
+  - name: apiserver
     parameters:
       instances: 1
       routes:
       - route: ${PUBLICAPISERVER_HOST}.\${default-domain}
       - route: ${SERVICEBROKER_HOST}.\${default-domain}
+    requires:
+      - name: publicapiserver-config
+      - name: broker-catalog
+      - name: database
   - name: metricsforwarder
     requires:
     - name: metricsforwarder-config

--- a/src/autoscaler/build-extension-file.sh
+++ b/src/autoscaler/build-extension-file.sh
@@ -82,7 +82,7 @@ modules:
       - route: ${PUBLICAPISERVER_HOST}.\${default-domain}
       - route: ${SERVICEBROKER_HOST}.\${default-domain}
     requires:
-      - name: publicapiserver-config
+      - name: apiserver-config
       - name: broker-catalog
       - name: database
   - name: metricsforwarder
@@ -107,10 +107,10 @@ resources:
           basic_auth:
             password: "${METRICSFORWARDER_HEALTH_PASSWORD}"
 
-- name: publicapiserver-config
+- name: apiserver-config
   parameters:
     config:
-      publicapiserver-config:
+      apiserver-config:
         scaling_rules:
           cpu:
             upper_threshold: $CPU_LOWER_THRESHOLD

--- a/src/autoscaler/integration/integration_golangapi_scheduler_test.go
+++ b/src/autoscaler/integration/integration_golangapi_scheduler_test.go
@@ -528,7 +528,7 @@ var _ = Describe("Integration_GolangApi_Scheduler", func() {
 			golangConfJson, err := golangConf.ToJSON()
 			Expect(err).NotTo(HaveOccurred())
 
-			vcapServicesJson := testhelpers.GetVcapServices("publicapiserver-config", golangConfJson)
+			vcapServicesJson := testhelpers.GetVcapServices("apiserver-config", golangConfJson)
 			os.Setenv("VCAP_SERVICES", vcapServicesJson)
 
 			os.Setenv("PORT", strconv.Itoa(components.Ports[GolangAPICFServer]))

--- a/src/autoscaler/mta.tpl.yaml
+++ b/src/autoscaler/mta.tpl.yaml
@@ -36,7 +36,7 @@ modules:
       - name: apply-api-changelog
         command: " chmod +x ./BOOT-INF/classes/bin/apply-api-changelog.sh ; /home/vcap/app/BOOT-INF/classes/bin/apply-api-changelog.sh"
 
-  - name: publicapiserver
+  - name: apiserver
     type: go
     path: .
     properties:
@@ -49,6 +49,7 @@ modules:
     - name: broker-catalog
     - name: database
     - name: app-autoscaler-application-logs
+    - name: app-autoscaler-dynatrace
     parameters:
       memory: 1G
       disk-quota: 1G

--- a/src/autoscaler/mta.tpl.yaml
+++ b/src/autoscaler/mta.tpl.yaml
@@ -45,7 +45,7 @@ modules:
       GOTOOLCHAIN: local
       GOVERSION: go1.GO_MINOR_VERSION
     requires:
-    - name: publicapiserver-config
+    - name: apiserver-config
     - name: broker-catalog
     - name: database
     - name: app-autoscaler-application-logs
@@ -85,11 +85,11 @@ resources:
     service-tags:
     - metricsforwarder-config
     path: metricsforwarder/default_config.json
-- name: publicapiserver-config
+- name: apiserver-config
   type: org.cloudfoundry.user-provided-service
   parameters:
     service-tags:
-    - publicapiserver-config
+    - apiserver-config
     path: api/default_config.json
 - name: broker-catalog
   type: org.cloudfoundry.user-provided-service


### PR DESCRIPTION
This PR matches current vm name with mtar module vm name:

 - Rename 'publicapiserver' module to 'apiserver'
 - Add new dependencies to 'apiserver' module: 'publicapiserver-config', 'broker-catalog', and 'database'
 - Include 'app-autoscaler-dynatrace' as a new dependency for 'apiserver' in mta.tpl.yaml