### PR TITLE
chore(ci): tag all CI related VMs and disks (#3854)

### DIFF
--- a/ci/autoscaler/scripts/deploy-autoscaler.sh
+++ b/ci/autoscaler/scripts/deploy-autoscaler.sh
@@ -79,6 +79,9 @@ function create_manifest() {
 
 	bosh_deploy_vars=""
 
+	# always use the ops file that tags all deployment related VMs and disks
+	OPS_FILES_TO_USE="${OPS_FILES_TO_USE} -o ${ci_dir}/operations/tag-vms-and-disks.yml"
+
 	# add deployment name
 	bosh -n -d "${deployment_name}" interpolate "${deployment_manifest}" ${OPS_FILES_TO_USE} \
 		${bosh_deploy_opts} ${BOSH_DEPLOY_VARS} \

--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -245,7 +245,7 @@ jobs:
       vars-files: autoscaler-env-vars-store
     params:
       SYSTEM_DOMAIN: autoscaler.app-runtime-interfaces.ci.cloudfoundry.org
-      OPS_FILES: "operations/cf/scale-to-one-az.yml operations/autoscaler/scale_out_cf_for_app-autoscaler.yaml operations/autoscaler/set-cpu-entitlement-per-share.yaml operations/autoscaler/add-trusted-certs.yaml operations/cf/use-compiled-releases.yml operations/autoscaler/enable_mtls.yml operations/autoscaler/add-eventgenerator-log-cache-uaa-client.yml operations/cf/experimental/disable-v2-api.yml"
+      OPS_FILES: "operations/cf/scale-to-one-az.yml operations/autoscaler/scale_out_cf_for_app-autoscaler.yaml operations/autoscaler/set-cpu-entitlement-per-share.yaml operations/autoscaler/add-trusted-certs.yaml operations/cf/use-compiled-releases.yml operations/autoscaler/enable_mtls.yml operations/autoscaler/add-eventgenerator-log-cache-uaa-client.yml operations/cf/experimental/disable-v2-api.yml operations/autoscaler/tag-vms-and-disks.yml"
       BOSH_DEPLOY_ARGS: "-v diego_cell_instances=3 -v grafana_redirect_uri=https://grafana.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org/login/generic_oauth"
     ensure:
       put: autoscaler-env-vars-store

--- a/ci/infrastructure/scripts/deploy-postgres.sh
+++ b/ci/infrastructure/scripts/deploy-postgres.sh
@@ -17,6 +17,7 @@ release_ops="${repo_dir}/templates/operations"
 ops_files=${OPS_FILES:-"${release_ops}/add_static_ips.yml\
                        ${ci_dir}/operations/set-postgres-disk.yml\
                        ${ci_dir}/operations/add-multiapps-databases-to-postgres.yml \
+                       ${ci_dir}/operations/tag-vms-and-disks.yml \
                        "}
 
 

--- a/ci/operations/tag-vms-and-disks.yml
+++ b/ci/operations/tag-vms-and-disks.yml
@@ -1,0 +1,5 @@
+# this ops-file adds custom tags to all VMs and disks of a deployment, see also https://bosh.io/docs/manifest-v2/#tags
+- type: replace
+  path: /tags?
+  value:
+    belongs-to: autoscaler


### PR DESCRIPTION
Let's reintroduce the tagging because we found a way to also tag the bosh director and jumpbox, see https://github.com/cloudfoundry/app-autoscaler-env-bbl-state/pull/5. By also tagging the director and the jumpbox, we were finally able to tag all autoscaler related CI VMs.

For further details, see also the following PR that initially brought the tagging but got reverted because we thought that we can't introduce tagging for the jumpbox and bosh director: https://github.com/cloudfoundry/app-autoscaler-release/pull/3854#issue-3196165134. 