### PR TITLE
 Allow customization of log for dbtasks cf task

### DIFF
--- a/src/autoscaler/dbtasks/src/main/resources/bin/apply-changelog.sh
+++ b/src/autoscaler/dbtasks/src/main/resources/bin/apply-changelog.sh
@@ -79,11 +79,12 @@ function run_liquibase() {
   local -r user="$2"
   local -r password="$3"
   local -r changelog="$4"
+  local -r log_level="${LOG_LEVEL:-DEBUG}"
 
   local classpath=$(readlink -f /home/vcap/app/BOOT-INF/lib/* | tr '\n' ':')
 
   "$JAVA_BIN" -cp "$classpath" liquibase.integration.commandline.Main \
-    --url "$jdbcdburl" --username="$user" --password="$password" --driver=org.postgresql.Driver --logLevel=DEBUG --changeLogFile="$changelog" update
+    --url "$jdbcdburl" --username="$user" --password="$password" --driver=org.postgresql.Driver --logLevel="$log_level" --changeLogFile="$changelog" update
 }
 
 function main() {

--- a/src/autoscaler/mta.tpl.yaml
+++ b/src/autoscaler/mta.tpl.yaml
@@ -25,6 +25,7 @@ modules:
     path: .
     properties:
       JBP_LOG_LEVEL:
+      LOG_LEVEL: INFO
       DEBUG:
     build-parameters:
       builder: custom


### PR DESCRIPTION
This pull request makes a small update to the logging configuration for the autoscaler module. It sets the `LOG_LEVEL` property to `INFO` in the `src/autoscaler/mta.tpl.yaml` file.