### PR TITLE
chore(ci): align time resources with awake time of CI related VMs

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -107,12 +107,14 @@ resources:
     repository: "ghcr.io/cloudfoundry/app-autoscaler-release-tools"
     tag: "main"
 
-- name: every-night
+  # start/stop/days of this resource fall into the timeframe where the CI related VMs are awake. see also .github/workflows/resume-ci-vms.yml
+- name: every-morning
   type: time
   source:
-    start: 10:00 PM
-    stop: 11:00 PM
-    location: "Europe/Berlin"
+    start: 05:30 AM
+    stop: 06:30 AM
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+    location: "UTC"
 
 - name: ci
   type: git
@@ -591,7 +593,7 @@ jobs:
     - get: "app-autoscaler-tools"
     - get: bbl-state
     - get: ci
-    - get: every-night
+    - get: every-morning
       trigger: true
   - task: cleanup-autoscaler-deployments
     image: "app-autoscaler-tools"
@@ -605,7 +607,7 @@ jobs:
     - get: "app-autoscaler-tools"
     - get: bbl-state
     - get: ci
-    - get: every-night
+    - get: every-morning
       passed: [ cleanup-autoscaler-deployments ]
       trigger: true
     - get: gcp-jammy-stemcell

--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -47,8 +47,14 @@ resources:
       - ci/autoscaler
       - ci/operations
 
-- name: every-day
+  # start/stop/days of this resource fall into the timeframe where the CI related VMs are awake. see also .github/workflows/resume-ci-vms.yml
+- name: every-morning
   type: time
+  source:
+    start: 05:30 AM
+    stop: 06:30 AM
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+    location: "UTC"
 
 - name: postgres-repo
   type: git
@@ -194,7 +200,7 @@ jobs:
   - in_parallel:
     - get: bbl-state
     - get: cf-deployment-concourse-tasks
-    - get: every-day
+    - get: every-morning
       trigger: true
   - task: bosh-cleanup
     file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
@@ -206,7 +212,7 @@ jobs:
     - in_parallel:
         - get: bbl-state
         - get: ci
-        - get: every-day
+        - get: every-morning
           passed: [ bosh-cleanup ]
           trigger: true
         - get: gcp-jammy-stemcell


### PR DESCRIPTION
# Problem
#3856 introduced hibernation to all CI related VMs. The Concourse time-resource need to be adjusted so that they trigger the jobs during the awaken times of the CI related VMs.

# Solution
Adjust Concourse time-resource to fall into the awaken times of the CI related VMs.