### PR TITLE
chore(tests): remove PostgreSQL 12 from test matrix

### DIFF
--- a/.github/workflows/postgres.yaml
+++ b/.github/workflows/postgres.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        postgres: [12, 15, 16]
+        postgres: [15, 16]
         suite: [test, integration]
     env:
       DB_DATABASE: autoscaler


### PR DESCRIPTION
# Issue

PostgreSQL 12 is end of life since [9 months](https://endoflife.date/postgresql) and we can save some GitHub Action workflow runs by removing the PostgreSQL 12 tests from the test matrix

# Fix

Remove them from the matrix

# Note

Depends on https://github.com/cloudfoundry/community/pull/1303 to mergeable.
