### PR TITLE
Use different trigger for the multiapps-controller

### DIFF
--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -273,6 +273,8 @@ jobs:
     - get: postgres-release
     - get: multiapps-controller-web-war
     - get: multiapps-controller-web-manifest
+    - get: every-morning-monday-till-friday
+      trigger: true
   - task: deploy-postgres
     file: ci/ci/infrastructure/tasks/deploy-postgres.yml
     params:


### PR DESCRIPTION
The trigger defined in #3883 is too late. We switch to a different one.