### PR TITLE
Increase key length to 4096 for Postgres-related SSL 

### DIFF
--- a/operations/add-postgres-variables.yml
+++ b/operations/add-postgres-variables.yml
@@ -6,6 +6,7 @@
     options:
       is_ca: true
       common_name: postgresCA
+      key_length: 4096
 
 - type: replace
   path: /variables/-
@@ -20,6 +21,7 @@
       extended_key_usage:
         - client_auth
         - server_auth
+      key_length: 4096
 
 - type: replace
   path: /variables/-
@@ -33,3 +35,5 @@
         - ((deployment_name)).autoscalerpostgres.service.cf.internal
       extended_key_usage:
         - client_auth
+      key_length: 4096
+


### PR DESCRIPTION
This pull request updates the `operations/add-postgres-variables.yml` file to enhance security by increasing the key length for cryptographic operations. The key length is now explicitly set to 4096 bits in multiple sections of the file.

Security enhancements:

* Added `key_length: 4096` to the `options` section for the `postgresCA` variable to enforce a stronger cryptographic key length.
* Included `key_length: 4096` in the `options` section to ensure consistent key length for client and server authentication.
* Added `key_length: 4096` to the `options` section for the autoscaler Postgres service, further standardizing the key length across configurations.