### PR TITLE
fix(ci): Fix image build

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -4,11 +4,11 @@ on:
     branches: ['main']
     paths:
       - 'ci/dockerfiles/**'
-      - '.github/workflows/image.yml'
+      - '.github/workflows/image.yaml'
   pull_request:
     paths:
       - 'ci/dockerfiles/**'
-      - '.github/workflows/image.yml'
+      - '.github/workflows/image.yaml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -18,7 +18,6 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    container: jetpackio/devbox:latest@sha256:084acab190e61dcfcc234af1a8861633ca75fe6a72394c57de488de45bba9242
     permissions:
       contents: read
       packages: write
@@ -46,6 +45,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.image_suffix }}
 
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.13.0
+      
       - name: Get ginkgo version from autoscaler-release
         id: ginkgo
         run: |


### PR DESCRIPTION
# Issue

Our `autoscaler-tools` image build is broken since ages: 
<img width="1661" height="258" alt="image" src="https://github.com/user-attachments/assets/dc250704-db87-4896-95c8-cfcccbfe196c" />

# Fix

Don't run the build in devbox, just install the `devbox` command to fix the workflow.

# Note 

The trigger was broken, so we did not see the failures in any PRs touching the workflow.