### PR TITLE
chore: fix Go version determination to use devbox.json

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # v0.13.0
-      
+
       - name: Get ginkgo version from autoscaler-release
         id: ginkgo
         run: |
@@ -55,12 +55,19 @@ jobs:
           echo "GINKGO version from devbox: '${version}'"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-      - id: get-golang-version
-        shell: bash
-        run: |
-          version=$(devbox info go | head --lines=1 | cut --field=2 --delimiter=" ")
-          echo "Go version from devbox: '${version}'"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: Get Go version from devbox.json
+        id: get-golang-version
+        uses: jannekem/run-python-script-action@bbfca66c612a28f3eeca0ae40e1f810265e2ea68 # v1
+        with:
+          script: |
+            import json
+            import os
+            with open('devbox.json', 'r') as f:
+                devbox_config = json.load(f)
+            go_version = devbox_config['packages']['go']
+            print(f"Go version from devbox.json: '{go_version}'")
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as hf:
+                print(f"version={go_version}", file=hf)
 
       - name: Build and push
         id: build-and-push


### PR DESCRIPTION
# Issue

The wrong Go version is packaged in our CI image: https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/18191694489/job/51787975268

```
Run version=$(devbox info go | head --lines=1 | cut --field=2 --delimiter=" ")
Go version from devbox: '1.25.0'
```

but actually Go 1.24.3 should be in the image.

# Fix

Parse the `devbox.json` to get the Go version: https://github.com/cloudfoundry/app-autoscaler-release/actions/runs/18338845499/job/52229114616?pr=3959
```
Run jannekem/run-python-script-action@bbfca66c612a28f3eeca0ae40e1f810265e2ea68
/usr/bin/python /tmp/tmp-41095-Rxpi4UaJ1oc0-.py
Go version from devbox.json: '1.24.3'
```

# Note 

[Reached out to devbox discord](https://discord.com/channels/903306922852245526/1009933892385517619/1425405295793934347) to understand if this a bug in `devbox info`.