### PR TITLE
chore(ci): configure retries=3 for multiapp controller concourse job

### DIFF
--- a/ci/infrastructure/pipeline.yml
+++ b/ci/infrastructure/pipeline.yml
@@ -293,4 +293,6 @@ jobs:
     - get: every-morning-monday-till-friday
       trigger: true
   - task: deploy-multiapps-controller
+    attempts: 3
+    timeout: 3h
     file: ci/ci/infrastructure/tasks/deploy-multiapps-controller.yml


### PR DESCRIPTION
## Problem

The deployment of the Multiapps Controller occasionally fails due to unavailability of underlying infrastructure (hibernation) issues.

## Solution

Added attempts: 3 to retry the concourse task up to three times in case of failure

Tested [concourse job](https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/infrastructure/jobs/deploy-multiapps-controller/builds/242)


<img width="1073" height="777" alt="2026-04-21_13-05-53" src="https://github.com/user-attachments/assets/72bfdd73-e617-46a2-b2ca-529bb0dd05cb" />
