### PR TITLE
chore(ci): scale up deploy-service, require `deploy-cf` to be passed before deploying multiapps-controller

### DIFF
--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -267,7 +267,7 @@ jobs:
   - in_parallel:
     - get: bbl-state
       trigger: true
-      passed: [setup-infrastructure]
+      passed: [setup-infrastructure, deploy-cf]
     - get: ci
     - get: postgres-repo
     - get: postgres-release

--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -40,7 +40,7 @@ resources:
   source:
     uri: git@github.com:cloudfoundry/app-autoscaler-release
     private_key: ((autoscaler-deploy-key-private))
-    branch: ci-fixes-123
+    branch: main
     fetch_tags: true
     paths:
       - ci/infrastructure

--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -40,7 +40,7 @@ resources:
   source:
     uri: git@github.com:cloudfoundry/app-autoscaler-release
     private_key: ((autoscaler-deploy-key-private))
-    branch: main
+    branch: ci-fixes-123
     fetch_tags: true
     paths:
       - ci/infrastructure

--- a/ci/infrastructure/scripts/deploy-multiapps-controller.sh
+++ b/ci/infrastructure/scripts/deploy-multiapps-controller.sh
@@ -24,7 +24,7 @@ function deploy_multiapps_controller() {
   pushd multiapps-controller-web-manifest
   cf push -f ./*.yml "${app_name}"
   # scale up to be able to handle huge (>1GB) .MTARs
-  cf scale -m 4G -k 2G deploy-service
+  cf scale -m 4G -k 2G deploy-service -f
   popd
 }
 

--- a/ci/infrastructure/scripts/deploy-multiapps-controller.sh
+++ b/ci/infrastructure/scripts/deploy-multiapps-controller.sh
@@ -23,6 +23,8 @@ function deploy_multiapps_controller() {
   mv multiapps-controller-web-war/*.war .
   pushd multiapps-controller-web-manifest
   cf push -f ./*.yml "${app_name}"
+  # scale up to be able to handle huge (>1GB) .MTARs
+  cf scale -m 4G -k 2G deploy-service
   popd
 }
 


### PR DESCRIPTION
# Problem
* deploy service is too small to handle >1GB .MTAR files
* CF needs to be deployed first before deploying the multiapps controller


# Solution
* scale up `deploy-service`
* require `deploy-cf` to be passed before deploying deploy service

# Validation
Screenshot shows that `deploy-cf` must pass:
<img width="887" alt="Screenshot 2025-07-08 at 10 21 59" src="https://github.com/user-attachments/assets/4fa0d758-ac38-48f9-9357-50f697df92e3" />


Screenshot shows that scaling up works:
<img width="1119" alt="Screenshot 2025-07-08 at 10 22 05" src="https://github.com/user-attachments/assets/1d4afb8c-526e-4b6b-a5e8-054b466f0f5b" />