### PR TITLE
chore: Overcommit memory in CI CF env

### DIFF
--- a/ci/operations/scale_out_cf_for_app-autoscaler.yaml
+++ b/ci/operations/scale_out_cf_for_app-autoscaler.yaml
@@ -23,3 +23,6 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/maximum_app_disk_in_mb?
   value: 4096
 
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego/executor/memory_capacity_mb?
+  value: 64536


### PR DESCRIPTION
# Issue

If many PRs are in in flight apps fail to start with
`insufficient resources: memory`

# Fix

Overcommit memory. This should work as our apps use way less memory than
their quota, e.g.

```
$ cf app operator
Showing health and status for app operator in org autoscaler-mta-3951 /
space autoscaler-mta-3951 as admin...

name:              operator
requested state:   started
routes:
autoscaler-mta-3951-operator.autoscaler.app-runtime-interfaces.ci.cloudfoundry.org
last uploaded:     Tue 30 Sep 11:12:02 CEST 2025
stack:             cflinuxfs4
buildpacks:
	name           version   detect output   buildpack name
	go_buildpack   1.10.38   go              go

type:           web
sidecars:
instances:      1/2
memory usage:   1024M
state     since                  cpu    memory        disk
logging               cpu entitlement   details
#0   running   2025-09-30T09:14:01Z   1.3%   24.1M of 1G   75.3M of 1G
113B/s of unlimited   5.7%
#1   down      2025-09-30T09:38:59Z   0.0%   0B of 0B      0B of 0B
0B/s of 0B/s                            insufficient resources: memory
```
