### PR TITLE
🔧 Fix: Set log-level for text-sinks.

### DIFF
--- a/src/autoscaler/helpers/logger.go
+++ b/src/autoscaler/helpers/logger.go
@@ -22,7 +22,7 @@ func InitLoggerFromConfig(conf *LoggingConfig, name string) lager.Logger {
 	logger := lager.NewLogger(name)
 
 	if conf.PlainTextSink {
-		plaintextFormatSink := createPlaintextSink()
+		plaintextFormatSink := createPlaintextSink(logLevel)
 		logger.RegisterSink(plaintextFormatSink)
 	} else {
 		redactedSink := createRedactedSink(logLevel)
@@ -47,9 +47,11 @@ func parseLogLevel(level string) (lager.LogLevel, error) {
 	}
 }
 
-func createPlaintextSink() lager.Sink {
+func createPlaintextSink(logLevel lager.LogLevel) lager.Sink {
 	slogger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	return lager.NewSlogSink(slogger)
+	slogSink := lager.NewSlogSink(slogger)
+	withMinLevelConfig := lager.NewReconfigurableSink(slogSink, logLevel)
+	return withMinLevelConfig
 }
 
 func createRedactedSink(logLevel lager.LogLevel) lager.Sink {


### PR DESCRIPTION
Currently app-autoscaler seems to ignore in many cases the configured log-level. The potential cause is in [helpers/logger.go:50-62](<https://github.com/cloudfoundry/app-autoscaler-release/blob/c2f15b725e67aff52f387b7ef01ab19288435d2d/src/autoscaler/helpers/logger.go#L50-L62> "code on github"). This PR should fix this.