### PR TITLE
fix_invalid_YAML_notation

### DIFF
--- a/ci/autoscaler/pipeline.yml
+++ b/ci/autoscaler/pipeline.yml
@@ -191,8 +191,7 @@ jobs:
   - <<: *deploy-autoscaler-task
     params:
       TARGETS: "deploy-autoscaler"
-      <<: *acceptance-log-cache-syslog-params
-      <<: *app-autoscaler-ops-files-log-cache-syslog
+      <<: [*acceptance-log-cache-syslog-params, *app-autoscaler-ops-files-log-cache-syslog]
     timeout: 30m
   - task: register-broker
     image: "app-autoscaler-tools"
@@ -249,8 +248,7 @@ jobs:
   - <<: *deploy-autoscaler-task
     params:
       TARGETS: "deploy-autoscaler"
-      <<: *performance-env
-      <<: *app-autoscaler-ops-files-log-cache-syslog
+      <<: [*performance-env, *app-autoscaler-ops-files-log-cache-syslog]
     timeout: 30m
   - task: register-broker
     image: "app-autoscaler-tools"
@@ -298,8 +296,7 @@ jobs:
     image: "app-autoscaler-tools"
     file: ci/ci/autoscaler/tasks/deploy-previous-autoscaler.yml
     params:
-      <<: *upgrade-test-params
-      <<: *app-autoscaler-ops-files-upgrade
+      <<: [*upgrade-test-params, *app-autoscaler-ops-files-upgrade]
     timeout: 30m
   - task: register-broker
     image: "app-autoscaler-tools"
@@ -320,8 +317,7 @@ jobs:
   - <<: *deploy-autoscaler-task
     params:
       TARGETS: "deploy-autoscaler"
-      <<: *upgrade-test-params
-      <<: *app-autoscaler-ops-files-upgrade
+      <<: [*upgrade-test-params, *app-autoscaler-ops-files-upgrade]
     timeout: 30m
   - task: autoscaler-post-upgrade
     image: "app-autoscaler-tools"


### PR DESCRIPTION
Reason: Make target does not work like that. Changed the Yaml accordingly. This was the error before:

> make set-autoscaler-pipeline           
> gh cli found
> gh version 2.73.0 (nixpkgs)
> https://github.com/cli/cli/releases/tag/v2.73.0
> no pull requests found for branch "main"
> error: error parsing yaml before applying templates: yaml: unmarshal errors:
>   line 195: mapping key "<<" already defined at line 194
>   line 253: mapping key "<<" already defined at line 252
>   line 302: mapping key "<<" already defined at line 301
>   line 324: mapping key "<<" already defined at line 323
> make: *** [Makefile:31: set-autoscaler-pipeline] Error 1