### PR TITLE
chore(ci): hibernate all VMs inside the autoscaler network

### DIFF
--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -19,7 +19,11 @@ jobs:
 
       - name: resume VMs
         run: |
-          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list \
+            --filter="networkInterfaces.network:autoscaler-network" \
+            --format="value(name,zone)" \
+            --sort-by="~labels.deployment:bosh" \ # resume bosh director last
+          | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
               echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -23,8 +23,8 @@ jobs:
       - name: resume VMs
         run: |
           gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
-            if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE"; then
-              echo "failed to resume $INSTANCE_NAME in $ZONE, continuing with next instance"
+            if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
+              echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue
             fi
           done

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   resume:
+    env:
+      BBL_STATE_PATH: ${{ github.workspace }}/app-autoscaler-env-bbl-state/bbl-state
     runs-on: ubuntu-latest
     steps:
       - name: checkout app-autoscaler-release
         uses: actions/checkout@v4
-        with:
-          path: app-autoscaler-release
 #
 #      - name: auth gcloud
 #        uses: google-github-actions/auth@v2
@@ -35,11 +35,9 @@ jobs:
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 # v0.12.0
         with:
           enable-cache: true
-          project-path: ${{ github.workspace }}/app-autoscaler-release
 
       - name: make devbox shellenv available
         run: |
-          cd "${GITHUB_WORKSPACE}/app-autoscaler-release"
           eval "$(devbox shellenv)"
           printenv >> "$GITHUB_ENV"
 
@@ -52,8 +50,4 @@ jobs:
 
       - name: test bosh command
         run: |
-          export BBL_STATE_PATH="${GITHUB_WORKSPACE}/app-autoscaler-env-bbl-state/bbl-state"
-          cd "${GITHUB_WORKSPACE}/app-autoscaler-release"
-          direnv reload .
-          env
-          #bosh vms -d cf
+          bosh vms -d cf

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -13,23 +13,6 @@ jobs:
     steps:
       - name: checkout app-autoscaler-release
         uses: actions/checkout@v4
-#
-#      - name: auth gcloud
-#        uses: google-github-actions/auth@v2
-#        with:
-#          credentials_json: '${{ secrets.GCP_APP_RUNTIME_INTERFACES_AUTOSCALER_DEPLOYER_KEY }}'
-#
-#      - name: set up gcloud
-#        uses: google-github-actions/setup-gcloud@v2
-#
-#      - name: resume VMs
-#        run: |
-#          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
-#            if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
-#              echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
-#              continue
-#            fi
-#          done
 
       - name: install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 # v0.12.0
@@ -51,3 +34,21 @@ jobs:
       - name: test bosh command
         run: |
           bosh vms -d cf
+
+#
+#      - name: auth gcloud
+#        uses: google-github-actions/auth@v2
+#        with:
+#          credentials_json: '${{ secrets.GCP_APP_RUNTIME_INTERFACES_AUTOSCALER_DEPLOYER_KEY }}'
+#
+#      - name: set up gcloud
+#        uses: google-github-actions/setup-gcloud@v2
+#
+#      - name: resume VMs
+#        run: |
+#          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
+#            if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
+#              echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
+#              continue
+#            fi
+#          done

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -52,6 +52,4 @@ jobs:
             eval "$(bbl print-env)"
           popd > /dev/null
 
-      - name: recreate router VM
-        run: |
           bosh recreate router -d cf -n

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -46,7 +46,8 @@ jobs:
           ssh-key: ${{ secrets.BBL_SSH_KEY }}
           path: app-autoscaler-env-bbl-state
 
-      - name: login to bosh
+      # after suspension and resumption, backend VMs become unreachable by the load balancer and require recreation.
+      - name: recreate router VM
         run: |
           pushd "${GITHUB_WORKSPACE}/app-autoscaler-env-bbl-state/bbl-state" > /dev/null
             eval "$(bbl print-env)"

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -9,6 +9,23 @@ jobs:
   resume:
     runs-on: ubuntu-latest
     steps:
+      - name: auth gcloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCP_APP_RUNTIME_INTERFACES_AUTOSCALER_DEPLOYER_KEY }}'
+
+      - name: set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: resume VMs
+        run: |
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
+            if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
+              echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
+              continue
+            fi
+          done
+
       - name: checkout app-autoscaler-release
         uses: actions/checkout@v4
 
@@ -26,30 +43,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: cloudfoundry/app-autoscaler-env-bbl-state
-          ssh-key: ${{ secrets.bbl_ssh_key }}
+          ssh-key: ${{ secrets.BBL_SSH_KEY }}
           path: app-autoscaler-env-bbl-state
 
-      - name: test bosh command
+      - name: login to bosh
         run: |
           pushd "${GITHUB_WORKSPACE}/app-autoscaler-env-bbl-state/bbl-state" > /dev/null
             eval "$(bbl print-env)"
           popd > /dev/null
-          bosh vms -d cf
 
-#
-#      - name: auth gcloud
-#        uses: google-github-actions/auth@v2
-#        with:
-#          credentials_json: '${{ secrets.GCP_APP_RUNTIME_INTERFACES_AUTOSCALER_DEPLOYER_KEY }}'
-#
-#      - name: set up gcloud
-#        uses: google-github-actions/setup-gcloud@v2
-#
-#      - name: resume VMs
-#        run: |
-#          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
-#            if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
-#              echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
-#              continue
-#            fi
-#          done
+      - name: recreate router VM
+        run: |
+          bosh recreate router -d cf -n

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: resume VMs
         run: |
-          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh") | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE"; then
               echo "failed to resume $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -55,4 +55,5 @@ jobs:
           export BBL_STATE_PATH="${GITHUB_WORKSPACE}/app-autoscaler-env-bbl-state/bbl-state"
           cd "${GITHUB_WORKSPACE}/app-autoscaler-release"
           direnv reload .
-          bosh vms -d cf
+          env
+          #bosh vms -d cf

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: resume VMs
         run: |
-          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh") | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE"; then
               echo "failed to resume $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -9,22 +9,47 @@ jobs:
   resume:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: checkout app-autoscaler-release
         uses: actions/checkout@v4
-
-      - name: auth gcloud
-        uses: google-github-actions/auth@v2
         with:
-          credentials_json: '${{ secrets.GCP_APP_RUNTIME_INTERFACES_AUTOSCALER_DEPLOYER_KEY }}'
+          path: app-autoscaler-release
+#
+#      - name: auth gcloud
+#        uses: google-github-actions/auth@v2
+#        with:
+#          credentials_json: '${{ secrets.GCP_APP_RUNTIME_INTERFACES_AUTOSCALER_DEPLOYER_KEY }}'
+#
+#      - name: set up gcloud
+#        uses: google-github-actions/setup-gcloud@v2
+#
+#      - name: resume VMs
+#        run: |
+#          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
+#            if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
+#              echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
+#              continue
+#            fi
+#          done
 
-      - name: set up gcloud
-        uses: google-github-actions/setup-gcloud@v2
+      - name: install devbox
+        uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 # v0.12.0
+        with:
+          enable-cache: true
+          project-path: ${{ github.workspace }}/app-autoscaler-release
 
-      - name: resume VMs
+      - name: make devbox shellenv available
         run: |
-          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
-            if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
-              echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
-              continue
-            fi
-          done
+          cd "${GITHUB_WORKSPACE}/app-autoscaler-release"
+          eval "$(devbox shellenv)"
+          printenv >> "$GITHUB_ENV"
+
+      - name: checkout app-autoscaler-env-bbl-state
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: cloudfoundry/app-autoscaler-env-bbl-state
+          ssh-key: ${{ secrets.bbl_ssh_key }}
+          path: bbl
+
+      - name: test bosh command
+        run: |
+          bosh vms -d cf

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: resume VMs
         run: |
-          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE"; then
               echo "failed to resume $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   resume:
-    env:
-      BBL_STATE_PATH: ${{ github.workspace }}/app-autoscaler-env-bbl-state/bbl-state
     runs-on: ubuntu-latest
     steps:
       - name: checkout app-autoscaler-release
@@ -33,10 +31,9 @@ jobs:
 
       - name: test bosh command
         run: |
-          ls -l app-autoscaler-env-bbl-state
-          ls -l
-          pwd
-          direnv reload .
+          pushd "${GITHUB_WORKSPACE}/app-autoscaler-env-bbl-state/bbl-state" > /dev/null
+            eval "$(bbl print-env)"
+          popd > /dev/null
           bosh vms -d cf
 
 #

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -48,8 +48,9 @@ jobs:
         with:
           repository: cloudfoundry/app-autoscaler-env-bbl-state
           ssh-key: ${{ secrets.bbl_ssh_key }}
-          path: bbl
+          path: app-autoscaler-env-bbl-state
 
       - name: test bosh command
         run: |
+          direnv reload
           bosh vms -d cf

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -19,11 +19,7 @@ jobs:
 
       - name: resume VMs
         run: |
-          gcloud compute instances list \
-            --filter="networkInterfaces.network:autoscaler-network" \
-            --format="value(name,zone)" \
-            --sort-by="~labels.deployment:bosh" \ # resume bosh director last
-          | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="~labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE" --async; then
               echo "failed to initiate resuming $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -52,5 +52,6 @@ jobs:
 
       - name: test bosh command
         run: |
-          direnv reload
+          cd "${GITHUB_WORKSPACE}/app-autoscaler-release"
+          direnv reload .
           bosh vms -d cf

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: test bosh command
         run: |
+          ls -l app-autoscaler-env-bbl-state
+          ls -l
+          pwd
           direnv reload .
           bosh vms -d cf
 

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: resume VMs
         run: |
-          gcloud compute instances list --filter="labels.belongs-to:autoscaler" --format="value(name,zone)" | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances resume "$INSTANCE_NAME" --zone="$ZONE"; then
               echo "failed to resume $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: test bosh command
         run: |
+          export BBL_STATE_PATH="${GITHUB_WORKSPACE}/app-autoscaler-env-bbl-state/bbl-state"
           cd "${GITHUB_WORKSPACE}/app-autoscaler-release"
           direnv reload .
           bosh vms -d cf

--- a/.github/workflows/resume-ci-vms.yml
+++ b/.github/workflows/resume-ci-vms.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: test bosh command
         run: |
+          direnv reload .
           bosh vms -d cf
 
 #

--- a/.github/workflows/suspend-ci-vms.yml
+++ b/.github/workflows/suspend-ci-vms.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: suspend VMs
         run: |
-          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh") | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances suspend "$INSTANCE_NAME" --zone="$ZONE"; then
               echo "failed to suspend $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/suspend-ci-vms.yml
+++ b/.github/workflows/suspend-ci-vms.yml
@@ -22,11 +22,7 @@ jobs:
 
       - name: suspend VMs
         run: |
-          gcloud compute instances list \
-            --filter="networkInterfaces.network:autoscaler-network" \
-            --format="value(name,zone)" \
-            --sort-by="labels.deployment:bosh" \ # suspend bosh director first
-          | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances suspend "$INSTANCE_NAME" --zone="$ZONE" --async; then
               echo "failed to initiate suspending $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/suspend-ci-vms.yml
+++ b/.github/workflows/suspend-ci-vms.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: suspend VMs
         run: |
-          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh") | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances suspend "$INSTANCE_NAME" --zone="$ZONE"; then
               echo "failed to suspend $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/suspend-ci-vms.yml
+++ b/.github/workflows/suspend-ci-vms.yml
@@ -23,8 +23,8 @@ jobs:
       - name: suspend VMs
         run: |
           gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
-            if ! gcloud compute instances suspend "$INSTANCE_NAME" --zone="$ZONE"; then
-              echo "failed to suspend $INSTANCE_NAME in $ZONE, continuing with next instance"
+            if ! gcloud compute instances suspend "$INSTANCE_NAME" --zone="$ZONE" --async; then
+              echo "failed to initiate suspending $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue
             fi
           done

--- a/.github/workflows/suspend-ci-vms.yml
+++ b/.github/workflows/suspend-ci-vms.yml
@@ -22,7 +22,11 @@ jobs:
 
       - name: suspend VMs
         run: |
-          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" --sort-by="labels.deployment:bosh" | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list \
+            --filter="networkInterfaces.network:autoscaler-network" \
+            --format="value(name,zone)" \
+            --sort-by="labels.deployment:bosh" \ # suspend bosh director first
+          | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances suspend "$INSTANCE_NAME" --zone="$ZONE" --async; then
               echo "failed to initiate suspending $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/.github/workflows/suspend-ci-vms.yml
+++ b/.github/workflows/suspend-ci-vms.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: suspend VMs
         run: |
-          gcloud compute instances list --filter="labels.belongs-to:autoscaler" --format="value(name,zone)" | while read -r INSTANCE_NAME ZONE; do
+          gcloud compute instances list --filter="networkInterfaces.network:autoscaler-network" --format="value(name,zone)" | while read -r INSTANCE_NAME ZONE; do
             if ! gcloud compute instances suspend "$INSTANCE_NAME" --zone="$ZONE"; then
               echo "failed to suspend $INSTANCE_NAME in $ZONE, continuing with next instance"
               continue

--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -108,7 +108,7 @@ resources:
     tag: "main"
 
   # start/stop/days of this resource fall into the timeframe where the CI related VMs are awake. see also .github/workflows/resume-ci-vms.yml
-- name: every-morning
+- name: every-morning-monday-till-friday
   type: time
   source:
     start: 05:30 AM
@@ -593,7 +593,7 @@ jobs:
     - get: "app-autoscaler-tools"
     - get: bbl-state
     - get: ci
-    - get: every-morning
+    - get: every-morning-monday-till-friday
       trigger: true
   - task: cleanup-autoscaler-deployments
     image: "app-autoscaler-tools"
@@ -607,7 +607,7 @@ jobs:
     - get: "app-autoscaler-tools"
     - get: bbl-state
     - get: ci
-    - get: every-morning
+    - get: every-morning-monday-till-friday
       passed: [ cleanup-autoscaler-deployments ]
       trigger: true
     - get: gcp-jammy-stemcell

--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -79,9 +79,6 @@ function create_manifest() {
 
 	bosh_deploy_vars=""
 
-	# always use the ops file that tags all deployment related VMs and disks
-	OPS_FILES_TO_USE="${OPS_FILES_TO_USE} -o ${ci_dir}/operations/tag-vms-and-disks.yml"
-
 	# add deployment name
 	bosh -n -d "${deployment_name}" interpolate "${deployment_manifest}" ${OPS_FILES_TO_USE} \
 		${bosh_deploy_opts} ${BOSH_DEPLOY_VARS} \

--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -48,7 +48,7 @@ resources:
       - ci/operations
 
   # start/stop/days of this resource fall into the timeframe where the CI related VMs are awake. see also .github/workflows/resume-ci-vms.yml
-- name: every-morning
+- name: every-morning-monday-till-friday
   type: time
   source:
     start: 05:30 AM
@@ -200,7 +200,7 @@ jobs:
   - in_parallel:
     - get: bbl-state
     - get: cf-deployment-concourse-tasks
-    - get: every-morning
+    - get: every-morning-monday-till-friday
       trigger: true
   - task: bosh-cleanup
     file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
@@ -212,7 +212,7 @@ jobs:
     - in_parallel:
         - get: bbl-state
         - get: ci
-        - get: every-morning
+        - get: every-morning-monday-till-friday
           passed: [ bosh-cleanup ]
           trigger: true
         - get: gcp-jammy-stemcell

--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -245,7 +245,7 @@ jobs:
       vars-files: autoscaler-env-vars-store
     params:
       SYSTEM_DOMAIN: autoscaler.app-runtime-interfaces.ci.cloudfoundry.org
-      OPS_FILES: "operations/cf/scale-to-one-az.yml operations/autoscaler/scale_out_cf_for_app-autoscaler.yaml operations/autoscaler/set-cpu-entitlement-per-share.yaml operations/autoscaler/add-trusted-certs.yaml operations/cf/use-compiled-releases.yml operations/autoscaler/enable_mtls.yml operations/autoscaler/add-eventgenerator-log-cache-uaa-client.yml operations/cf/experimental/disable-v2-api.yml operations/autoscaler/tag-vms-and-disks.yml"
+      OPS_FILES: "operations/cf/scale-to-one-az.yml operations/autoscaler/scale_out_cf_for_app-autoscaler.yaml operations/autoscaler/set-cpu-entitlement-per-share.yaml operations/autoscaler/add-trusted-certs.yaml operations/cf/use-compiled-releases.yml operations/autoscaler/enable_mtls.yml operations/autoscaler/add-eventgenerator-log-cache-uaa-client.yml operations/cf/experimental/disable-v2-api.yml"
       BOSH_DEPLOY_ARGS: "-v diego_cell_instances=3 -v grafana_redirect_uri=https://grafana.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org/login/generic_oauth"
     ensure:
       put: autoscaler-env-vars-store

--- a/ci/infrastructure/scripts/deploy-postgres.sh
+++ b/ci/infrastructure/scripts/deploy-postgres.sh
@@ -17,7 +17,6 @@ release_ops="${repo_dir}/templates/operations"
 ops_files=${OPS_FILES:-"${release_ops}/add_static_ips.yml\
                        ${ci_dir}/operations/set-postgres-disk.yml\
                        ${ci_dir}/operations/add-multiapps-databases-to-postgres.yml \
-                       ${ci_dir}/operations/tag-vms-and-disks.yml \
                        "}
 
 

--- a/ci/operations/tag-vms-and-disks.yml
+++ b/ci/operations/tag-vms-and-disks.yml
@@ -1,5 +1,0 @@
-# this ops-file adds custom tags to all VMs and disks of a deployment, see also https://bosh.io/docs/manifest-v2/#tags
-- type: replace
-  path: /tags?
-  value:
-    belongs-to: autoscaler

--- a/renovate.json
+++ b/renovate.json
@@ -77,5 +77,5 @@
     "enabled": true
   },
   "timezone": "UTC",
-  "schedule": ["* 6-17 * * 1-5"]
+  "schedule": ["* 6-16 * * 1-5"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -77,5 +77,5 @@
     "enabled": true
   },
   "timezone": "UTC",
-  "schedule": ["* 5-17 * * 1-5"]
+  "schedule": ["* 6-17 * * 1-5"]
 }


### PR DESCRIPTION
# Problem 1
The current hibernation #3856 does only hibernate those VMs that are tagged with `belongs-to: autoscaler`. The problem here is that the Bosh director and some more VMs aren't labelled because they are being set up by a reusable job, which does not offer the possibility via it's interface to add tagging. 

https://github.com/cloudfoundry/app-autoscaler-release/blob/18e3fb14deec1eb6908a5927ff93cea4bd9f0b68/ci/infrastructure/pipeline.yml#L131-L132

https://github.com/cloudfoundry/cf-deployment-concourse-tasks/blob/main/bbl-up/task.yml

# Solution 1
* suspend/resume all VMs inside the `autoscaler` network to catch all VMs
* revert tagging logic introduced with #3854 

# Problem 2
The resuming all VMs turned out to break the ingress traffic into the CF landscape. To be precise, suspending and resuming the load balancer's backend VM seem to not work, leading to the problem that all ingress traffic to `https://api.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org/` was broken

# Solution 2
Recreating the router VM via bosh turns out to make the load balancer reach the router again.


# Validation
* successful suspend run: https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/16147351143/job/45569614755
* successful resume run: https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/16147414217/job/45569830508


