### PR TITLE
Fix(operator) : Set Scalingengine Database Cut off duration to 10 days

### DIFF
--- a/src/autoscaler/operator/config/config.go
+++ b/src/autoscaler/operator/config/config.go
@@ -20,13 +20,14 @@ var (
 )
 
 const (
-	DefaultLoggingLevel        string = "info"
-	DefaultRefreshInterval            = 1 * time.Hour
-	DefaultCutoffDuration             = 2 * 24 * time.Hour
-	DefaultSyncInterval               = 24 * time.Hour
-	DefaultDBLockRetryInterval        = 5 * time.Second
-	DefaultDBLockTTL                  = 15 * time.Second
-	DefaultHttpClientTimeout          = 5 * time.Second
+	DefaultLoggingLevel                  string = "info"
+	DefaultRefreshInterval                      = 1 * time.Hour
+	DefaultCutoffDuration                       = 2 * 24 * time.Hour
+	DefaultScalingEngineDbCutoffDuration        = 10 * 24 * time.Hour
+	DefaultSyncInterval                         = 24 * time.Hour
+	DefaultDBLockRetryInterval                  = 5 * time.Second
+	DefaultDBLockTTL                            = 15 * time.Second
+	DefaultHttpClientTimeout                    = 5 * time.Second
 )
 
 type DbPrunerConfig struct {
@@ -104,7 +105,7 @@ func defaultConfig() Config {
 		Db: make(map[string]db.DatabaseConfig),
 		ScalingEngineDb: DbPrunerConfig{
 			RefreshInterval: DefaultRefreshInterval,
-			CutoffDuration:  DefaultCutoffDuration,
+			CutoffDuration:  DefaultScalingEngineDbCutoffDuration,
 		},
 		ScalingEngine: ScalingEngineConfig{
 			SyncInterval: DefaultSyncInterval,

--- a/src/autoscaler/operator/config/config_test.go
+++ b/src/autoscaler/operator/config/config_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Config", func() {
 						ConnectionMaxLifetime: 0 * time.Second,
 					}), "scalingengine_db")
 					Expect(conf.ScalingEngineDb.RefreshInterval).To(Equal(config.DefaultRefreshInterval))
-					Expect(conf.ScalingEngineDb.CutoffDuration).To(Equal(config.DefaultCutoffDuration))
+					Expect(conf.ScalingEngineDb.CutoffDuration).To(Equal(config.DefaultScalingEngineDbCutoffDuration))
 
 					Expect(conf.ScalingEngine.SyncInterval).To(Equal(config.DefaultSyncInterval))
 					Expect(conf.Scheduler.SyncInterval).To(Equal(config.DefaultSyncInterval))


### PR DESCRIPTION
**Problem**

With the fix in https://github.com/cloudfoundry/app-autoscaler-release/pull/3968, the defaults are also applied to the scalingengine database which is not correct.

**Solution**

Apply different default (10 days) to clean up scalingengine database (as configured in bosh [based operation configuration](https://github.com/cloudfoundry/app-autoscaler-release/blob/main/jobs/operator/spec#L176-L188))