### PR TITLE
Migrate broken resource so that it works with Concourse `v8`

### DIFF
--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -17,7 +17,7 @@ groups:
 
 resource_types:
 - name: file-url
-  type: docker-image
+  type: registry-image
   source:
     repository: pivotalservices/concourse-curl-resource
     tag: latest


### PR DESCRIPTION
# Problem
The `multiapps-controller-web-war` resource was broken after the migration to Concourse `v8`.

# Solution
Apply suggested fix from a colleague
<img width="932" height="148" alt="Screenshot 2026-03-25 at 14 52 45" src="https://github.com/user-attachments/assets/5348c811-011a-444b-8e6a-09cadfe5b6ff" />
https://cloudfoundry.slack.com/archives/C0RUU7GBZ/p1774444644044639

# Verification
I updated the pipeline in Concourse and it looks good!

<img width="1797" height="523" alt="Screenshot 2026-03-25 at 14 59 26" src="https://github.com/user-attachments/assets/1203c9a9-c7b2-4e38-ab86-3a1a6e357988" />

