### PR TITLE
Daily re-deployment of the multiapps-controller

### DIFF
--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -56,6 +56,14 @@ resources:
     days: [Monday, Tuesday, Wednesday, Thursday, Friday]
     location: "UTC"
 
+- name: every-morning-9am-monday-till-friday
+  type: time
+  source:
+    start: 09:00 AM
+    stop: 09:30 AM
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+    location: "UTC"
+
 - name: postgres-repo
   type: git
   icon: github
@@ -273,6 +281,8 @@ jobs:
     - get: postgres-release
     - get: multiapps-controller-web-war
     - get: multiapps-controller-web-manifest
+    - get: every-morning-9am-monday-till-friday
+      trigger: true
   - task: deploy-postgres
     file: ci/ci/infrastructure/tasks/deploy-postgres.yml
     params:


### PR DESCRIPTION
This change adds a time-based trigger to re-deploy the multiapps-controller every working day at 9am. This is a workaround for the issues that the multiapps-controller sometimes has after landscape-suspension and wakening.